### PR TITLE
Fix PTX fallback path in CSGOptiX.cc to match CMake install destination

### DIFF
--- a/CSGOptiX/CSGOptiX.cc
+++ b/CSGOptiX/CSGOptiX.cc
@@ -440,7 +440,7 @@ CSGOptiX::CSGOptiX(const CSGFoundry* foundry_)
 #ifdef CONFIG_Debug
       _optixpath("${CSGOptiX__optixpath:-$OPTICKS_PREFIX/ptx/CSGOptiX_generated_CSGOptiX7.cu.ptx}"),
 #elif CONFIG_Release
-    _optixpath("${CSGOptiX__optixpath:-$OPTICKS_PREFIX/ptx/CSGOptiX_generated_CSGOptiX7.cu.ptx}"),
+      _optixpath("${CSGOptiX__optixpath:-$OPTICKS_PREFIX/ptx/CSGOptiX_generated_CSGOptiX7.cu.ptx}"),
 #else
     _optixpath(nullptr),
 #endif


### PR DESCRIPTION
The CMake install rule in CSGOptiX/CMakeLists.txt has always installed the PTX kernel to $PREFIX/ptx/CSGOptiX_generated_CSGOptiX7.cu.ptx since the initial import (commit b7b27c246). The runtime fallback path in CSGOptiX.cc originally matched this, resolving $OPTICKS_PREFIX/ptx/CSGOptiX_generated_CSGOptiX7.cu.ptx. However, commit 2637f2c1d  replaced that correct fallback with $OPTICKS_PREFIX/optix/objects-Release/CSGOptiX_OPTIX/CSGOptiX7.ptx — a build-tree path that doesn't exist after installation. This was partially worked around in commit 7fa876749 (PR #177) by setting the CSGOptiX__optixpath environment variable in the Dockerfile, but that fix doesn't apply to spack-based deployments. This PR restores the fallback path in CSGOptiX.cc to match the actual CMake install destination, making the PTX discoverable out of the box without  requiring env vars or symlinks.