### PR TITLE
fix: use stree fallback for matline lookup when CSGFoundry is unavail…

### DIFF
--- a/sysrap/SEvt.cc
+++ b/sysrap/SEvt.cc
@@ -2473,7 +2473,7 @@ sgs SEvt::addGenstep(const quad6& q_)
     if(matline_ >= G4_INDEX_OFFSET  )
     {
         unsigned mtindex = matline_ - G4_INDEX_OFFSET ;
-        int matline = cf ? cf->lookup_mtline(mtindex) : 0 ;
+        int matline = cf ? cf->lookup_mtline(mtindex) : (tree ? tree->lookup_mtline(mtindex) : 0);
         // cf(SGeo) used for lookup
         // BUT: that just uses SSim::lookup_mtline
         // so SEvt should hold sim(SSim) ?


### PR DESCRIPTION
…able

In the DD4hep integration path, SEvt::addGenstep uses setSim() which sets tree but not cf (CSGFoundry). The existing code falls back to matline=0 (Air) when cf is NULL, causing all Cerenkov photons to sample wavelengths using Air RINDEX (n=1.0) instead of the correct material. This produces +42% excess hits and wrong UV wavelengths.

The fix adds tree->lookup_mtline() as a fallback, which calls the same underlying SSim::lookup_mtline().