### PR TITLE
fix(scontext): enable GPU memory allocation heuristic when multiple devices are visible

### DIFF
--- a/sysrap/scontext.h
+++ b/sysrap/scontext.h
@@ -92,12 +92,12 @@ inline void scontext::initConfig()
     {
         std::cerr << "scontext::initConfig : ZERO VISIBLE DEVICES - CHECK CUDA_VISIBLE_DEVICES envvar \n" ; 
     }
-    else if(numdev > 1)
+    else if(numdev >= 1)
     {
-        std::cerr << "scontext::initConfig : MORE THAN ONE VISIBLE DEVICES - CHECK CUDA_VISIBLE_DEVICES envvar \n" ; 
-    }
-    else if(numdev == 1)
-    {
+        if(numdev > 1)
+            std::cerr << "scontext::initConfig : MORE THAN ONE VISIBLE DEVICES - CHECK CUDA_VISIBLE_DEVICES envvar \n"
+                      << "scontext::initConfig : Defaulting to the first device\n";
+
         int idev = 0 ; 
         std::string name = device_name(idev); 
         size_t vram = totalGlobalMem_bytes(idev);


### PR DESCRIPTION
Previously, the heuristic was effectively disabled if more than one CUDA device was visible. This change allows the logic to proceed when ≥1 devices are visible, defaulting to device 0 with a warning.