### PR TITLE
Add mutex lock in AddOpticksHits method

### DIFF
--- a/src/g4appmt.h
+++ b/src/g4appmt.h
@@ -209,7 +209,7 @@ struct PhotonSD : public G4VSensitiveDetector
             {
                 theCreationProcessid = -1;
             }
-            //std::cout << hit.wavelength << " " << position << " " << direction << " " << polarization << std::endl;
+            // std::cout << hit.wavelength << " " << position << " " << direction << " " << polarization << std::endl;
             PhotonHit *newHit = new PhotonHit(0, hit.wavelength, hit.time, position, direction, polarization);
             fPhotonHitsCollection->insert(newHit);
         }


### PR DESCRIPTION
Added a mutex lock to the AddOpticksHits method for thread safety.

Reported in https://github.com/BNLNPPS/eic-opticks/issues/200