### PR TITLE
fix(qudarap): avoid CUDA 12.5 nvcc hang in qsim boundary Philox draw

### DIFF
--- a/qudarap/qsim.h
+++ b/qudarap/qsim.h
@@ -70,7 +70,7 @@ TODO:
 
 struct qcerenkov ;
 
-static QSIM_METHOD QSIM_NOINLINE float qsim_rng_uniform(RNG* rng)
+static QSIM_METHOD QSIM_NOINLINE float qsim_rng_uniform(RNG *rng)
 {
     return curand_uniform(rng);
 }
@@ -1099,7 +1099,7 @@ inline QSIM_METHOD int qsim::propagate_at_boundary(unsigned& flag, RNG& rng, sct
     // spend pathological compile time when this curand state-machine is fully
     // inlined into this large function at high optimization. CUDA 13.0.2
     // compiles cleanly either way, but this preserves the original RNG stream.
-    const float u_reflect = qsim_rng_uniform(&rng) ;
+    const float u_reflect = qsim_rng_uniform(&rng);
     bool reflect = u_reflect > TransCoeff  ;
 
 #if !defined(PRODUCTION) && defined(DEBUG_TAG)


### PR DESCRIPTION
This fix is to preserve the original RNG stream and stop NVCC 12.5 from inlining that scalar Philox state machine into the giant boundary function. I changed [qsim.h](https://github.com/workspaces/eic-opticks/qudarap/qsim.h#L73) to add a __noinline__ helper and used it at [qsim.h](https://github.com/workspaces/eic-opticks/qudarap/qsim.h#L1095) and [qsim.h](https://github.com/workspaces/eic-opticks/qudarap/qsim.h#L1101). That keeps behavior identical to the original single-draw code, works with CUDA 13, and should avoid the CUDA 12.5 compile-time pathology without burning extra randoms.

Resolves #57 