### PR TITLE
build(docker): use official prebuilt CMake binary instead of building from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,12 @@ RUN apt update \
  && apt install -y libssl-dev \
     nlohmann-json3-dev \
     libglfw3-dev libglu1-mesa-dev libxmu-dev libglew-dev libglm-dev \
-    cmake qtbase5-dev libxerces-c-dev libexpat1-dev \
+    qtbase5-dev libxerces-c-dev libexpat1-dev \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/cmake/src && curl -sL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz | tar -xz --strip-components 1 -C /opt/cmake/src \
- && cmake -S /opt/cmake/src -B /opt/cmake/build \
- && cmake --build /opt/cmake/build --parallel --target install \
- && rm -fr /opt/cmake
+RUN curl -fsSL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz \
+    | tar -xz --strip-components=1 -C /usr/local
 
 RUN mkdir -p /opt/geant4/src && curl -sL https://github.com/Geant4/geant4/archive/refs/tags/v${GEANT4_VERSION}.tar.gz | tar -xz --strip-components 1 -C /opt/geant4/src \
  && cmake -S /opt/geant4/src -B /opt/geant4/build -DGEANT4_USE_OPENGL_X11=ON -DGEANT4_USE_QT=ON -DGEANT4_USE_GDML=ON -DGEANT4_INSTALL_DATA=ON -DGEANT4_BUILD_MULTITHREADED=ON \


### PR DESCRIPTION
Install the requested CMake version in the Docker image from Kitware's official prebuilt
`linux-x86_64` binary tarball instead of compiling it from source.

The PR workflow failures were happening while Docker was building CMake from source, ending with
`The runner has received a shutdown signal`. This points to runner interruption or build cost, not
a repo code error.

- Removes one of the most expensive steps in the Docker image build
- Avoids rebuilding CMake from source on every PR workflow run
- Makes the PR workflow jobs less likely to be terminated before completion
