### PR TITLE
ci: tune cpp-linter to use repo style and reduce PR noise

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Microsoft

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -29,7 +29,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          style: microsoft
+          style: file
           ignore: include/argparse
           lines-changed-only: true
           thread-comments: update

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -33,8 +33,11 @@ jobs:
           ignore: include/argparse
           lines-changed-only: true
           thread-comments: update
-          format-review: true
+          format-review: false
           tidy-checks: '-*'
+          tidy-review: false
+          step-summary: true
+          file-annotations: true
 
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed != 0


### PR DESCRIPTION
Configure the `cpp-linter` workflow to read formatting rules from the repository and make its PR feedback less noisy.

This makes the formatting source of truth live in the repository instead of being hard-coded in the workflow, which gives us a cleaner path to adjust style over time.

It also shifts `cpp-linter` feedback away from noisy PR comment churn and toward the GitHub Actions UI, while still failing the job when checks fail.