### PR TITLE
sysrap: add std::string overloads for Type functions

### DIFF
--- a/sysrap/OpticksGenstep.h
+++ b/sysrap/OpticksGenstep.h
@@ -45,6 +45,7 @@ enum
 #if defined(__CUDACC__) || defined(__CUDABE__)
 #else
 #include <cstring>
+#include <string>
 #include "OpticksPhoton.h"
 
 struct OpticksGenstep_
@@ -71,6 +72,7 @@ struct OpticksGenstep_
     static constexpr const char* INPUT_PHOTON_            = "INPUT_PHOTON" ;
 
     static unsigned Type(const char* name); 
+    static unsigned Type(const std::string& name); 
     static const char* Name(unsigned type); 
 
     static bool IsValid(int gentype);
@@ -112,6 +114,11 @@ inline unsigned OpticksGenstep_::Type(const char* name)
     if(strcmp(name,FRAME_)==0)                    type = OpticksGenstep_FRAME ;
     if(strcmp(name,INPUT_PHOTON_)==0)             type = OpticksGenstep_INPUT_PHOTON ;
     return type ; 
+}
+
+inline unsigned OpticksGenstep_::Type(const std::string& name) 
+{
+    return Type(name.c_str());
 }
 
 inline const char* OpticksGenstep_::Name(unsigned type)

--- a/sysrap/storchtype.h
+++ b/sysrap/storchtype.h
@@ -22,6 +22,7 @@ enum {
 #if defined(__CUDACC__) || defined(__CUDABE__)
 #else
 #include <cstring>
+#include <string>
 
 struct storchtype
 {
@@ -35,6 +36,7 @@ struct storchtype
     static constexpr const char* T_SPHERE_  = "sphere" ;
 
     static unsigned Type(const char* name); 
+    static unsigned Type(const std::string& name); 
     static const char* Name(unsigned type); 
     static bool     IsValid(unsigned type); 
 }; 
@@ -50,6 +52,11 @@ inline unsigned storchtype::Type(const char* name)
     if(strcmp(name,T_SPHERE_MARSAGLIA_)==0) type = T_SPHERE_MARSAGLIA ; 
     if(strcmp(name,T_SPHERE_)==0) type = T_SPHERE ; 
     return type ; 
+}
+
+inline unsigned storchtype::Type(const std::string& name) 
+{
+    return Type(name.c_str());
 }
 
 inline const char* storchtype::Name(unsigned type)


### PR DESCRIPTION
Allows Type() to accept std::string directly in OpticksGenstep and storchtype, improving host-side usability. No impact on device code.