### PR TITLE
fix: enable graphics capability for NVIDIA driver

### DIFF
--- a/spack/Dockerfile
+++ b/spack/Dockerfile
@@ -72,6 +72,7 @@ ENV OPTICKS_HOME=/src/eic-opticks
 # due to the test script hard-wiring this location.  This variable is not
 # canonical and only invented for here!
 ENV OPTICKS_BUILD=/opt/eic-opticks/build
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
 
 RUN git clone https://github.com/BNLNPPS/eic-opticks.git $OPTICKS_HOME
 RUN which python


### PR DESCRIPTION
Add 'graphics' to NVIDIA_DRIVER_CAPABILITIES in Dockerfile to enable GPU-accelerated graphical APIs (OpenGL/Vulkan). This fixes runtime errors related to OptiX initialization failing due to missing driver capabilities within the container environment.

Resolves #79 