### PR TITLE
refactor(sysrap): make shared RNG use explicit via traits

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,1 @@
 BasedOnStyle: Microsoft
-BreakTemplateDeclarations: MultiLine
-PackConstructorInitializers: Never
-BreakConstructorInitializers: AfterColon

--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,4 @@
 BasedOnStyle: Microsoft
+BreakTemplateDeclarations: MultiLine
+PackConstructorInitializers: Never
+BreakConstructorInitializers: AfterColon

--- a/sysrap/SEvent.cc
+++ b/sysrap/SEvent.cc
@@ -7,9 +7,6 @@
 #include "stran.h"
 #include "sframe.h"
 
-#include "srngcpu.h"
-using RNG = srngcpu ;
-
 #include "storch.h"
 #include "scerenkov.h"
 #include "sscint.h"
@@ -414,7 +411,3 @@ std::string SEvent::DescSeed( const int* seed, int num_seed, int edgeitems )  //
     std::string s = ss.str();
     return s ;
 }
-
-
-
-

--- a/sysrap/SGenerate.h
+++ b/sysrap/SGenerate.h
@@ -31,7 +31,6 @@ struct SGenerate
 #include "sphoton.h"
 
 #include "srngcpu.h"
-using RNG = srngcpu ;
 
 #include "storch.h"
 #include "scarrier.h"
@@ -79,7 +78,7 @@ inline NP* SGenerate::GeneratePhotons(const NP* gs_ )
     sphoton* pp = (sphoton*)ph->bytes() ;
 
     unsigned rng_seed = 1u ;
-    RNG rng ;
+    srngcpu rng;
     rng.seed = rng_seed ;
 
     for(int i=0 ; i < tot_photon ; i++ )
@@ -102,5 +101,4 @@ inline NP* SGenerate::GeneratePhotons(const NP* gs_ )
     delete se ;
     return ph ;
 }
-
 

--- a/sysrap/sboundary.h
+++ b/sysrap/sboundary.h
@@ -21,6 +21,7 @@ components, then combine the Fresnel transmission/reflection coefficients.
 
 **/
 
+#include "srng_traits.h"
 
 struct sboundary
 {
@@ -67,11 +68,11 @@ struct sboundary
     float3 A_parallel ; 
     float3 alt_pol ;  // check an alternative polarization expression  
 
-    sboundary(RNG& rng, sctx& ctx );  
+    template <typename Rng> sboundary(Rng &rng, sctx &ctx);
 };
 
-inline sboundary::sboundary( RNG& rng, sctx& ctx ) 
-    :
+template <typename Rng>
+inline sboundary::sboundary(Rng &rng, sctx &ctx) :
     p(ctx.p),
     s(ctx.s),
     n1(s.material1.x),
@@ -103,7 +104,7 @@ inline sboundary::sboundary( RNG& rng, sctx& ctx )
     TT(normalize(E2_t)), 
     TransCoeff(tir || n1c1 == 0.f ? 0.f : n2c2*dot(E2_t,E2_t)/n1c1),
     ReflectCoeff(1.f - TransCoeff),
-    u_reflect(curand_uniform(&rng)),
+    u_reflect(srng_uniform(rng)),
     reflect(u_reflect > TransCoeff), 
     flag(reflect ? BOUNDARY_REFLECT : BOUNDARY_TRANSMIT),
     Coeff(reflect ? ReflectCoeff : TransCoeff),

--- a/sysrap/scarrier.h
+++ b/sysrap/scarrier.h
@@ -14,13 +14,6 @@
 #include "scuda.h"
 #include "squad.h"
 
-#if defined(__CUDACC__) || defined(__CUDABE__)
-#else
-#include "srngcpu.h"
-#endif
-
-
-
 struct scarrier
 {
     quad q0 ;
@@ -30,10 +23,9 @@ struct scarrier
     quad q4 ;
     quad q5 ;
 
-
-    SCARRIER_METHOD static void generate( sphoton& p, RNG& rng, const quad6& gs, unsigned long long photon_id, unsigned genstep_id );
-
-
+    template <typename Rng>
+    SCARRIER_METHOD static void generate(sphoton &p, Rng &rng, const quad6 &gs, unsigned long long photon_id,
+                                         unsigned genstep_id);
 
 #if defined(__CUDACC__) || defined(__CUDABE__) || defined(MOCK_CURAND) || defined(MOCK_CUDA)
 #else
@@ -42,10 +34,13 @@ struct scarrier
 
 };
 
