### PR TITLE
refactor(qudarap): remove OLD_MONOLITHIC_CURANDSTATE code path

### DIFF
--- a/qudarap/QRng.cc
+++ b/qudarap/QRng.cc
@@ -4,13 +4,7 @@
 
 #include "QRng.hh"
 #include "SCurandSpec.h"
-
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-#include "SCurandStateMonolithic.hh"
-#else
 #include "SEventConfig.hh"
-#include "SCurandState.h"
-#endif
 
 #include "sdirectory.h"
 #include "ssys.h"
@@ -55,12 +49,8 @@ QRng::QRng(unsigned skipahead_event_offset_)
     parse_rc(SCurandSpec::ParseSeedOffset(seed, offset, SEED_OFFSET )),
     qr(new qrng<RNG>(seed, offset, skipahead_event_offset)), 
     d_qr(nullptr),
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-    rngmax(0)
-#else
     rngmax(SEventConfig::MaxCurand()),
     cs(nullptr)
-#endif
 {
     init(); 
 }
@@ -82,11 +72,7 @@ template<> void QRng::initStates<XORWOW>()
     assert( is_XORWOW ); 
 
     LOG(info) << "initStates<XORWOW> LoadAndUpload and set_uploaded_states " ; 
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-    XORWOW* d_uploaded_states = LoadAndUpload(rngmax, SCurandStateMonolithic::Path()) ;  
-#else
     XORWOW* d_uploaded_states = LoadAndUpload(rngmax, cs); 
-#endif
     qr->set_uploaded_states( d_uploaded_states ); 
 }
 
@@ -138,125 +124,6 @@ QRng::~QRng()
 {
 }
 
