### PR TITLE
fix: cast operand type while shifting a numpy array

### DIFF
--- a/ana/histype.py
+++ b/ana/histype.py
@@ -102,8 +102,8 @@ class HisType(SeqType):
 
         """
         qq = np.zeros( (len(q), 32), dtype=np.int8 )  # 32 bytes for each item, ie 64 nibbles 
-        for i in np.arange(16): qq[:,i]    = ( q[:,0] >> (4*i) ) & 0xf     
-        for i in np.arange(16): qq[:,16+i] = ( q[:,1] >> (4*i) ) & 0xf     
+        for i in np.arange(16): qq[:,i]    = ( q[:,0] >> np.uint64(4*i) ) & 0xf
+        for i in np.arange(16): qq[:,16+i] = ( q[:,1] >> np.uint64(4*i) ) & 0xf
         return qq 
 
     def __init__(self):


### PR DESCRIPTION
```
$ python tests/compare_ab.py
[from opticks.ana.p import * 
[ana/p.py:from opticks.CSG.CSGFoundry import CSGFoundry 
]ana/p.py:from opticks.CSG.CSGFoundry import CSGFoundry 
[ana/p.py:cf = CSGFoundry.Load()
CSGFoundry.CFBase returning [/home/dmitri/.opticks/GEOM/dummy], note:[via GEOM] 
ERROR CSGFoundry.CFBase returned None OR non-existing CSGFoundry dir so cannot CSGFoundry.Load
]ana/p.py:cf = CSGFoundry.Load()
]from opticks.ana.p import * 
sevt.init W2M
 None
Traceback (most recent call last):
  File "/home/dmitri/esi-g4ox/tests/compare_ab.py", line 4, in <module>
    a = s.SEvt.Load("/tmp/GEOM/fakegeom/simg4ox/ALL0_none/A000/")
  File "/opt/pypoetry/venv/esi-shell-8VhIZC3Z-py3.10/lib/python3.10/site-packages/opticks/sysrap/sevt.py", line 57, in Load
    return None if f is None else cls(f, **kwa)
  File "/opt/pypoetry/venv/esi-shell-8VhIZC3Z-py3.10/lib/python3.10/site-packages/opticks/sysrap/sevt.py", line 96, in __init__
    self.init_seq(f)
  File "/opt/pypoetry/venv/esi-shell-8VhIZC3Z-py3.10/lib/python3.10/site-packages/opticks/sysrap/sevt.py", line 373, in init_seq
    q  = ht.seqhis(q_)  # ht from opticks.ana.p
  File "/opt/pypoetry/venv/esi-shell-8VhIZC3Z-py3.10/lib/python3.10/site-packages/opticks/ana/histype.py", line 121, in seqhis
    qq = self.Convert(q)
  File "/opt/pypoetry/venv/esi-shell-8VhIZC3Z-py3.10/lib/python3.10/site-packages/opticks/ana/histype.py", line 105, in Convert
    for i in np.arange(16): qq[:,i]    = ( q[:,0] >> (4*i) ) & 0xf
TypeError: ufunc 'right_shift' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```