-
-
-inline SCARRIER_METHOD void scarrier::generate( sphoton& p_, RNG& rng, const quad6& gs, unsigned long long photon_id, unsigned genstep_id )  // static
+template <typename Rng>
+inline SCARRIER_METHOD void scarrier::generate(sphoton &p_, Rng &rng, const quad6 &gs, unsigned long long photon_id,
+                                               unsigned genstep_id)
 {
+    (void)rng;
+    (void)genstep_id;
+
     quad4& p = (quad4&)p_ ;
 
     p.q0.f = gs.q2.f ;
@@ -72,6 +67,3 @@ inline void scarrier::FillGenstep( scarrier& gs, int matline, int numphoton_per_
 
 }
 #endif
-
-
-

--- a/sysrap/scurand.h
+++ b/sysrap/scurand.h
@@ -4,35 +4,31 @@
    #define SCURAND_METHOD __device__
    #include "curand_kernel.h"
 #else
-   #define SCURAND_METHOD 
-   #include "srngcpu.h"
-#endif 
+#define SCURAND_METHOD
+#endif
+
+#include "srng_traits.h"
 
 template <typename T>
 struct scurand
 {
-   static SCURAND_METHOD T uniform( RNG* rng );  
+    template <typename Rng> static SCURAND_METHOD T uniform(Rng *rng);
 };
 
-
-
-template<> inline float scurand<float>::uniform( RNG* rng ) 
+template <> template <typename Rng> inline SCURAND_METHOD float scurand<float>::uniform(Rng *rng)
 { 
 #ifdef FLIP_RANDOM
-    return 1.f - curand_uniform(rng) ;
+    return 1.f - srng_uniform(*rng);
 #else
-    return curand_uniform(rng) ;
+    return srng_uniform(*rng);
 #endif
 }
 
-template<> inline double scurand<double>::uniform( RNG* rng ) 
+template <> template <typename Rng> inline SCURAND_METHOD double scurand<double>::uniform(Rng *rng)
 { 
 #ifdef FLIP_RANDOM
-    return 1. - curand_uniform_double(rng) ;
+    return 1. - srng_uniform_double(*rng);
 #else
-    return curand_uniform_double(rng) ;
+    return srng_uniform_double(*rng);
 #endif
 }
-
-
-

--- a/sysrap/srng.h
+++ b/sysrap/srng.h
@@ -17,44 +17,94 @@ So have to implement all methods in each specialization, or use a separate helpe
 
 **/
 
+#include "srng_traits.h"
 #include <curand_kernel.h>
 
 using XORWOW = curandStateXORWOW ;
 using Philox = curandStatePhilox4_32_10 ; 
 
 #if defined(RNG_XORWOW)
-using RNG = XORWOW ;
+using DefaultDeviceRNG = XORWOW;
 #elif defined(RNG_PHILOX)
-using RNG = Philox ;
+using DefaultDeviceRNG = Philox;
 #endif
 
+#if defined(RNG_XORWOW) || defined(RNG_PHILOX)
+#if !defined(MOCK_CURAND) && !defined(MOCK_CUDA)
+using RNG = DefaultDeviceRNG;
+#endif
+#endif
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
+
+template <> struct srng<XORWOW>
+{
+    static SRNG_METHOD float uniform(XORWOW &state)
+    {
+        return curand_uniform(&state);
+    }
+    static SRNG_METHOD double uniform_double(XORWOW &state)
+    {
+        return curand_uniform_double(&state);
+    }
+};
+
+template <> struct srng<Philox>
+{
+    static SRNG_METHOD float uniform(Philox &state)
+    {
+        return curand_uniform(&state);
+    }
+
+    static SRNG_METHOD double uniform_double(Philox &state)
+    {
+        return curand_uniform_double(&state);
+    }
+};
+
 #else
 
 #include <cstring>
 #include <sstream>
 #include <string>
 
-template<typename T> struct srng {};
-
 // template specializations for the different states
 template<> 
 struct srng<XORWOW>  
 { 
     static constexpr char CODE = 'X' ;
-    static constexpr const char* NAME = "XORWOW" ; 
-    static constexpr unsigned SIZE = sizeof(XORWOW) ; 
-    static constexpr bool UPLOAD_RNG_STATES = true ; 
+    static constexpr const char *NAME = "XORWOW";
+    static constexpr unsigned SIZE = sizeof(XORWOW);
+    static constexpr bool UPLOAD_RNG_STATES = true;
+
+    static inline float uniform(XORWOW &state)
+    {
+        return curand_uniform(&state);
+    }
+
+    static inline double uniform_double(XORWOW &state)
+    {
+        return curand_uniform_double(&state);
+    }
 };
 
 template<> 
 struct srng<Philox>  
 { 
     static constexpr char CODE = 'P' ;
-    static constexpr const char* NAME = "Philox" ; 
-    static constexpr unsigned SIZE = sizeof(Philox) ; 
-    static constexpr bool UPLOAD_RNG_STATES = false ; 
+    static constexpr const char *NAME = "Philox";
+    static constexpr unsigned SIZE = sizeof(Philox);
+    static constexpr bool UPLOAD_RNG_STATES = false;
+
+    static inline float uniform(Philox &state)
+    {
+        return curand_uniform(&state);
+    }
+
+    static inline double uniform_double(Philox &state)
+    {
+        return curand_uniform_double(&state);
+    }
 };
 
 // helper function

--- a/sysrap/srng_traits.h
+++ b/sysrap/srng_traits.h
@@ -1,0 +1,28 @@
+#pragma once
+/**
+srng_traits.h : common RNG traits interface
+===========================================
+
+Shared CPU/GPU generation headers should accept an RNG object explicitly
+instead of depending on an include-order-selected global RNG alias.
+
+Concrete RNG headers specialize srng<T> and provide uniform accessors.
+**/
+
+#if defined(__CUDACC__) || defined(__CUDABE__)
+#define SRNG_METHOD __device__
+#else
+#define SRNG_METHOD inline
+#endif
+
+template <typename T> struct srng;
+
+template <typename Rng> SRNG_METHOD float srng_uniform(Rng &rng)
+{
+    return srng<Rng>::uniform(rng);
+}
+
+template <typename Rng> SRNG_METHOD double srng_uniform_double(Rng &rng)
+{
+    return srng<Rng>::uniform_double(rng);
+}

--- a/sysrap/srngcpu.h
+++ b/sysrap/srngcpu.h
@@ -24,6 +24,7 @@ To extend that see::
 
 #include <random>
 #include "s_seq.h"
+#include "srng_traits.h"
 
 struct srngcpu
 {
@@ -118,7 +119,19 @@ inline std::string srngcpu::demo(int n)
 inline float  curand_uniform(srngcpu* state ){         return state->generate_float() ; }
 inline double curand_uniform_double(srngcpu* state ){ return state->generate_double() ; }
 
+template <> struct srng<srngcpu>
+{
+    static constexpr char CODE = 'C';
+    static constexpr const char *NAME = "srngcpu";
+    static constexpr unsigned SIZE = sizeof(srngcpu);
+    static constexpr bool UPLOAD_RNG_STATES = false;
 
-
-
-
+    static inline float uniform(srngcpu &state)
+    {
+        return state.generate_float();
+    }
+    static inline double uniform_double(srngcpu &state)
+    {
+        return state.generate_double();
+    }
+};

--- a/sysrap/storch.h
+++ b/sysrap/storch.h
@@ -35,6 +35,7 @@ Techniques to implement the spirit of the old torch gensteps in much less code
 //#include "scurand.h"
 #include "smath.h"
 #include "sphoton.h"
+#include "srng_traits.h"
 #include "storchtype.h"
 
 /**
@@ -68,8 +69,9 @@ struct storch
 
     // NB : organized into 6 quads : are constained not to change that
 
-    STORCH_METHOD static void generate( sphoton& p, RNG& rng, const quad6& gs, unsigned long long photon_id, unsigned genstep_id );
-
+    template <typename Rng>
+    STORCH_METHOD static void generate(sphoton &p, Rng &rng, const quad6 &gs, unsigned long long photon_id,
+                                       unsigned genstep_id);
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
 #else
@@ -183,7 +185,9 @@ the photon_id and genstep_id inputs are informational only.
 
 **/
 
-STORCH_METHOD void storch::generate( sphoton& p, RNG& rng, const quad6& gs_, unsigned long long photon_id, unsigned genstep_id )  // static
+template <typename Rng>
+STORCH_METHOD void storch::generate(sphoton &p, Rng &rng, const quad6 &gs_, unsigned long long photon_id,
+                                    unsigned genstep_id)
 {
     const storch& gs = (const storch&)gs_ ;   // casting between union-ed types : quad6 and storch
 
@@ -213,10 +217,8 @@ STORCH_METHOD void storch::generate( sphoton& p, RNG& rng, const quad6& gs_, uns
         p.time = gs.time ;
         p.mom = gs.mom ;
 
-        float u_zenith  = gs.zenith.x  + curand_uniform(&rng)*(gs.zenith.y-gs.zenith.x)   ;
-        float u_azimuth = gs.azimuth.x + curand_uniform(&rng)*(gs.azimuth.y-gs.azimuth.x) ;
-
-
+        float u_zenith = gs.zenith.x + srng_uniform(rng) * (gs.zenith.y - gs.zenith.x);
+        float u_azimuth = gs.azimuth.x + srng_uniform(rng) * (gs.azimuth.y - gs.azimuth.x);
 
         float r = gs.radius*u_zenith ;
 
@@ -252,8 +254,8 @@ STORCH_METHOD void storch::generate( sphoton& p, RNG& rng, const quad6& gs_, uns
         p.wavelength = gs.wavelength ;
         p.time = gs.time ;
 
-        float u_zenith  = gs.zenith.x  + curand_uniform(&rng)*(gs.zenith.y-gs.zenith.x)   ;
-        float u_azimuth = gs.azimuth.x + curand_uniform(&rng)*(gs.azimuth.y-gs.azimuth.x) ;
+        float u_zenith = gs.zenith.x + srng_uniform(rng) * (gs.zenith.y - gs.zenith.x);
+        float u_azimuth = gs.azimuth.x + srng_uniform(rng) * (gs.azimuth.y - gs.azimuth.x);
 
         float phi = 2.f*M_PIf*u_azimuth ;  // azimuth range 0->2pi
         float sinPhi = sinf(phi);
@@ -311,8 +313,8 @@ STORCH_METHOD void storch::generate( sphoton& p, RNG& rng, const quad6& gs_, uns
 
         do
         {
-            u0_zenith  = gs.zenith.x  + curand_uniform(&rng)*(gs.zenith.y-gs.zenith.x)   ;   // aka polar theta
-            u1_azimuth = gs.azimuth.x + curand_uniform(&rng)*(gs.azimuth.y-gs.azimuth.x) ;   // aka azimuth phi
+            u0_zenith = gs.zenith.x + srng_uniform(rng) * (gs.zenith.y - gs.zenith.x);     // aka polar theta
+            u1_azimuth = gs.azimuth.x + srng_uniform(rng) * (gs.azimuth.y - gs.azimuth.x); // aka azimuth phi
 
             u = 2.f*u0_zenith - 1.f ;
             v = 2.f*u1_azimuth - 1.f ;

--- a/sysrap/tests/sboundary_test.cc
+++ b/sysrap/tests/sboundary_test.cc
@@ -18,7 +18,6 @@ Build and run::
 **/
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "sphoton.h"
 #include "sstate.h"
@@ -36,7 +35,7 @@ const char* FOLD = getenv("FOLD") ;
 
 int main(int argc, char** argv)
 {
-    RNG rng ;   
+    srngcpu rng;
 
     float3 nrm = make_float3(0.f, 0.f, 1.f ); // surface normal in +z direction 
 

--- a/sysrap/tests/scarrier_test.cc
+++ b/sysrap/tests/scarrier_test.cc
@@ -11,7 +11,6 @@ Standalone compile and run with::
 #include <vector>
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "scuda.h"
 #include "squad.h"
@@ -28,7 +27,7 @@ NP* make_carrier_photon( const NP* gs, const NP* se )
     const quad6* gg = (quad6*)gs->bytes() ;  
     const int*   seed = (int*)se->bytes() ;  
 
-    RNG rng ; 
+    srngcpu rng;
 
     int tot_photon = se->shape[0] ; 
     NP* ph = NP::Make<float>( tot_photon, 4, 4); 
@@ -65,4 +64,3 @@ int main(int argc, char** argv)
     test_generate(); 
     return 0 ; 
 }
-

--- a/sysrap/tests/scerenkov_test.cc
+++ b/sysrap/tests/scerenkov_test.cc
@@ -15,7 +15,6 @@ TODO: instead of this use actual qcerenkov.h together with srngcpu.h ?
 #include <vector>
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "scuda.h"
 #include "squad.h"
@@ -31,8 +30,6 @@ NP* make_cerenkov_photon( const NP* gs, const NP* se )
     const quad6* gg = (quad6*)gs->bytes() ;  
     const int*   seed = (int*)se->bytes() ;  
 
-    RNG rng ; 
-  
     int tot_photon = se->shape[0] ; 
     NP* ph = NP::Make<float>( tot_photon, 4, 4); 
     sphoton* pp = (sphoton*)ph->bytes() ; 
@@ -69,4 +66,3 @@ int main(int argc, char** argv)
     test_generate(); 
     return 0 ; 
 }
-

--- a/sysrap/tests/scurand_test.cc
+++ b/sysrap/tests/scurand_test.cc
@@ -7,13 +7,12 @@
 #include <cstdio>
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "scurand.h"
 
 int main()
 {
-    RNG rng ;   
+    srngcpu rng;
 
     for(int i=0 ; i < 20 ; i++)
     {

--- a/sysrap/tests/stmm_vs_sboundary_test.cc
+++ b/sysrap/tests/stmm_vs_sboundary_test.cc
@@ -51,7 +51,6 @@ boundary.
 **/
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "sphoton.h"
 #include "sstate.h"
@@ -282,7 +281,7 @@ sboundary.h::
 
 int main(int argc, char** argv)
 {
-    RNG rng ; 
+    srngcpu rng;
     rng.set_fake(0.);     // 0.:force transmit 1.:force reflect 
 
     float3 mom = normalize(make_float3(1.f, 0.f, -1.f)) ; 

--- a/sysrap/tests/storch_test.cc
+++ b/sysrap/tests/storch_test.cc
@@ -14,7 +14,6 @@ HMM: not standalone anymore, currently using libSysrap
 #include <cstdlib>
 
 #include "srngcpu.h"
-using RNG = srngcpu ; 
 
 #include "scuda.h"
 #include "squad.h"
@@ -81,7 +80,7 @@ NP* storch_test::make_torch_photon( const NP* gs, const NP* se )
     const quad6* gg = (quad6*)gs->bytes() ;  
     const int*   seed = (int*)se->bytes() ;  
 
-    RNG rng ; 
+    srngcpu rng;
 
     int tot_photon = se->shape[0] ; 
     NP* ph = NP::Make<float>( tot_photon, 4, 4); 
@@ -130,4 +129,3 @@ int main(int argc, char** argv)
 
     return 0 ; 
 }
-


### PR DESCRIPTION
This removes fragile include-order coupling around the global `RNG` alias. Shared headers like
`sysrap/storch.h` were implicitly depending on callers to define `using RNG = ...` before inclusion,
which made CPU mock paths and CUDA paths easy to break when a header pulled in `sysrap/srng.h`
directly.

The change makes `RNG` selection explicit at call sites by templating shared generation functions
over the `RNG` type and routing random access through `srng_traits`. CPU code can now pass `srngcpu`
directly, while CUDA code continues to use the selected device `RNG`. This keeps CPU mock generation
and GPU generation sharing the same implementation without relying on hidden global alias state.
