### PR TITLE
feat(config): move event mode and maxslot config to JSON

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -21,5 +21,10 @@
     "distance": 0.0,
     "mode": 255,
     "type": "disc"
+  },
+
+  "event": {
+    "mode": "DebugLite",
+    "maxslot": 1000000
   }
 }

--- a/src/configurator.cpp
+++ b/src/configurator.cpp
@@ -9,6 +9,8 @@
 #include <nlohmann/json.hpp>
 #include <cuda_runtime.h>
 
+#include "sysrap/SEventConfig.hh"
+
 #include "configurator.h"
 #include "config.h"
 
@@ -102,6 +104,11 @@ void Configurator::ReadConfig(std::string filepath)
       .mode = torch_["mode"],
       .type = storchtype::Type(torch_["type"])
     };
+
+    nlohmann::json event_ = json["event"];
+
+    SEventConfig::SetEventMode( string(event_["mode"]).c_str() );
+    SEventConfig::SetMaxSlot( event_["maxslot"] );
   }
   catch (nlohmann::json::exception& e) {
     std::string errmsg{"Failed reading config parameters from " + filepath + "\n" + e.what()};

--- a/tests/test_simg4ox.sh
+++ b/tests/test_simg4ox.sh
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
 
-set -e
-
-export USER=fakeuser
-export GEOM=fakegeom
-export OPTICKS_EVENT_MODE=DebugLite
-export OPTICKS_MAX_SLOT=1000000
-
-simg4ox -g $OPTICKS_HOME/tests/geom/raindrop.gdml -m $OPTICKS_HOME/tests/run.mac
+USER=fakeuser GEOM=fakegeom simg4ox -g $OPTICKS_HOME/tests/geom/raindrop.gdml -m $OPTICKS_HOME/tests/run.mac
 python $OPTICKS_HOME/tests/compare_ab.py


### PR DESCRIPTION
Previously, event mode and maxslot were set via environment variables in test scripts. This change moves those settings to config/dev.json and updates configurator.cpp to read and apply them using SEventConfig.