### PR TITLE
fix(qudarap): treat missing scintillation ICDF as non-fatal

### DIFF
--- a/qudarap/QSim.cc
+++ b/qudarap/QSim.cc
@@ -322,21 +322,23 @@ void QSim::init()
     bool MISSING_PMT = REQUIRE_PMT == true && has_PMT == false ;
 
     LOG(LEVEL)
-        << " MISSING_PMT " << ( MISSING_PMT ? "YES" : "NO " )
-        << " has_PMT " << ( has_PMT ? "YES" : "NO " )
-        << " QSim::pmt " << ( pmt ? "YES" : "NO " )
-        << " QSim::pmt->d_pmt " << ( sim->pmt ? "YES" : "NO " )
-        << " [" << _QSim__REQUIRE_PMT << "] " << ( REQUIRE_PMT ? "YES" : "NO " )
-        ;
+        << " MISSING_PMT " << (MISSING_PMT ? "YES" : "NO ")
+        << " has_PMT " << (has_PMT ? "YES" : "NO ")
+        << " QSim::pmt " << (pmt ? "YES" : "NO ")
+        << " QSim::pmt->d_pmt " << (sim->pmt ? "YES" : "NO ")
+        << " QSim::scint " << (scint ? "YES" : "NO ")
+        << " QSim::scint->d_scint " << (sim->scint ? "YES" : "NO ")
+        << " [" << _QSim__REQUIRE_PMT << "] " << (REQUIRE_PMT ? "YES" : "NO ");
 
-    LOG_IF(fatal, MISSING_PMT )
+    LOG_IF(fatal, MISSING_PMT)
         << " MISSING_PMT ABORT "
-        << " MISSING_PMT " << ( MISSING_PMT ? "YES" : "NO " )
-        << " has_PMT " << ( has_PMT ? "YES" : "NO " )
-        << " QSim::pmt " << ( pmt ? "YES" : "NO " )
-        << " QSim::pmt->d_pmt " << ( sim->pmt ? "YES" : "NO " )
-        << " [" << _QSim__REQUIRE_PMT << "] " << ( REQUIRE_PMT ? "YES" : "NO " )
-        ;
+        << " MISSING_PMT " << (MISSING_PMT ? "YES" : "NO ")
+        << " has_PMT " << (has_PMT ? "YES" : "NO ")
+        << " QSim::pmt " << (pmt ? "YES" : "NO ")
+        << " QSim::pmt->d_pmt " << (sim->pmt ? "YES" : "NO ")
+        << " QSim::scint " << (scint ? "YES" : "NO ")
+        << " QSim::scint->d_scint " << (sim->scint ? "YES" : "NO ")
+        << " [" << _QSim__REQUIRE_PMT << "] " << (REQUIRE_PMT ? "YES" : "NO ");
 
     assert(MISSING_PMT == false) ;
     if(MISSING_PMT)  std::raise(SIGINT);
@@ -346,6 +348,26 @@ void QSim::init()
     INSTANCE = this ;
     LOG(LEVEL) << desc() ;
     LOG(LEVEL) << descComponents() ;
