### PR TITLE
style: configure clang-format template and initializer rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,4 @@
 BasedOnStyle: Microsoft
+BreakTemplateDeclarations: MultiLine
+PackConstructorInitializers: Never
+BreakConstructorInitializers: AfterColon


### PR DESCRIPTION
Add formatting rules for multiline template declarations and constructor initializer lists.
