### PR TITLE
Safeguard for Opticks binary tree size

### DIFF
--- a/CSG/CSGImport.cc
+++ b/CSG/CSGImport.cc
@@ -308,6 +308,12 @@ CSGPrim* CSGImport::importPrim(int primIdx, const snode& node )
     std::vector<const sn*> nds ; 
     sn::GetLVNodesComplete(nds, lvid);   // many nullptr in unbalanced deep complete binary trees
     int bn = nds.size();                 // binary nodes
+    
+    if (bn > 100000) // Check if binary tree blows up and warn user
+        {
+        std::cerr << "Too many nodes in binary tree (more than a 100 000) built by Opticks. Likely a nested subtraction/union solid that Opticks turns into a full binary tree. Check your geometry as described in: https://github.com/BNLNPPS/esi-g4ox/issues/127" << std::endl;
+        assert(bn < 100000);
+        }
 
     // 2. count total subs for any listnodes of this lvid 
 


### PR DESCRIPTION
Stop Opticks geometry read-in if binary tree size blows up. Warn user and suggest solution. 

Solves https://github.com/BNLNPPS/eic-opticks/issues/77

Test:
./build/src/simg4ox -g dune_forward_geometry_2025_april_replaced_elliptical_tubes.gdml -m esi-g4ox/run.mac

Exits with error as expected:

```Too many nodes in binary tree (more than a 100 000) built by Opticks. Likely a nested subtraction/union solid that Opticks turns into a full binary tree. Check your geometry as described in: https://github.com/BNLNPPS/esi-g4ox/issues/127
simg4ox: /esi/eic-opticks/CSG/CSGImport.cc:312: CSGPrim* CSGImport::importPrim(int, const snode&): Assertion `bn < 100000' failed.
```

Fixed DUNE geometry works fine, no exit:
./build/src/simg4ox -g duneforwarddetector3.gdml -m esi-g4ox/run.mac