+}
+
+bool QSim::hasScint() const
+{
+    return sim != nullptr && scint != nullptr && sim->scint != nullptr;
+}
+
+void QSim::requireScint(const char *caller) const
+{
+    bool missing_scint = hasScint() == false;
+
+    LOG_IF(fatal, missing_scint)
+        << caller << " requires scintillation data, but QSim was initialized without QScint"
+        << " scint " << (scint ? "YES" : "NO ") << " sim " << (sim ? "YES" : "NO ")
+        << " sim->scint " << (sim && sim->scint ? "YES" : "NO ") << " snam::ICDF "
+        << snam::ICDF;
+
+    assert(missing_scint == false);
+    if (missing_scint)
+        std::raise(SIGINT);
 }
 
 /**
@@ -896,6 +918,7 @@ qsim* QSim::getDevicePtr() const
 
 char QSim::getScintTexFilterMode() const
 {
+    requireScint("QSim::getScintTexFilterMode");
     return scint->tex->getFilterMode() ;
 }
 
@@ -939,25 +962,24 @@ std::string QSim::descComponents() const
 {
     std::stringstream ss ;
     ss << std::endl
-       << "QSim::descComponents"
-       << std::endl
-       << " (QBase)base             " << ( base      ? "YES" : "NO " )  << std::endl
-       << " (QEvt)qev           " << ( qev     ? "YES" : "NO " )  << std::endl
-       << " (SEvt)sev               " << ( sev       ? "YES" : "NO " )  << std::endl
-       << " (QRng)rng               " << ( rng       ? "YES" : "NO " )  << std::endl
-       << " (QScint)scint           " << ( scint     ? "YES" : "NO " )  << std::endl
-       << " (QCerenkov)cerenkov     " << ( cerenkov  ? "YES" : "NO " )  << std::endl
-       << " (QBnd)bnd               " << ( bnd       ? "YES" : "NO " )  << std::endl
-       << " (QOptical)optical       " << ( optical   ? "YES" : "NO " )  << std::endl
-       << " (QDebug)debug_          " << ( debug_    ? "YES" : "NO " )  << std::endl
-       << " (QProp)prop             " << ( prop      ? "YES" : "NO " )  << std::endl
-       << " (QPMT)pmt               " << ( pmt       ? "YES" : "NO " )  << std::endl
-       << " (QMultiFilm)multifilm   " << ( multifilm ? "YES" : "NO " )  << std::endl
-       << " (qsim)sim               " << ( sim       ? "YES" : "NO " )  << std::endl
-       << " (qsim)d_sim             " << ( d_sim     ? "YES" : "NO " )  << std::endl
-       << " (qdebug)dbg             " << ( dbg       ? "YES" : "NO " )  << std::endl
-       << " (qdebug)d_dbg           " << ( d_dbg     ? "YES" : "NO " )  << std::endl
-       ;
+       << "QSim::descComponents" << std::endl
+       << " (QBase)base             " << (base ? "YES" : "NO ") << std::endl
+       << " (QEvt)qev           " << (qev ? "YES" : "NO ") << std::endl
+       << " (SEvt)sev               " << (sev ? "YES" : "NO ") << std::endl
+       << " (QRng)rng               " << (rng ? "YES" : "NO ") << std::endl
+       << " (QScint)scint           " << (scint ? "YES" : "NO ") << std::endl
+       << " (QCerenkov)cerenkov     " << (cerenkov ? "YES" : "NO ") << std::endl
+       << " (QBnd)bnd               " << (bnd ? "YES" : "NO ") << std::endl
+       << " (QOptical)optical       " << (optical ? "YES" : "NO ") << std::endl
+       << " (QDebug)debug_          " << (debug_ ? "YES" : "NO ") << std::endl
+       << " (QProp)prop             " << (prop ? "YES" : "NO ") << std::endl
+       << " (QPMT)pmt               " << (pmt ? "YES" : "NO ") << std::endl
+       << " (QMultiFilm)multifilm   " << (multifilm ? "YES" : "NO ") << std::endl
+       << " (qsim)sim               " << (sim ? "YES" : "NO ") << std::endl
+       << " (qsim)hasScint          " << (hasScint() ? "YES" : "NO ") << std::endl
+       << " (qsim)d_sim             " << (d_sim ? "YES" : "NO ") << std::endl
+       << " (qdebug)dbg             " << (dbg ? "YES" : "NO ") << std::endl
+       << " (qdebug)d_dbg           " << (d_dbg ? "YES" : "NO ") << std::endl;
     std::string s = ss.str();
     return s ;
 }
@@ -1169,6 +1191,7 @@ extern void QSim_scint_wavelength(   dim3 numBlocks, dim3 threadsPerBlock, qsim*
 
 NP* QSim::scint_wavelength(unsigned num_wavelength, unsigned& hd_factor )
 {
+    requireScint("QSim::scint_wavelength");
 
     bool qsim_disable_hd = ssys::getenvbool("QSIM_DISABLE_HD");
     hd_factor = qsim_disable_hd ? 0u : scint->tex->getHDFactor() ;
@@ -1237,6 +1260,8 @@ extern void QSim_dbg_gs_generate(dim3 numBlocks, dim3 threadsPerBlock, qsim* sim
 NP* QSim::dbg_gs_generate(unsigned num_photon, unsigned type )
 {
     assert( type == SCINT_GENERATE || type == CERENKOV_GENERATE );
+    if (type == SCINT_GENERATE)
+        requireScint("QSim::dbg_gs_generate");
 
     configureLaunch( num_photon, 1 );
     sphoton* d_photon = QU::device_alloc<sphoton>(num_photon, "QSim::dbg_gs_generate:num_photon") ;

--- a/qudarap/QSim.cc
+++ b/qudarap/QSim.cc
@@ -167,11 +167,10 @@ void QSim::UploadComponents( const SSim* ssim  )
         LOG(LEVEL) << "  propcom null, snam::PROPCOM " <<  snam::PROPCOM ;
     }
 
-
     const NP* icdf = ssim->get(snam::ICDF);
-    if( icdf == nullptr )
+    if (icdf == nullptr)
     {
-        LOG(error) << " icdf null, snam::ICDF " << snam::ICDF ;
+        LOG(LEVEL) << " no scintillation ICDF, skip QScint upload. snam::ICDF: " << snam::ICDF;
     }
     else
     {
@@ -179,7 +178,6 @@ void QSim::UploadComponents( const SSim* ssim  )
         QScint* scint = new QScint( icdf, hd_factor); // custom high-definition inverse CDF for scintillation generation
         LOG(LEVEL) << scint->desc();
     }
-
 
     // TODO: make this more like the others : acting on the available inputs rather than the mode
     bool is_simtrace = SEventConfig::IsRGModeSimtrace() ;
@@ -2053,5 +2051,3 @@ std::string QSim::Switches()  // static
 {
     return Desc(',');
 }
-
-

--- a/qudarap/QSim.cu
+++ b/qudarap/QSim.cu
@@ -81,6 +81,14 @@ __global__ void _QSim_scint_wavelength(qsim* sim, float* wavelength, unsigned nu
     unsigned id = blockIdx.x*blockDim.x + threadIdx.x;
     if (id >= num_wavelength) return;
 
+    if (sim->scint == nullptr)
+    {
+        if (id == 0)
+            printf("//_QSim_scint_wavelength missing scint, returning zeros \n");
+        wavelength[id] = 0.f;
+        return;
+    }
+
     RNG rng ;
     sim->rng->init(rng, 0, id ) ;
 
@@ -161,7 +169,14 @@ __global__ void _QSim_dbg_gs_generate(qsim* sim, qdebug* dbg, sphoton* photon, u
     else if( type == SCINT_GENERATE )
     {
         const quad6& gs = (const quad6&)dbg->scint_gs ;
-        sim->scint->generate(p, rng, gs, idx, gsid );
+        if (sim->scint != nullptr)
+        {
+            sim->scint->generate(p, rng, gs, idx, gsid );
+        }
+        else if (idx == 0)
+        {
+            printf("//_QSim_dbg_gs_generate missing scint, leaving photon zeroed \n");
+        }
     }
     photon[idx] = p ;
 }

--- a/qudarap/QSim.hh
+++ b/qudarap/QSim.hh
@@ -98,6 +98,7 @@ struct QUDARAP_API QSim
 private:
     QSim();
     void init();
+    void requireScint(const char *caller) const;
 
     static constexpr const char* _QSim__REQUIRE_PMT = "QSim__REQUIRE_PMT" ;
     static const bool   REQUIRE_PMT;
@@ -141,7 +142,7 @@ public:
     std::string desc() const ;
     std::string descFull() const ;
     std::string descComponents() const ;
-
+    bool hasScint() const;
 
     // TODO: relocate non-essential methods into tests or elsewhere
 
@@ -212,5 +213,4 @@ public:
     static std::string Desc(char delim='\n');
     static std::string Switches();
 };
-
 


### PR DESCRIPTION
Some GDML geometries define only optical/Cerenkov material properties and do not include
scintillation properties such as FASTCOMPONENT, SLOWCOMPONENT, or REEMISSIONPROB.

In those cases U4Scint does not generate `icdf.npy`, so `QSim::UploadComponents` should skip
`QScint` setup instead of reporting an error for a valid non-scintillating geometry.

Resolves https://github.com/BNLNPPS/eic-opticks/issues/265