-
-
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-
-const char* QRng::Load_FAIL_NOTES = R"(
-QRng::Load_FAIL_NOTES
-=================================
-
-QRng::Load failed to load the RNG files. 
-These files should have been created during the *opticks-full* installation 
-by the bash function *opticks-prepare-installation* 
-which runs *qudarap-prepare-installation*. 
-
-Investigate by looking at the contents of the RNG directory, 
-as shown below::
-
-    epsilon:~ blyth$ ls -l  ~/.opticks/rngcache/RNG/
-    total 892336
-    -rw-r--r--  1 blyth  staff   44000000 Oct  6 19:43 QCurandState_1000000_0_0.bin
-    -rw-r--r--  1 blyth  staff  132000000 Oct  6 19:53 QCurandState_3000000_0_0.bin
-    epsilon:~ blyth$ 
-
-
-)" ;
-
-#else
-const char* QRng::Load_FAIL_NOTES = R"(
-QRng::Load_FAIL_NOTES
-===============================
-
-TODO : for new chunked impl
-
-)" ;
-
-#endif
-
-
-
-
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-
-/**
-QRng::LoadAndUpload
---------------------
-
-In the old monolithic impl rngmax is an output argument obtained from file_size/item_size 
-and at the same time kinda an input to specify which file to load. 
-
-In the new chunked impl with partial chunk loading the rngmax is an input value
-that can be set to anything. 
-
-**/
-
-XORWOW* QRng::LoadAndUpload(ULL& rngmax, const char* path)  // static 
-{
-    XORWOW* h_states = Load(rngmax, path); 
-    XORWOW* d_states = UploadAndFree(h_states, rngmax ); 
-    return d_states ; 
-}
-
-XORWOW* QRng::Load(ULL& rngmax, const char* path)  // static 
-{
-    bool null_path = path == nullptr ; 
-    LOG_IF(fatal, null_path ) << " QRng::Load null path " ; 
-    assert( !null_path );  
-
-    FILE *fp = fopen(path,"rb");
-    bool failed = fp == nullptr ; 
-    LOG_IF(fatal, failed ) << " unabled to open file [" << path << "]" ; 
-    LOG_IF(error, failed ) << Load_FAIL_NOTES  ; 
-    assert(!failed); 
-
-
-    fseek(fp, 0L, SEEK_END);
-    long file_size = ftell(fp);
-    rewind(fp);
-
-    long type_size = sizeof(RNG) ;  
-    long item_size = 44 ; 
-
-    rngmax = file_size/item_size ; 
-
-
-    LOG(LEVEL) 
-        << " path " << path 
-        << " file_size " << file_size 
-        << " item_size " << item_size 
-        << " type_size " << type_size 
-        << " rngmax " << rngmax
-        ; 
-
-    assert( file_size % item_size == 0 );  
-
-    XORWOW* rng_states = (XORWOW*)malloc(sizeof(XORWOW)*rngmax);
-
-    for(ULL i = 0 ; i < rngmax ; ++i )
-    {   
-        XORWOW& rng = rng_states[i] ;
-        fread(&rng.d,                     sizeof(unsigned int),1,fp);   //  1
-        fread(&rng.v,                     sizeof(unsigned int),5,fp);   //  5 
-        fread(&rng.boxmuller_flag,        sizeof(int)         ,1,fp);   //  1 
-        fread(&rng.boxmuller_flag_double, sizeof(int)         ,1,fp);   //  1
-        fread(&rng.boxmuller_extra,       sizeof(float)       ,1,fp);   //  1
-        fread(&rng.boxmuller_extra_double,sizeof(double)      ,1,fp);   //  2    11*4 = 44 
-    }   
-    fclose(fp);
-
-    return rng_states ; 
-}
-
-XORWOW* QRng::UploadAndFree(XORWOW* h_states, ULL num_states )  // static 
-{
-    const char* label_0 = "QRng::UploadAndFree/rng_states" ; 
-    XORWOW* d_states = QU::UploadArray<XORWOW>(h_states, num_states, label_0 ) ;   
-    free(h_states); 
-    return d_states ;  
-}
-
-#else
 
 /**
 QRng::LoadAndUpload
@@ -434,8 +301,6 @@ XORWOW* QRng::LoadAndUpload(ULL _rngmax, const SCurandState& cs)  // static
     return complete ? d0 : nullptr ; 
 }
 
-#endif
-
 
 /**
 QRng::Save
@@ -533,5 +398,4 @@ void QRng::generate( T* uu, unsigned ni, unsigned nv, unsigned evid )
 
 template void QRng::generate<float>( float*,   unsigned, unsigned, unsigned ); 
 template void QRng::generate<double>( double*, unsigned, unsigned, unsigned ); 
-
 

--- a/qudarap/QRng.hh
+++ b/qudarap/QRng.hh
@@ -23,13 +23,7 @@ TODO : implement sanity check for use after loading::
 #include "plog/Severity.h"
 #include "curand_kernel.h"   
 #include "qrng.h"
-
-//#define OLD_MONOLITHIC_CURANDSTATE 1
-
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-#else
 #include "SCurandState.h"
-#endif
 
 
 
@@ -43,19 +37,8 @@ struct QUDARAP_API QRng
     static const QRng* Get(); 
     static std::string Desc();
 
-    static const char* Load_FAIL_NOTES ; 
-
-
-
-#ifdef OLD_MONOLITHIC_CURANDSTATE
-    static constexpr const char* IMPL = "OLD_MONOLITHIC_CURANDSTATE" ; 
-    static XORWOW* LoadAndUpload(ULL& rngmax, const char* path); 
-    static XORWOW* Load(ULL& rngmax, const char* path); 
-    static XORWOW* UploadAndFree(RNG* h_states, ULL num_states ); 
-#else
     static constexpr const char* IMPL = "CHUNKED_CURANDSTATE" ; 
     static XORWOW* LoadAndUpload(ULL rngmax, const SCurandState& cs); 
-#endif
     static void Save( XORWOW* states, unsigned num_states, const char* path ); 
 
 
@@ -69,10 +52,7 @@ struct QUDARAP_API QRng
     qrng<RNG>*     qr ;  
     qrng<RNG>*     d_qr ;  
     ULL            rngmax ;
-
-#ifndef OLD_MONOLITHIC_CURANDSTATE
     SCurandState   cs ; 
-#endif
 
 
     QRng(unsigned skipahead_event_offset=1) ;  
@@ -93,4 +73,3 @@ struct QUDARAP_API QRng
     dim3 threadsPerBlock ; 
 
 };
-

--- a/qudarap/tests/QRngTest.py
+++ b/qudarap/tests/QRngTest.py
@@ -2,7 +2,7 @@
 """
 ::
  
-    PICK=AB ~/o/qudarap/tests/QRngTest.sh pdb 
+    ~/o/qudarap/tests/QRngTest.sh pdb
 
 """
 import logging 
@@ -98,51 +98,22 @@ class QRngTest(object):
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     TEST = os.environ.get("TEST", "generate") 
-    PICK = os.environ.get("PICK", "A") 
 
     TYPE = "float"
-    a_IMPL = "CHUNKED_CURANDSTATE"
-    b_IMPL = "OLD_MONOLITHIC_CURANDSTATE"
+    impl = "CHUNKED_CURANDSTATE"
 
-    a_reldir = "%s/%s" % (TYPE, a_IMPL)
-    b_reldir = "%s/%s" % (TYPE, b_IMPL)
+    reldir = "%s/%s" % (TYPE, impl)
 
-    reldir = None
-    if PICK == "A":reldir = a_reldir
-    if PICK == "B":reldir = b_reldir
+    print("%s:TEST:%s FOLD:%s reldir:%s" % ( sys.argv[0], TEST, QRngTest.FOLD, reldir))
 
-    print("%s:TEST:%s PICK:%s FOLD:%s reldir:%s" % ( sys.argv[0], TEST, PICK, QRngTest.FOLD, reldir))
+    t = QRngTest(reldir)
 
-    if PICK in tuple("AB"):       
-        t = QRngTest(reldir)  
-
-        if TEST == "generate": 
-            uu = t.uu
-            uuh = t.uuh
-            print("uu.shape\n",uu.shape)
-            print("uu[:10]\n",uu[:10])
-            t.check_skipahead_shifts(1)
-            #t.uu_plot()
-        else:
-            print("%s:TEST:%s unhandled : run ana/pdb individually for each TEST" % (sys.argv[0],TEST) )
-        pass
-
-    elif PICK == "AB":
-        a = QRngTest(a_reldir)  
-        b = QRngTest(b_reldir)  
-
-        if TEST == "generate":
-            auu = a.uu
-            buu = b.uu
-            auu_buu_match = np.all( auu == buu )  
-            print("auu.shape\n",auu.shape)
-            print("buu.shape\n",buu.shape)
-            print("auu_buu_match:%d\n" % auu_buu_match)
-            assert auu_buu_match
-        else:
-            print("%s:TEST:%s unhandled : run ana/pdb individually for each TEST" % (sys.argv[0],TEST) )
-        pass
-    pass
+    if TEST == "generate":
+        uu = t.uu
+        uuh = t.uuh
+        print("uu.shape\n",uu.shape)
+        print("uu[:10]\n",uu[:10])
+        t.check_skipahead_shifts(1)
+    else:
+        print("%s:TEST:%s unhandled : run ana/pdb individually for each TEST" % (sys.argv[0],TEST) )
 pass
-
-

--- a/sysrap/SEventConfig.hh
+++ b/sysrap/SEventConfig.hh
@@ -129,11 +129,8 @@ MaxCurand
    Used by QRng with XORWOW running when curandState files are needed.
    With chunked curandstate controls how many chunk files and how much
    of the final chunk to load into memory.
-
-   With OLD_MONOLITHIC_CURANDSTATE specifies which monolithic file to load.
-
-   In both cases the value limits the total number of photons that can be
-   XORWOW simulated irrespective of multi-launching to fit within VRAM.
+   The value limits the total number of photons that can be XORWOW
+   simulated irrespective of multi-launching to fit within VRAM.
 
 
 MaxSlot OPTICKS_MAX_SLOT


### PR DESCRIPTION
Drop the retired monolithic curandState flag and its dead QRng branch, leaving the chunked
curandState path as the only supported implementation.  This also removes stale test and config
references to the legacy mode.

Motivation: reduce maintenance overhead, eliminate misleading legacy scaffolding, and make future
RNG changes easier to reason about.
