### PR TITLE
Async gpu std example

### DIFF
--- a/examples/async_gpu_std/CMakeLists.txt
+++ b/examples/async_gpu_std/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(async_gpu_std LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Order matters: pull in glm before eic-opticks because the installed
+# eic-opticks::SysRap target's link interface references glm::glm but the
+# package's Config.cmake does not declare it as a dependency.
+find_package(glm REQUIRED)
+find_package(eic-opticks REQUIRED)
+find_package(Geant4 REQUIRED ui_all vis_all)
+find_package(Threads REQUIRED)
+
+add_executable(async_gpu_std async_gpu_std.cpp async_gpu_std.h)
+target_link_libraries(async_gpu_std
+    eic-opticks::G4CX
+    eic-opticks::SysRap
+    eic-opticks::U4
+    ${Geant4_LIBRARIES}
+    Threads::Threads
+)
+
+install(TARGETS async_gpu_std)

--- a/examples/async_gpu_std/apex.gdml
+++ b/examples/async_gpu_std/apex.gdml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <matrix coldim="2" name="RINDEX0x6000000ed5f0" values="2.33932e-06 1.65 2.91728e-06 1.65 3.0996e-06 1.65 3.64659e-06 1.65 4.06506e-06 1.65 7.74901e-06 1.65 9.68627e-06 1.65 1.16966e-05 1.65"/>
+    <matrix coldim="2" name="GROUPVEL0x6000000ed6c0" values="2.33932e-06 181.692 2.6283e-06 181.692 3.00844e-06 181.692 3.3731e-06 181.692 3.85582e-06 181.692 5.90703e-06 181.692 8.71764e-06 181.692 1.16966e-05 181.692"/>
+    <matrix coldim="2" name="WLSCOMPONENT0x6000000ed860" values="2.33932e-06 0 2.91728e-06 0.0005 3.0996e-06 0.002 3.64659e-06 0.022 4.06506e-06 0.0005 7.74901e-06 0 9.68627e-06 0 1.16966e-05 0"/>
+    <matrix coldim="2" name="WLSABSLENGTH0x6000000ed790" values="2.33932e-06 10000 2.91728e-06 10000 3.0996e-06 10000 3.64659e-06 10000 4.06506e-06 0.187 7.74901e-06 0.0005 9.68627e-06 0.0005 1.16966e-05 0.0005"/>
+    <matrix coldim="1" name="WLSTIMECONSTANT0x6000010e1b20" values="1.136"/>
+    <matrix coldim="2" name="RINDEX0x6000000ed930" values="2.33932e-06 1.5 2.91728e-06 1.5 3.0996e-06 1.5 3.64659e-06 1.5 4.06506e-06 1.5 7.74901e-06 1.5 9.68627e-06 1.5 1.16966e-05 1.5"/>
+    <matrix coldim="2" name="GROUPVEL0x6000000eda00" values="2.33932e-06 199.862 2.6283e-06 199.862 3.00844e-06 199.862 3.3731e-06 199.862 3.85582e-06 199.862 5.90703e-06 199.862 8.71764e-06 199.862 1.16966e-05 199.862"/>
+    <matrix coldim="2" name="RINDEX0x6000000edad0" values="2.33932e-06 1.58 2.91728e-06 1.58 3.0996e-06 1.58 3.64659e-06 1.58 4.06506e-06 1.58 7.74901e-06 1.58 9.68627e-06 1.58 1.16966e-05 1.58"/>
+    <matrix coldim="2" name="GROUPVEL0x6000000edba0" values="2.33932e-06 189.742 2.6283e-06 189.742 3.00844e-06 189.742 3.3731e-06 189.742 3.85582e-06 189.742 5.90703e-06 189.742 8.71764e-06 189.742 1.16966e-05 189.742"/>
+    <matrix coldim="2" name="WLSCOMPONENT0x6000000edd40" values="2.33932e-06 0.0005 2.91728e-06 0.02 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0 9.68627e-06 0 1.16966e-05 0"/>
+    <matrix coldim="2" name="WLSABSLENGTH0x6000000edc70" values="2.33932e-06 2000 2.91728e-06 2000 3.0996e-06 0.8 3.64659e-06 0.8 4.06506e-06 3 7.74901e-06 0.0001 9.68627e-06 0.0001 1.16966e-05 0.0001"/>
+    <matrix coldim="1" name="WLSTIMECONSTANT0x6000010e1c00" values="1.26"/>
+    <matrix coldim="2" name="RINDEX0x6000000ede10" values="2.33932e-06 1.23 2.91728e-06 1.23 3.0996e-06 1.23 3.64659e-06 1.23 4.06506e-06 1.235 7.74901e-06 1.315 9.68627e-06 1.45 1.16966e-05 5.45"/>
+    <matrix coldim="2" name="GROUPVEL0x6000000edee0" values="2.33932e-06 243.734 2.6283e-06 243.734 3.00844e-06 243.734 3.3731e-06 243.734 3.85582e-06 234.483 5.90703e-06 214.29 8.71764e-06 150.84 1.16966e-05 11.2451"/>
+    <matrix coldim="2" name="RAYLEIGH0x6000000ee220" values="2.33932e-06 900 2.91728e-06 900 3.0996e-06 900 3.64659e-06 900 4.06506e-06 900 7.74901e-06 900 9.68627e-06 900 1.16966e-05 900"/>
+    <matrix coldim="2" name="ABSLENGTH0x6000000ee150" values="2.33932e-06 10000 2.91728e-06 10000 3.0996e-06 10000 3.64659e-06 10000 4.06506e-06 10000 7.74901e-06 10000 9.68627e-06 10000 1.16966e-05 10000"/>
+    <matrix coldim="2" name="SCINTILLATIONCOMPONENT10x6000000edfb0" values="2.33932e-06 0 2.91728e-06 0 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0.000238409 9.68627e-06 0.0398859 1.16966e-05 0.00422473"/>
+    <matrix coldim="2" name="SCINTILLATIONCOMPONENT20x6000000ee080" values="2.33932e-06 0 2.91728e-06 0 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0.000238409 9.68627e-06 0.0398859 1.16966e-05 0.00422473"/>
+    <matrix coldim="2" name="FASTCOMPONENT" values="2.33932e-06 0 2.91728e-06 0 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0.000238409 9.68627e-06 0.0398859 1.16966e-05 0.00422473"/>
+    <matrix coldim="2" name="SLOWCOMPONENT" values="2.33932e-06 0 2.91728e-06 0 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0.000238409 9.68627e-06 0.0398859 1.16966e-05 0.00422473"/>
+    <matrix coldim="2" name="REEMISSIONPROB" values="2.33932e-06 0 2.91728e-06 0 3.0996e-06 0 3.64659e-06 0 4.06506e-06 0 7.74901e-06 0 9.68627e-06 0 1.16966e-05 0"/>
+    <matrix coldim="1" name="SCINTILLATIONYIELD0x6000010e1c70" values="24000"/>
+    <matrix coldim="1" name="RESOLUTIONSCALE0x6000010e1c70" values="1"/>
+    <matrix coldim="1" name="SCINTILLATIONTIMECONSTANT10x6000010e1c70" values="7"/>
+    <matrix coldim="1" name="SCINTILLATIONTIMECONSTANT20x6000010e1c70" values="1400"/>
+    <matrix coldim="1" name="SCINTILLATIONYIELD10x6000010e1c70" values="0.75"/>
+    <matrix coldim="1" name="SCINTILLATIONYIELD20x6000010e1c70" values="0.25"/>
+    <matrix coldim="2" name="REFLECTIVITY0x6000000ee2f0" values="2.33932e-06 0.98 2.91728e-06 0.98 3.0996e-06 0.98 3.64659e-06 0.98 4.06506e-06 0.98 7.74901e-06 0.98 9.68627e-06 0.98 1.16966e-05 0.98"/>
+    <matrix coldim="2" name="EFFICIENCY_SIPM" values="2.33932e-06 1.0 2.91728e-06 1.0 3.0996e-06 1.0 3.64659e-06 1.0 4.06506e-06 1.0 7.74901e-06 1.0 9.68627e-06 1.0 1.16966e-05 1.0"/>
+  </define>
+
+  <materials>
+    <isotope N="12" Z="6" name="C120x600002ee5980">
+      <atom unit="g/mole" value="12"/>
+    </isotope>
+    <isotope N="13" Z="6" name="C130x600002ee59c0">
+      <atom unit="g/mole" value="13.0034"/>
+    </isotope>
+    <element name="C0x600000ce1080">
+      <fraction n="0.9893" ref="C120x600002ee5980"/>
+      <fraction n="0.0107" ref="C130x600002ee59c0"/>
+    </element>
+    <isotope N="1" Z="1" name="H10x600002ee5a40">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H20x600002ee5a80">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H0x600000ce1130">
+      <fraction n="0.999885" ref="H10x600002ee5a40"/>
+      <fraction n="0.000115" ref="H20x600002ee5a80"/>
+    </element>
+    <material name="pTP0x121e06e10" state="solid">
+      <property name="RINDEX" ref="RINDEX0x6000000ed5f0"/>
+      <property name="GROUPVEL" ref="GROUPVEL0x6000000ed6c0"/>
+      <property name="WLSCOMPONENT" ref="WLSCOMPONENT0x6000000ed860"/>
+      <property name="WLSABSLENGTH" ref="WLSABSLENGTH0x6000000ed790"/>
+      <property name="WLSTIMECONSTANT" ref="WLSTIMECONSTANT0x6000010e1b20"/>
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="68.6661371678143"/>
+      <D unit="g/cm3" value="1.23"/>
+      <fraction n="0.938728183298287" ref="C0x600000ce1080"/>
+      <fraction n="0.0612718167017128" ref="H0x600000ce1130"/>
+    </material>
+    <isotope N="16" Z="8" name="O160x600002ee5ac0">
+      <atom unit="g/mole" value="15.9949"/>
+    </isotope>
+    <isotope N="17" Z="8" name="O170x600002ee5b40">
+      <atom unit="g/mole" value="16.9991"/>
+    </isotope>
+    <isotope N="18" Z="8" name="O180x600002ee5b80">
+      <atom unit="g/mole" value="17.9992"/>
+    </isotope>
+    <element name="O0x600000ce11e0">
+      <fraction n="0.99757" ref="O160x600002ee5ac0"/>
+      <fraction n="0.00038" ref="O170x600002ee5b40"/>
+      <fraction n="0.00205" ref="O180x600002ee5b80"/>
+    </element>
+    <material name="acrylicMcMaster0x121e06f20" state="solid">
+      <property name="RINDEX" ref="RINDEX0x6000000ed930"/>
+      <property name="GROUPVEL" ref="GROUPVEL0x6000000eda00"/>
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="68.6088807971964"/>
+      <D unit="g/cm3" value="1.19"/>
+      <fraction n="0.599841070879962" ref="C0x600000ce1080"/>
+      <fraction n="0.0805418407442842" ref="H0x600000ce1130"/>
+      <fraction n="0.319617088375753" ref="O0x600000ce11e0"/>
+    </material>
+    <material name="bluewlsacrylic0x121e075c0" state="solid">
+      <property name="RINDEX" ref="RINDEX0x6000000edad0"/>
+      <property name="GROUPVEL" ref="GROUPVEL0x6000000edba0"/>
+      <property name="WLSCOMPONENT" ref="WLSCOMPONENT0x6000000edd40"/>
+      <property name="WLSABSLENGTH" ref="WLSABSLENGTH0x6000000edc70"/>
+      <property name="WLSTIMECONSTANT" ref="WLSTIMECONSTANT0x6000010e1c00"/>
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="64.6844741120544"/>
+      <D unit="g/cm3" value="1.023"/>
+      <fraction n="0.914708531800025" ref="C0x600000ce1080"/>
+      <fraction n="0.0852914681999746" ref="H0x600000ce1130"/>
+    </material>
+    <isotope N="36" Z="18" name="Ar360x600002ee5bc0">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar380x600002ee5c00">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar400x600002ee5b00">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar0x600000ce1290">
+      <fraction n="0.003365" ref="Ar360x600002ee5bc0"/>
+      <fraction n="0.000632" ref="Ar380x600002ee5c00"/>
+      <fraction n="0.996003" ref="Ar400x600002ee5b00"/>
+    </element>
+    <material name="G4_lAr0x121e076d0" state="liquid">
+      <property name="RINDEX" ref="RINDEX0x6000000ede10"/>
+      <property name="GROUPVEL" ref="GROUPVEL0x6000000edee0"/>
+      <property name="RAYLEIGH" ref="RAYLEIGH0x6000000ee220"/>
+      <property name="ABSLENGTH" ref="ABSLENGTH0x6000000ee150"/>
+      <property name="SCINTILLATIONCOMPONENT1" ref="SCINTILLATIONCOMPONENT10x6000000edfb0"/>
+      <property name="SCINTILLATIONCOMPONENT2" ref="SCINTILLATIONCOMPONENT20x6000000ee080"/>
+      <property name="FASTCOMPONENT" ref="FASTCOMPONENT"/>
+      <property name="SLOWCOMPONENT" ref="SLOWCOMPONENT"/>
+      <property name="REEMISSIONPROB" ref="REEMISSIONPROB"/>
+      <property name="SCINTILLATIONYIELD" ref="SCINTILLATIONYIELD0x6000010e1c70"/>
+      <property name="RESOLUTIONSCALE" ref="RESOLUTIONSCALE0x6000010e1c70"/>
+      <property name="SCINTILLATIONTIMECONSTANT1" ref="SCINTILLATIONTIMECONSTANT10x6000010e1c70"/>
+      <property name="SCINTILLATIONTIMECONSTANT2" ref="SCINTILLATIONTIMECONSTANT20x6000010e1c70"/>
+      <property name="SCINTILLATIONYIELD1" ref="SCINTILLATIONYIELD10x6000010e1c70"/>
+      <property name="SCINTILLATIONYIELD2" ref="SCINTILLATIONYIELD20x6000010e1c70"/>
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar0x600000ce1290"/>
+    </material>
+  </materials>
+
+  <solids>
+    <box lunit="mm" name="pTPlayer0x6000010e2920" x="500" y="500" z="0.002"/>
+    <box lunit="mm" name="pTPsubstrate0x6000010e2990" x="500" y="500" z="6"/>
+    <box lunit="mm" name="BlueWLSplate0x6000010e2a00" x="500" y="500" z="6"/>
+    <box lunit="mm" name="SiPMs0x6000010e2a70" x="6" y="1" z="6"/>
+    <box lunit="mm" name="ReflectiveFoilBackPlane0x6000010e2ae0" x="500" y="500" z="0.065"/>
+    <opticalsurface finish="3" model="1" name="Vikuiti0x6000010e1ce0" type="0" value="0">
+      <property name="REFLECTIVITY" ref="REFLECTIVITY0x6000000ee2f0"/>
+    </opticalsurface>
+    <opticalsurface finish="0" model="1" name="SiPMSurface" type="0" value="0">
+      <property name="EFFICIENCY" ref="EFFICIENCY_SIPM"/>
+    </opticalsurface>
+    <box lunit="mm" name="ReflectiveFoilEdgeTop0x6000010e2b50" x="500" y="0.065" z="6"/>
+    <box lunit="mm" name="ReflectiveFoilEdgeBot0x6000010e2bc0" x="500" y="0.065" z="6"/>
+    <box lunit="mm" name="ReflectiveFoilEdgeLeft0x6000010e2c30" x="0.065" y="500" z="6"/>
+    <box lunit="mm" name="ReflectiveFoilEdgeRight0x6000010e2ca0" x="0.065" y="500" z="6"/>
+    <box lunit="mm" name="solidWorld0x6000010e2300" x="1000" y="1000" z="1000"/>
+  </solids>
+
+  <structure>
+    <volume name="logicpTPlayer0x600000ae2300">
+      <materialref ref="pTP0x121e06e10"/>
+      <solidref ref="pTPlayer0x6000010e2920"/>
+    </volume>
+    <volume name="logicpTPsubstrate0x600000ae23a0">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="pTPsubstrate0x6000010e2990"/>
+    </volume>
+    <volume name="logicBlueWLSplate0x600000ae2440">
+      <materialref ref="bluewlsacrylic0x121e075c0"/>
+      <solidref ref="BlueWLSplate0x6000010e2a00"/>
+    </volume>
+    <volume name="logicSiPMs0x600000ae24e0">
+      <materialref ref="G4_lAr0x121e076d0"/>
+      <solidref ref="SiPMs0x6000010e2a70"/>
+      <auxiliary auxtype="SensDet" auxvalue="PhotonDetector"/>
+    </volume>
+    <volume name="logicReflectiveFoilBackPlane0x600000ae2580">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="ReflectiveFoilBackPlane0x6000010e2ae0"/>
+    </volume>
+    <volume name="logicReflectiveFoilEdgeTop0x600000ae2620">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="ReflectiveFoilEdgeTop0x6000010e2b50"/>
+    </volume>
+    <volume name="logicReflectiveFoilEdgeBot0x600000ae26c0">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="ReflectiveFoilEdgeBot0x6000010e2bc0"/>
+    </volume>
+    <volume name="logicReflectiveFoilEdgeLeft0x600000ae2760">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="ReflectiveFoilEdgeLeft0x6000010e2c30"/>
+    </volume>
+    <volume name="logicReflectiveFoilEdgeRight0x600000ae2800">
+      <materialref ref="acrylicMcMaster0x121e06f20"/>
+      <solidref ref="ReflectiveFoilEdgeRight0x6000010e2ca0"/>
+    </volume>
+    <volume name="logicWorld0x600000ae1f40">
+      <materialref ref="G4_lAr0x121e076d0"/>
+      <solidref ref="solidWorld0x6000010e2300"/>
+      <physvol name="physpTPlayer0x6000018e2580">
+        <volumeref ref="logicpTPlayer0x600000ae2300"/>
+        <position name="physpTPlayer0x6000018e2580_pos" unit="mm" x="0" y="0" z="246.999"/>
+      </physvol>
+      <physvol name="physpTPsubstrate0x6000018e26c0">
+        <volumeref ref="logicpTPsubstrate0x600000ae23a0"/>
+        <position name="physpTPsubstrate0x6000018e26c0_pos" unit="mm" x="0" y="0" z="250"/>
+      </physvol>
+      <physvol name="physBlueWLSplate0x6000018e2800">
+        <volumeref ref="logicBlueWLSplate0x600000ae2440"/>
+        <position name="physBlueWLSplate0x6000018e2800_pos" unit="mm" x="0" y="0" z="258"/>
+      </physvol>
+      <physvol name="physSiPMs0x6000018e2940">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2940_pos" unit="mm" x="-241.935483870968" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="1" name="physSiPMs0x6000018e29e0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e29e0_pos" unit="mm" x="-225.806451612903" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="2" name="physSiPMs0x6000018e2a30">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2a30_pos" unit="mm" x="-209.677419354839" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="3" name="physSiPMs0x6000018e2a80">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2a80_pos" unit="mm" x="-193.548387096774" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="4" name="physSiPMs0x6000018e2ad0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2ad0_pos" unit="mm" x="-177.41935483871" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="5" name="physSiPMs0x6000018e2b20">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2b20_pos" unit="mm" x="-161.290322580645" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="6" name="physSiPMs0x6000018e2b70">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2b70_pos" unit="mm" x="-145.161290322581" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="7" name="physSiPMs0x6000018e2bc0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2bc0_pos" unit="mm" x="-129.032258064516" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="8" name="physSiPMs0x6000018e2c10">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2c10_pos" unit="mm" x="-112.903225806452" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="9" name="physSiPMs0x6000018e2c60">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2c60_pos" unit="mm" x="-96.7741935483871" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="10" name="physSiPMs0x6000018e2cb0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2cb0_pos" unit="mm" x="-80.6451612903226" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="11" name="physSiPMs0x6000018e2d00">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2d00_pos" unit="mm" x="-64.5161290322581" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="12" name="physSiPMs0x6000018e2d50">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2d50_pos" unit="mm" x="-48.3870967741935" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="13" name="physSiPMs0x6000018e2da0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2da0_pos" unit="mm" x="-32.258064516129" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="14" name="physSiPMs0x6000018e2df0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2df0_pos" unit="mm" x="-16.1290322580645" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="15" name="physSiPMs0x6000018e2e40">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2e40_pos" unit="mm" x="0" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="16" name="physSiPMs0x6000018e2e90">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2e90_pos" unit="mm" x="16.1290322580645" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="17" name="physSiPMs0x6000018e2ee0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2ee0_pos" unit="mm" x="32.258064516129" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="18" name="physSiPMs0x6000018e2f30">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2f30_pos" unit="mm" x="48.3870967741935" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="19" name="physSiPMs0x6000018e2f80">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2f80_pos" unit="mm" x="64.516129032258" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="20" name="physSiPMs0x6000018e2fd0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e2fd0_pos" unit="mm" x="80.6451612903226" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="21" name="physSiPMs0x6000018e3020">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3020_pos" unit="mm" x="96.7741935483871" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="22" name="physSiPMs0x6000018e3070">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3070_pos" unit="mm" x="112.903225806452" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="23" name="physSiPMs0x6000018e30c0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e30c0_pos" unit="mm" x="129.032258064516" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="24" name="physSiPMs0x6000018e3110">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3110_pos" unit="mm" x="145.161290322581" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="25" name="physSiPMs0x6000018e3160">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3160_pos" unit="mm" x="161.290322580645" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="26" name="physSiPMs0x6000018e31b0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e31b0_pos" unit="mm" x="177.41935483871" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="27" name="physSiPMs0x6000018e3200">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3200_pos" unit="mm" x="193.548387096774" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="28" name="physSiPMs0x6000018e3250">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e3250_pos" unit="mm" x="209.677419354839" y="251" z="258"/>
+      </physvol>
+      <physvol copynumber="29" name="physSiPMs0x6000018e32a0">
+        <volumeref ref="logicSiPMs0x600000ae24e0"/>
+        <position name="physSiPMs0x6000018e32a0_pos" unit="mm" x="225.806451612903" y="251" z="258"/>
+      </physvol>
+      <physvol name="physReflectiveFoilBackPlane0x6000018e3390">
+        <volumeref ref="logicReflectiveFoilBackPlane0x600000ae2580"/>
+        <position name="physReflectiveFoilBackPlane0x6000018e3390_pos" unit="mm" x="0" y="0" z="261.033"/>
+      </physvol>
+      <physvol name="physReflectiveFoilEdgeTop0x6000018e36b0">
+        <volumeref ref="logicReflectiveFoilEdgeTop0x600000ae2620"/>
+        <position name="physReflectiveFoilEdgeTop0x6000018e36b0_pos" unit="mm" x="0" y="251.533" z="258"/>
+      </physvol>
+      <physvol name="physReflectiveFoilEdgeBot0x6000018e3750">
+        <volumeref ref="logicReflectiveFoilEdgeBot0x600000ae26c0"/>
+        <position name="physReflectiveFoilEdgeBot0x6000018e3750_pos" unit="mm" x="0" y="-250.033" z="258"/>
+      </physvol>
+      <physvol name="physReflectiveFoilEdgeLeft0x6000018e37f0">
+        <volumeref ref="logicReflectiveFoilEdgeLeft0x600000ae2760"/>
+        <position name="physReflectiveFoilEdgeLeft0x6000018e37f0_pos" unit="mm" x="250.033" y="0" z="258"/>
+      </physvol>
+      <physvol name="physReflectiveFoilEdgeRight0x6000018e3890">
+        <volumeref ref="logicReflectiveFoilEdgeRight0x600000ae2800"/>
+        <position name="physReflectiveFoilEdgeRight0x6000018e3890_pos" unit="mm" x="-250.033" y="0" z="258"/>
+      </physvol>
+    </volume>
+    <skinsurface name="skin0x600002e09bc0" surfaceproperty="Vikuiti0x6000010e1ce0">
+      <volumeref ref="logicReflectiveFoilBackPlane0x600000ae2580"/>
+    </skinsurface>
+    <skinsurface name="skinedgetop0x600002e09b80" surfaceproperty="Vikuiti0x6000010e1ce0">
+      <volumeref ref="logicReflectiveFoilEdgeTop0x600000ae2620"/>
+    </skinsurface>
+    <skinsurface name="skinedgebot0x600002e09c00" surfaceproperty="Vikuiti0x6000010e1ce0">
+      <volumeref ref="logicReflectiveFoilEdgeBot0x600000ae26c0"/>
+    </skinsurface>
+    <skinsurface name="skinedgeleft0x600002e09c40" surfaceproperty="Vikuiti0x6000010e1ce0">
+      <volumeref ref="logicReflectiveFoilEdgeLeft0x600000ae2760"/>
+    </skinsurface>
+    <skinsurface name="skinedgeright0x600002e09c80" surfaceproperty="Vikuiti0x6000010e1ce0">
+      <volumeref ref="logicReflectiveFoilEdgeRight0x600000ae2800"/>
+    </skinsurface>
+    <skinsurface name="skinSiPM" surfaceproperty="SiPMSurface">
+      <volumeref ref="logicSiPMs0x600000ae24e0"/>
+    </skinsurface>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="logicWorld0x600000ae1f40"/>
+  </setup>
+
+</gdml>

--- a/examples/async_gpu_std/async_gpu_std.cpp
+++ b/examples/async_gpu_std/async_gpu_std.cpp
@@ -1,0 +1,150 @@
+// async_gpu_std.cpp — async CPU+GPU optical photon simulation, std-only.
+//
+// Same architecture as examples/async_gpu_launch but the GPU worker is a
+// plain std::thread driven by std::mutex + std::condition_variable +
+// std::queue, with no G4TaskGroup or G4Mutex.
+//
+// Usage:
+//   async_gpu_std -g apex.gdml -m run.mac [--async] [--sync] [-s SEED]
+
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <iostream>
+#include <string>
+
+#include "FTFP_BERT.hh"
+#include "G4OpticalPhysics.hh"
+#include "G4VModularPhysicsList.hh"
+
+#include "G4UIExecutive.hh"
+#include "G4UImanager.hh"
+#include "G4VisExecutive.hh"
+
+#include "G4RunManager.hh"
+#include "G4RunManagerFactory.hh"
+#include "G4VUserActionInitialization.hh"
+
+#include "async_gpu_std.h"
+#include "sysrap/OPTICKS_LOG.hh"
+
+struct ActionInitialization : public G4VUserActionInitialization
+{
+    G4App *fG4App;
+    ActionInitialization(G4App *app) : fG4App(app) {}
+
+    void BuildForMaster() const override
+    {
+        SetUserAction(fG4App->run_act_);
+    }
+
+    void Build() const override
+    {
+        SetUserAction(fG4App->prim_gen_);
+        SetUserAction(fG4App->run_act_);
+        SetUserAction(fG4App->event_act_);
+        SetUserAction(fG4App->tracking_);
+        SetUserAction(fG4App->stepping_);
+    }
+};
+
+static void usage(const char *prog)
+{
+    std::cerr <<
+        "Usage: " << prog << " [options]\n"
+        "  -g, --gdml PATH      GDML file (default: apex.gdml)\n"
+        "  -m, --macro PATH     Geant4 macro (default: run.mac)\n"
+        "  -s, --seed N         random seed (default: time())\n"
+        "  -i, --interactive    open interactive viewer\n"
+        "      --async          double-buffered async GPU (default)\n"
+        "      --sync           end-of-run GPU simulation\n"
+        "  -h, --help           show this message\n";
+}
+
+int main(int argc, char **argv)
+{
+    OPTICKS_LOG(argc, argv);
+
+    std::string gdml_file = "apex.gdml";
+    std::string macro_name = "run.mac";
+    long seed = static_cast<long>(std::time(nullptr));
+    bool seed_set = false;
+    bool interactive = false;
+    bool sync_mode = false;
+
+    for (int i = 1; i < argc; i++)
+    {
+        std::string a = argv[i];
+        auto next = [&](const char *flag) -> const char * {
+            if (i + 1 >= argc)
+            {
+                std::cerr << flag << " requires an argument\n";
+                std::exit(EXIT_FAILURE);
+            }
+            return argv[++i];
+        };
+
+        if (a == "-g" || a == "--gdml")
+            gdml_file = next("--gdml");
+        else if (a == "-m" || a == "--macro")
+            macro_name = next("--macro");
+        else if (a == "-s" || a == "--seed")
+        {
+            seed = std::atol(next("--seed"));
+            seed_set = true;
+        }
+        else if (a == "-i" || a == "--interactive")
+            interactive = true;
+        else if (a == "--sync")
+            sync_mode = true;
+        else if (a == "--async")
+            sync_mode = false;
+        else if (a == "-h" || a == "--help")
+        {
+            usage(argv[0]);
+            return EXIT_SUCCESS;
+        }
+        else
+        {
+            std::cerr << "unknown option: " << a << "\n";
+            usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    CLHEP::HepRandom::setTheSeed(seed);
+    G4cout << "Random seed: " << seed << (seed_set ? " (user)" : " (time)") << G4endl;
+
+    bool enable_async = !sync_mode;
+    G4cout << "Mode: " << (enable_async ? "ASYNC (std)" : "SYNC") << G4endl;
+
+    G4VModularPhysicsList *physics = new FTFP_BERT;
+    physics->RegisterPhysics(new G4OpticalPhysics);
+
+    auto *run_mgr = G4RunManagerFactory::CreateRunManager();
+    run_mgr->SetUserInitialization(physics);
+
+    G4App *g4app = new G4App(gdml_file, enable_async);
+
+    auto *actionInit = new ActionInitialization(g4app);
+    run_mgr->SetUserInitialization(actionInit);
+    run_mgr->SetUserInitialization(g4app->det_cons_);
+
+    G4UIExecutive *uix = nullptr;
+    G4VisManager *vis = nullptr;
+    if (interactive)
+    {
+        uix = new G4UIExecutive(argc, argv);
+        vis = new G4VisExecutive;
+        vis->Initialize();
+    }
+
+    G4UImanager *ui = G4UImanager::GetUIpointer();
+    ui->ApplyCommand("/control/execute " + macro_name);
+
+    if (interactive)
+        uix->SessionStart();
+
+    delete uix;
+    return EXIT_SUCCESS;
+}

--- a/examples/async_gpu_std/async_gpu_std.cpp
+++ b/examples/async_gpu_std/async_gpu_std.cpp
@@ -31,7 +31,9 @@
 struct ActionInitialization : public G4VUserActionInitialization
 {
     G4App *fG4App;
-    ActionInitialization(G4App *app) : fG4App(app) {}
+    ActionInitialization(G4App *app) : fG4App(app)
+    {
+    }
 
     void BuildForMaster() const override
     {
@@ -50,15 +52,15 @@ struct ActionInitialization : public G4VUserActionInitialization
 
 static void usage(const char *prog)
 {
-    std::cerr <<
-        "Usage: " << prog << " [options]\n"
-        "  -g, --gdml PATH      GDML file (default: apex.gdml)\n"
-        "  -m, --macro PATH     Geant4 macro (default: run.mac)\n"
-        "  -s, --seed N         random seed (default: time())\n"
-        "  -i, --interactive    open interactive viewer\n"
-        "      --async          double-buffered async GPU (default)\n"
-        "      --sync           end-of-run GPU simulation\n"
-        "  -h, --help           show this message\n";
+    std::cerr << "Usage: " << prog
+              << " [options]\n"
+                 "  -g, --gdml PATH      GDML file (default: apex.gdml)\n"
+                 "  -m, --macro PATH     Geant4 macro (default: run.mac)\n"
+                 "  -s, --seed N         random seed (default: time())\n"
+                 "  -i, --interactive    open interactive viewer\n"
+                 "      --async          double-buffered async GPU (default)\n"
+                 "      --sync           end-of-run GPU simulation\n"
+                 "  -h, --help           show this message\n";
 }
 
 int main(int argc, char **argv)

--- a/examples/async_gpu_std/async_gpu_std.cpp
+++ b/examples/async_gpu_std/async_gpu_std.cpp
@@ -30,8 +30,9 @@
 
 struct ActionInitialization : public G4VUserActionInitialization
 {
-    G4App *fG4App;
-    ActionInitialization(G4App *app) : fG4App(app)
+    G4App* fG4App;
+    ActionInitialization(G4App* app) :
+        fG4App(app)
     {
     }
 
@@ -50,7 +51,7 @@ struct ActionInitialization : public G4VUserActionInitialization
     }
 };
 
-static void usage(const char *prog)
+static void usage(const char* prog)
 {
     std::cerr << "Usage: " << prog
               << " [options]\n"
@@ -63,21 +64,21 @@ static void usage(const char *prog)
                  "  -h, --help           show this message\n";
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     OPTICKS_LOG(argc, argv);
 
     std::string gdml_file = "apex.gdml";
     std::string macro_name = "run.mac";
-    long seed = static_cast<long>(std::time(nullptr));
-    bool seed_set = false;
-    bool interactive = false;
-    bool sync_mode = false;
+    long        seed = static_cast<long>(std::time(nullptr));
+    bool        seed_set = false;
+    bool        interactive = false;
+    bool        sync_mode = false;
 
     for (int i = 1; i < argc; i++)
     {
         std::string a = argv[i];
-        auto next = [&](const char *flag) -> const char * {
+        auto        next = [&](const char* flag) -> const char* {
             if (i + 1 >= argc)
             {
                 std::cerr << flag << " requires an argument\n";
@@ -115,25 +116,26 @@ int main(int argc, char **argv)
     }
 
     CLHEP::HepRandom::setTheSeed(seed);
-    G4cout << "Random seed: " << seed << (seed_set ? " (user)" : " (time)") << G4endl;
+    G4cout << "Random seed: " << seed << (seed_set ? " (user)" : " (time)")
+           << G4endl;
 
     bool enable_async = !sync_mode;
     G4cout << "Mode: " << (enable_async ? "ASYNC (std)" : "SYNC") << G4endl;
 
-    G4VModularPhysicsList *physics = new FTFP_BERT;
+    G4VModularPhysicsList* physics = new FTFP_BERT;
     physics->RegisterPhysics(new G4OpticalPhysics);
 
-    auto *run_mgr = G4RunManagerFactory::CreateRunManager();
+    auto* run_mgr = G4RunManagerFactory::CreateRunManager();
     run_mgr->SetUserInitialization(physics);
 
-    G4App *g4app = new G4App(gdml_file, enable_async);
+    G4App* g4app = new G4App(gdml_file, enable_async);
 
-    auto *actionInit = new ActionInitialization(g4app);
+    auto* actionInit = new ActionInitialization(g4app);
     run_mgr->SetUserInitialization(actionInit);
     run_mgr->SetUserInitialization(g4app->det_cons_);
 
-    G4UIExecutive *uix = nullptr;
-    G4VisManager *vis = nullptr;
+    G4UIExecutive* uix = nullptr;
+    G4VisManager*  vis = nullptr;
     if (interactive)
     {
         uix = new G4UIExecutive(argc, argv);
@@ -141,7 +143,7 @@ int main(int argc, char **argv)
         vis->Initialize();
     }
 
-    G4UImanager *ui = G4UImanager::GetUIpointer();
+    G4UImanager* ui = G4UImanager::GetUIpointer();
     ui->ApplyCommand("/control/execute " + macro_name);
 
     if (interactive)

--- a/examples/async_gpu_std/async_gpu_std.h
+++ b/examples/async_gpu_std/async_gpu_std.h
@@ -75,8 +75,8 @@
 
 namespace
 {
-G4Mutex genstep_mutex = G4MUTEX_INITIALIZER;        // sync-mode SEvt collection
-std::mutex g4hits_mutex;                            // accumulator across worker threads
+G4Mutex genstep_mutex = G4MUTEX_INITIALIZER; // sync-mode SEvt collection
+std::mutex g4hits_mutex;                     // accumulator across worker threads
 std::vector<std::array<float, 16>> g4_accumulated_hits;
 } // namespace
 
@@ -92,8 +92,7 @@ bool IsSubtractionSolid(G4VSolid *solid)
         return true;
     if (G4BooleanSolid *bs = dynamic_cast<G4BooleanSolid *>(solid))
     {
-        if (IsSubtractionSolid(bs->GetConstituentSolid(0)) ||
-            IsSubtractionSolid(bs->GetConstituentSolid(1)))
+        if (IsSubtractionSolid(bs->GetConstituentSolid(0)) || IsSubtractionSolid(bs->GetConstituentSolid(1)))
             return true;
     }
     return false;
@@ -131,8 +130,14 @@ struct GenstepBuffer
         genstep_count++;
     }
 
-    bool empty() const { return gensteps.empty(); }
-    size_t size() const { return gensteps.size(); }
+    bool empty() const
+    {
+        return gensteps.empty();
+    }
+    size_t size() const
+    {
+        return gensteps.size();
+    }
 };
 
 struct GPUTask
@@ -140,8 +145,12 @@ struct GPUTask
     int batch_id;
     std::shared_ptr<GenstepBuffer> buffer;
 
-    GPUTask() : batch_id(-1), buffer(nullptr) {}
-    GPUTask(int bid, std::shared_ptr<GenstepBuffer> buf) : batch_id(bid), buffer(std::move(buf)) {}
+    GPUTask() : batch_id(-1), buffer(nullptr)
+    {
+    }
+    GPUTask(int bid, std::shared_ptr<GenstepBuffer> buf) : batch_id(bid), buffer(std::move(buf))
+    {
+    }
 };
 
 // ============================================================================
@@ -183,11 +192,8 @@ class GPUTaskManager
     std::atomic<uint64_t> total_gpu_time_us_{0};
 
   public:
-    GPUTaskManager(int64_t threshold = DEFAULT_PHOTON_THRESHOLD,
-                   size_t max_queue = DEFAULT_MAX_QUEUE_SIZE)
-        : photon_threshold_(threshold),
-          max_queue_size_(max_queue),
-          active_buffer_(std::make_shared<GenstepBuffer>())
+    GPUTaskManager(int64_t threshold = DEFAULT_PHOTON_THRESHOLD, size_t max_queue = DEFAULT_MAX_QUEUE_SIZE)
+        : photon_threshold_(threshold), max_queue_size_(max_queue), active_buffer_(std::make_shared<GenstepBuffer>())
     {
         if (const char *e = std::getenv("GPU_PHOTON_FLUSH_THRESHOLD"))
             photon_threshold_ = std::atoll(e);
@@ -195,7 +201,10 @@ class GPUTaskManager
             max_queue_size_ = std::max(1, std::atoi(e));
     }
 
-    ~GPUTaskManager() { shutdown(); }
+    ~GPUTaskManager()
+    {
+        shutdown();
+    }
 
     void start()
     {
@@ -205,8 +214,7 @@ class GPUTaskManager
         worker_ = std::thread(&GPUTaskManager::workerLoop, this);
 
         G4cout << "GPUTaskManager [std]: started"
-               << " threshold=" << photon_threshold_
-               << " max_queue=" << max_queue_size_ << G4endl;
+               << " threshold=" << photon_threshold_ << " max_queue=" << max_queue_size_ << G4endl;
     }
 
     void shutdown()
@@ -238,10 +246,8 @@ class GPUTaskManager
             worker_.join();
 
         G4cout << "GPUTaskManager [std]: shutdown"
-               << " batches=" << completed_batches_.load()
-               << " photons=" << total_photons_.load()
-               << " hits=" << total_hits_.load()
-               << " gpu_time=" << (total_gpu_time_us_.load() / 1e6) << "s" << G4endl;
+               << " batches=" << completed_batches_.load() << " photons=" << total_photons_.load()
+               << " hits=" << total_hits_.load() << " gpu_time=" << (total_gpu_time_us_.load() / 1e6) << "s" << G4endl;
     }
 
     // Hot path — invoked from SteppingAction
@@ -277,8 +283,7 @@ class GPUTaskManager
         }
         if (to_submit)
         {
-            G4cout << "GPUTaskManager [std]: final flush ("
-                   << to_submit->photon_count << " photons)" << G4endl;
+            G4cout << "GPUTaskManager [std]: final flush (" << to_submit->photon_count << " photons)" << G4endl;
             submitBuffer(to_submit);
         }
         waitForDrain();
@@ -290,11 +295,26 @@ class GPUTaskManager
         queue_drained_.wait(lock, [this]() { return task_queue_.empty(); });
     }
 
-    int getCompletedBatches() const { return completed_batches_.load(); }
-    uint64_t getTotalHits() const { return total_hits_.load(); }
-    uint64_t getTotalPhotons() const { return total_photons_.load(); }
-    int64_t getThreshold() const { return photon_threshold_; }
-    double getTotalGPUTime() const { return total_gpu_time_us_.load() / 1e6; }
+    int getCompletedBatches() const
+    {
+        return completed_batches_.load();
+    }
+    uint64_t getTotalHits() const
+    {
+        return total_hits_.load();
+    }
+    uint64_t getTotalPhotons() const
+    {
+        return total_photons_.load();
+    }
+    int64_t getThreshold() const
+    {
+        return photon_threshold_;
+    }
+    double getTotalGPUTime() const
+    {
+        return total_gpu_time_us_.load() / 1e6;
+    }
 
   private:
     void submitBuffer(std::shared_ptr<GenstepBuffer> buffer)
@@ -307,15 +327,12 @@ class GPUTaskManager
 
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
-            queue_not_full_.wait(lock, [this]() {
-                return task_queue_.size() < max_queue_size_ || shutdown_;
-            });
+            queue_not_full_.wait(lock, [this]() { return task_queue_.size() < max_queue_size_ || shutdown_; });
             if (shutdown_)
                 return;
 
             task_queue_.push(std::move(task));
-            G4cout << "GPUTaskManager [std]: queued batch " << batch_id
-                   << " (" << buffer->photon_count << " photons, "
+            G4cout << "GPUTaskManager [std]: queued batch " << batch_id << " (" << buffer->photon_count << " photons, "
                    << buffer->genstep_count << " gensteps)"
                    << " queue_size=" << task_queue_.size() << G4endl;
         }
@@ -324,17 +341,14 @@ class GPUTaskManager
 
     void workerLoop()
     {
-        G4cout << "GPUTaskManager [std]: worker thread started (tid="
-               << std::this_thread::get_id() << ")" << G4endl;
+        G4cout << "GPUTaskManager [std]: worker thread started (tid=" << std::this_thread::get_id() << ")" << G4endl;
 
         while (true)
         {
             GPUTask task;
             {
                 std::unique_lock<std::mutex> lock(queue_mutex_);
-                queue_not_empty_.wait(lock, [this]() {
-                    return !task_queue_.empty() || shutdown_;
-                });
+                queue_not_empty_.wait(lock, [this]() { return !task_queue_.empty() || shutdown_; });
                 if (task_queue_.empty() && shutdown_)
                     break;
 
@@ -358,8 +372,7 @@ class GPUTaskManager
     void runBatch(int batch_id, std::shared_ptr<GenstepBuffer> buffer)
     {
         G4cout << "=== GPU Batch " << batch_id << " ==="
-               << " photons=" << buffer->photon_count
-               << " gensteps=" << buffer->genstep_count << G4endl;
+               << " photons=" << buffer->photon_count << " gensteps=" << buffer->genstep_count << G4endl;
 
         G4CXOpticks *gx = G4CXOpticks::Get();
         SEvt *sev = SEvt::Get_EGPU();
@@ -371,8 +384,7 @@ class GPUTaskManager
 
         sev->clear_genstep();
         NP *gs_array = NP::Make<float>(buffer->gensteps.size(), 6, 4);
-        std::memcpy(gs_array->values<float>(), buffer->gensteps.data(),
-                    buffer->gensteps.size() * sizeof(quad6));
+        std::memcpy(gs_array->values<float>(), buffer->gensteps.data(), buffer->gensteps.size() * sizeof(quad6));
         sev->addGenstep(gs_array);
 
         auto t0 = std::chrono::high_resolution_clock::now();
@@ -416,9 +428,8 @@ class GPUTaskManager
 // Genstep construction (bypass U4 / SEvt for async path)
 // ============================================================================
 
-static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons,
-                                  G4double betaInverse, G4double pmin, G4double pmax,
-                                  G4double maxCos, G4double maxSin2,
+static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons, G4double betaInverse,
+                                  G4double pmin, G4double pmax, G4double maxCos, G4double maxSin2,
                                   G4double meanNumberOfPhotons1, G4double meanNumberOfPhotons2)
 {
     G4StepPoint *pre = aStep->GetPreStepPoint();
@@ -468,8 +479,8 @@ static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4
     return gs;
 }
 
-static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons,
-                                       G4int scnt, G4double ScintillationTime)
+static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons, G4int scnt,
+                                       G4double ScintillationTime)
 {
     G4StepPoint *pre = aStep->GetPreStepPoint();
     G4StepPoint *post = aStep->GetPostStepPoint();
@@ -516,10 +527,9 @@ static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aSte
 struct PhotonHit : public G4VHit
 {
     PhotonHit() = default;
-    PhotonHit(unsigned id, G4double energy, G4double time, G4ThreeVector position,
-              G4ThreeVector direction, G4ThreeVector polarization)
-        : fid(id), fenergy(energy), ftime(time), fposition(position), fdirection(direction),
-          fpolarization(polarization)
+    PhotonHit(unsigned id, G4double energy, G4double time, G4ThreeVector position, G4ThreeVector direction,
+              G4ThreeVector polarization)
+        : fid(id), fenergy(energy), ftime(time), fposition(position), fdirection(direction), fpolarization(polarization)
     {
     }
 
@@ -559,8 +569,7 @@ struct PhotonSD : public G4VSensitiveDetector
             return false;
 
         G4double energy_eV = track->GetTotalEnergy() / CLHEP::eV;
-        PhotonHit *hit = new PhotonHit(0, energy_eV, track->GetGlobalTime(),
-                                       aStep->GetPostStepPoint()->GetPosition(),
+        PhotonHit *hit = new PhotonHit(0, energy_eV, track->GetGlobalTime(), aStep->GetPostStepPoint()->GetPosition(),
                                        aStep->GetPostStepPoint()->GetMomentumDirection(),
                                        aStep->GetPostStepPoint()->GetPolarization());
         fPhotonHitsCollection->insert(hit);
@@ -579,18 +588,19 @@ struct PhotonSD : public G4VSensitiveDetector
         {
             PhotonHit *h = (*fPhotonHitsCollection)[i];
             float wl = (h->fenergy > 0) ? static_cast<float>(1239.84198 / h->fenergy) : 0.f;
-            g4_accumulated_hits.push_back({float(h->fposition.x()), float(h->fposition.y()),
-                                           float(h->fposition.z()), float(h->ftime),
-                                           float(h->fdirection.x()), float(h->fdirection.y()),
-                                           float(h->fdirection.z()), 0.f,
-                                           float(h->fpolarization.x()), float(h->fpolarization.y()),
-                                           float(h->fpolarization.z()), wl,
-                                           0.f, 0.f, 0.f, float(h->fid)});
+            g4_accumulated_hits.push_back({float(h->fposition.x()), float(h->fposition.y()), float(h->fposition.z()),
+                                           float(h->ftime), float(h->fdirection.x()), float(h->fdirection.y()),
+                                           float(h->fdirection.z()), 0.f, float(h->fpolarization.x()),
+                                           float(h->fpolarization.y()), float(h->fpolarization.z()), wl, 0.f, 0.f, 0.f,
+                                           float(h->fid)});
         }
         fTotalG4Hits += n;
     }
 
-    G4int GetTotalG4Hits() const { return fTotalG4Hits; }
+    G4int GetTotalG4Hits() const
+    {
+        return fTotalG4Hits;
+    }
 };
 
 // ============================================================================
@@ -602,7 +612,9 @@ struct DetectorConstruction : G4VUserDetectorConstruction
     std::filesystem::path gdml_file_;
     G4GDMLParser parser_;
 
-    DetectorConstruction(std::filesystem::path gdml_file) : gdml_file_(gdml_file) {}
+    DetectorConstruction(std::filesystem::path gdml_file) : gdml_file_(gdml_file)
+    {
+    }
 
     G4VPhysicalVolume *Construct() override
     {
@@ -617,10 +629,8 @@ struct DetectorConstruction : G4VUserDetectorConstruction
             for (auto lv : *lvStore)
             {
                 G4String lname = str_tolower(lv->GetName());
-                if (lname.find("detect") != std::string::npos ||
-                    lname.find("sipm") != std::string::npos ||
-                    lname.find("sensor") != std::string::npos ||
-                    lname.find("pmt") != std::string::npos ||
+                if (lname.find("detect") != std::string::npos || lname.find("sipm") != std::string::npos ||
+                    lname.find("sensor") != std::string::npos || lname.find("pmt") != std::string::npos ||
                     lname.find("arapuca") != std::string::npos)
                 {
                     G4String sdName = "PhotonDetector_" + lv->GetName();
@@ -647,7 +657,9 @@ struct DetectorConstruction : G4VUserDetectorConstruction
 struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 {
     SEvt *sev;
-    PrimaryGenerator(SEvt *sev) : sev(sev) {}
+    PrimaryGenerator(SEvt *sev) : sev(sev)
+    {
+    }
 
     void GeneratePrimaries(G4Event *event) override
     {
@@ -674,7 +686,9 @@ struct EventAction : G4UserEventAction
     SEvt *sev;
     G4int fTotalG4Hits{0};
 
-    EventAction(SEvt *sev) : sev(sev) {}
+    EventAction(SEvt *sev) : sev(sev)
+    {
+    }
 
     void EndOfEventAction(const G4Event *event) override
     {
@@ -694,7 +708,10 @@ struct EventAction : G4UserEventAction
         }
     }
 
-    G4int GetTotalG4Hits() const { return fTotalG4Hits; }
+    G4int GetTotalG4Hits() const
+    {
+        return fTotalG4Hits;
+    }
 };
 
 // ============================================================================
@@ -706,7 +723,9 @@ struct RunAction : G4UserRunAction
     EventAction *fEventAction;
     GPUTaskManager *fGPUTaskMgr{nullptr};
 
-    RunAction(EventAction *ea, GPUTaskManager *mgr = nullptr) : fEventAction(ea), fGPUTaskMgr(mgr) {}
+    RunAction(EventAction *ea, GPUTaskManager *mgr = nullptr) : fEventAction(ea), fGPUTaskMgr(mgr)
+    {
+    }
 
     void BeginOfRunAction(const G4Run *) override
     {
@@ -784,7 +803,9 @@ struct SteppingAction : G4UserSteppingAction
     SEvt *sev;
     GPUTaskManager *fGPUTaskMgr{nullptr};
 
-    SteppingAction(SEvt *sev, GPUTaskManager *mgr = nullptr) : sev(sev), fGPUTaskMgr(mgr) {}
+    SteppingAction(SEvt *sev, GPUTaskManager *mgr = nullptr) : sev(sev), fGPUTaskMgr(mgr)
+    {
+    }
 
     void UserSteppingAction(const G4Step *aStep) override
     {
@@ -793,8 +814,7 @@ struct SteppingAction : G4UserSteppingAction
             aStep->GetTrack()->GetCurrentStepNumber() > 10000)
             aStep->GetTrack()->SetTrackStatus(fStopAndKill);
 
-        G4SteppingManager *sm =
-            G4EventManager::GetEventManager()->GetTrackingManager()->GetSteppingManager();
+        G4SteppingManager *sm = G4EventManager::GetEventManager()->GetTrackingManager()->GetSteppingManager();
         if (sm->GetfStepStatus() == fAtRestDoItProc)
             return;
 
@@ -838,15 +858,15 @@ struct SteppingAction : G4UserSteppingAction
                     const G4Event *ev = G4EventManager::GetEventManager()->GetConstCurrentEvent();
                     if (!ev)
                         return;
-                    quad6 gs = MakeGenstep_Cerenkov(track, aStep, numPhotons, BetaInverse,
-                                                   Pmin, Pmax, maxCos, maxSin2, mean1, mean2);
+                    quad6 gs = MakeGenstep_Cerenkov(track, aStep, numPhotons, BetaInverse, Pmin, Pmax, maxCos, maxSin2,
+                                                    mean1, mean2);
                     fGPUTaskMgr->addGenstep(gs, numPhotons, ev->GetEventID());
                 }
                 else
                 {
                     G4AutoLock lock(&genstep_mutex);
-                    U4::CollectGenstep_G4Cerenkov_modified(track, aStep, numPhotons, BetaInverse,
-                                                           Pmin, Pmax, maxCos, maxSin2, mean1, mean2);
+                    U4::CollectGenstep_G4Cerenkov_modified(track, aStep, numPhotons, BetaInverse, Pmin, Pmax, maxCos,
+                                                           maxSin2, mean1, mean2);
                 }
             }
             else if (pname == "Scintillation")
@@ -864,8 +884,7 @@ struct SteppingAction : G4UserSteppingAction
 
                 const G4int tcKeys[3] = {kSCINTILLATIONTIMECONSTANT1, kSCINTILLATIONTIMECONSTANT2,
                                          kSCINTILLATIONTIMECONSTANT3};
-                const G4int yieldKeys[3] = {kSCINTILLATIONYIELD1, kSCINTILLATIONYIELD2,
-                                            kSCINTILLATIONYIELD3};
+                const G4int yieldKeys[3] = {kSCINTILLATIONYIELD1, kSCINTILLATIONYIELD2, kSCINTILLATIONYIELD3};
 
                 G4double tc[3] = {0, 0, 0};
                 G4double yield[3] = {0, 0, 0};
@@ -876,9 +895,8 @@ struct SteppingAction : G4UserSteppingAction
                     if (MPT->ConstPropertyExists(tcKeys[c]))
                     {
                         tc[c] = MPT->GetConstProperty(tcKeys[c]);
-                        yield[c] = MPT->ConstPropertyExists(yieldKeys[c])
-                                       ? MPT->GetConstProperty(yieldKeys[c])
-                                       : (c == 0 ? 1.0 : 0.0);
+                        yield[c] = MPT->ConstPropertyExists(yieldKeys[c]) ? MPT->GetConstProperty(yieldKeys[c])
+                                                                          : (c == 0 ? 1.0 : 0.0);
                         yieldSum += yield[c];
                         nComp = c + 1;
                     }
@@ -893,9 +911,7 @@ struct SteppingAction : G4UserSteppingAction
                     G4int remaining = numPhotons;
                     for (G4int c = 0; c < nComp; c++)
                     {
-                        G4int n = (c == nComp - 1)
-                                      ? remaining
-                                      : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        G4int n = (c == nComp - 1) ? remaining : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
                         remaining -= n;
                         if (n > 0)
                         {
@@ -910,9 +926,7 @@ struct SteppingAction : G4UserSteppingAction
                     G4int remaining = numPhotons;
                     for (G4int c = 0; c < nComp; c++)
                     {
-                        G4int n = (c == nComp - 1)
-                                      ? remaining
-                                      : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        G4int n = (c == nComp - 1) ? remaining : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
                         remaining -= n;
                         if (n > 0)
                             U4::CollectGenstep_DsG4Scintillation_r4695(track, aStep, n, c + 1, tc[c]);
@@ -930,11 +944,17 @@ struct SteppingAction : G4UserSteppingAction
 struct TrackingAction : G4UserTrackingAction
 {
     SEvt *sev;
-    TrackingAction(SEvt *sev) : sev(sev) {}
+    TrackingAction(SEvt *sev) : sev(sev)
+    {
+    }
 
-    void PreUserTrackingAction(const G4Track *) override {}
+    void PreUserTrackingAction(const G4Track *) override
+    {
+    }
 
-    void PostUserTrackingAction(const G4Track *) override {}
+    void PostUserTrackingAction(const G4Track *) override
+    {
+    }
 };
 
 // ============================================================================
@@ -954,21 +974,20 @@ struct G4App
     TrackingAction *tracking_;
 
     G4App(std::filesystem::path gdml_file, bool enable_async = true)
-        : sev(SEvt::CreateOrReuse_EGPU()),
-          gpu_task_mgr_(enable_async ? new GPUTaskManager() : nullptr),
-          det_cons_(new DetectorConstruction(gdml_file)),
-          prim_gen_(new PrimaryGenerator(sev)),
-          event_act_(new EventAction(sev)),
-          run_act_(new RunAction(event_act_, gpu_task_mgr_)),
-          stepping_(new SteppingAction(sev, gpu_task_mgr_)),
-          tracking_(new TrackingAction(sev))
+        : sev(SEvt::CreateOrReuse_EGPU()), gpu_task_mgr_(enable_async ? new GPUTaskManager() : nullptr),
+          det_cons_(new DetectorConstruction(gdml_file)), prim_gen_(new PrimaryGenerator(sev)),
+          event_act_(new EventAction(sev)), run_act_(new RunAction(event_act_, gpu_task_mgr_)),
+          stepping_(new SteppingAction(sev, gpu_task_mgr_)), tracking_(new TrackingAction(sev))
     {
         if (gpu_task_mgr_)
-            G4cout << "G4App [std]: async GPU mode (threshold="
-                   << gpu_task_mgr_->getThreshold() << " photons)" << G4endl;
+            G4cout << "G4App [std]: async GPU mode (threshold=" << gpu_task_mgr_->getThreshold() << " photons)"
+                   << G4endl;
         else
             G4cout << "G4App [std]: sync GPU mode (end-of-run)" << G4endl;
     }
 
-    ~G4App() { delete gpu_task_mgr_; }
+    ~G4App()
+    {
+        delete gpu_task_mgr_;
+    }
 };

--- a/examples/async_gpu_std/async_gpu_std.h
+++ b/examples/async_gpu_std/async_gpu_std.h
@@ -75,8 +75,8 @@
 
 namespace
 {
-G4Mutex genstep_mutex = G4MUTEX_INITIALIZER; // sync-mode SEvt collection
-std::mutex g4hits_mutex;                     // accumulator across worker threads
+G4Mutex                            genstep_mutex = G4MUTEX_INITIALIZER; // sync-mode SEvt collection
+std::mutex                         g4hits_mutex;                        // accumulator across worker threads
 std::vector<std::array<float, 16>> g4_accumulated_hits;
 } // namespace
 
@@ -84,15 +84,16 @@ std::vector<std::array<float, 16>> g4_accumulated_hits;
 // Geometry helpers
 // ============================================================================
 
-bool IsSubtractionSolid(G4VSolid *solid)
+bool IsSubtractionSolid(G4VSolid* solid)
 {
     if (!solid)
         return false;
-    if (dynamic_cast<G4SubtractionSolid *>(solid))
+    if (dynamic_cast<G4SubtractionSolid*>(solid))
         return true;
-    if (G4BooleanSolid *bs = dynamic_cast<G4BooleanSolid *>(solid))
+    if (G4BooleanSolid* bs = dynamic_cast<G4BooleanSolid*>(solid))
     {
-        if (IsSubtractionSolid(bs->GetConstituentSolid(0)) || IsSubtractionSolid(bs->GetConstituentSolid(1)))
+        if (IsSubtractionSolid(bs->GetConstituentSolid(0)) ||
+            IsSubtractionSolid(bs->GetConstituentSolid(1)))
             return true;
     }
     return false;
@@ -100,7 +101,8 @@ bool IsSubtractionSolid(G4VSolid *solid)
 
 std::string str_tolower(std::string s)
 {
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
@@ -111,12 +113,12 @@ std::string str_tolower(std::string s)
 struct GenstepBuffer
 {
     std::vector<quad6> gensteps;
-    std::vector<sgs> labels;
-    int64_t photon_count = 0;
-    int64_t genstep_count = 0;
-    int event_id = 0;
+    std::vector<sgs>   labels;
+    int64_t            photon_count = 0;
+    int64_t            genstep_count = 0;
+    int                event_id = 0;
 
-    void addGenstep(const quad6 &gs, int64_t numphotons)
+    void addGenstep(const quad6& gs, int64_t numphotons)
     {
         sgs label;
         label.index = gensteps.size();
@@ -142,13 +144,17 @@ struct GenstepBuffer
 
 struct GPUTask
 {
-    int batch_id;
+    int                            batch_id;
     std::shared_ptr<GenstepBuffer> buffer;
 
-    GPUTask() : batch_id(-1), buffer(nullptr)
+    GPUTask() :
+        batch_id(-1),
+        buffer(nullptr)
     {
     }
-    GPUTask(int bid, std::shared_ptr<GenstepBuffer> buf) : batch_id(bid), buffer(std::move(buf))
+    GPUTask(int bid, std::shared_ptr<GenstepBuffer> buf) :
+        batch_id(bid),
+        buffer(std::move(buf))
     {
     }
 };
@@ -166,38 +172,41 @@ class GPUTaskManager
 {
   public:
     static constexpr int64_t DEFAULT_PHOTON_THRESHOLD = 10000000; // 10M photons
-    static constexpr size_t DEFAULT_MAX_QUEUE_SIZE = 3;
+    static constexpr size_t  DEFAULT_MAX_QUEUE_SIZE = 3;
 
   private:
     int64_t photon_threshold_;
-    size_t max_queue_size_;
+    size_t  max_queue_size_;
 
     std::shared_ptr<GenstepBuffer> active_buffer_;
-    std::mutex buffer_mutex_;
+    std::mutex                     buffer_mutex_;
 
-    std::queue<GPUTask> task_queue_;
-    std::mutex queue_mutex_;
+    std::queue<GPUTask>     task_queue_;
+    std::mutex              queue_mutex_;
     std::condition_variable queue_not_full_;
     std::condition_variable queue_not_empty_;
     std::condition_variable queue_drained_;
 
-    std::thread worker_;
+    std::thread       worker_;
     std::atomic<bool> shutdown_{false};
     std::atomic<bool> running_{false};
 
-    std::atomic<int> batch_counter_{0};
-    std::atomic<int> completed_batches_{0};
+    std::atomic<int>      batch_counter_{0};
+    std::atomic<int>      completed_batches_{0};
     std::atomic<uint64_t> total_hits_{0};
     std::atomic<uint64_t> total_photons_{0};
     std::atomic<uint64_t> total_gpu_time_us_{0};
 
   public:
-    GPUTaskManager(int64_t threshold = DEFAULT_PHOTON_THRESHOLD, size_t max_queue = DEFAULT_MAX_QUEUE_SIZE)
-        : photon_threshold_(threshold), max_queue_size_(max_queue), active_buffer_(std::make_shared<GenstepBuffer>())
+    GPUTaskManager(int64_t threshold = DEFAULT_PHOTON_THRESHOLD,
+                   size_t  max_queue = DEFAULT_MAX_QUEUE_SIZE) :
+        photon_threshold_(threshold),
+        max_queue_size_(max_queue),
+        active_buffer_(std::make_shared<GenstepBuffer>())
     {
-        if (const char *e = std::getenv("GPU_PHOTON_FLUSH_THRESHOLD"))
+        if (const char* e = std::getenv("GPU_PHOTON_FLUSH_THRESHOLD"))
             photon_threshold_ = std::atoll(e);
-        if (const char *e = std::getenv("GPU_MAX_QUEUE_SIZE"))
+        if (const char* e = std::getenv("GPU_MAX_QUEUE_SIZE"))
             max_queue_size_ = std::max(1, std::atoi(e));
     }
 
@@ -214,7 +223,8 @@ class GPUTaskManager
         worker_ = std::thread(&GPUTaskManager::workerLoop, this);
 
         G4cout << "GPUTaskManager [std]: started"
-               << " threshold=" << photon_threshold_ << " max_queue=" << max_queue_size_ << G4endl;
+               << " threshold=" << photon_threshold_
+               << " max_queue=" << max_queue_size_ << G4endl;
     }
 
     void shutdown()
@@ -246,12 +256,15 @@ class GPUTaskManager
             worker_.join();
 
         G4cout << "GPUTaskManager [std]: shutdown"
-               << " batches=" << completed_batches_.load() << " photons=" << total_photons_.load()
-               << " hits=" << total_hits_.load() << " gpu_time=" << (total_gpu_time_us_.load() / 1e6) << "s" << G4endl;
+               << " batches=" << completed_batches_.load()
+               << " photons=" << total_photons_.load()
+               << " hits=" << total_hits_.load()
+               << " gpu_time=" << (total_gpu_time_us_.load() / 1e6) << "s"
+               << G4endl;
     }
 
     // Hot path — invoked from SteppingAction
-    void addGenstep(const quad6 &gs, int64_t numphotons, int eventID)
+    void addGenstep(const quad6& gs, int64_t numphotons, int eventID)
     {
         std::shared_ptr<GenstepBuffer> to_submit;
         {
@@ -283,7 +296,8 @@ class GPUTaskManager
         }
         if (to_submit)
         {
-            G4cout << "GPUTaskManager [std]: final flush (" << to_submit->photon_count << " photons)" << G4endl;
+            G4cout << "GPUTaskManager [std]: final flush (" << to_submit->photon_count
+                   << " photons)" << G4endl;
             submitBuffer(to_submit);
         }
         waitForDrain();
@@ -322,18 +336,21 @@ class GPUTaskManager
         if (!buffer || buffer->empty())
             return;
 
-        int batch_id = batch_counter_.fetch_add(1);
+        int     batch_id = batch_counter_.fetch_add(1);
         GPUTask task(batch_id, buffer);
 
         {
             std::unique_lock<std::mutex> lock(queue_mutex_);
-            queue_not_full_.wait(lock, [this]() { return task_queue_.size() < max_queue_size_ || shutdown_; });
+            queue_not_full_.wait(lock, [this]() {
+                return task_queue_.size() < max_queue_size_ || shutdown_;
+            });
             if (shutdown_)
                 return;
 
             task_queue_.push(std::move(task));
-            G4cout << "GPUTaskManager [std]: queued batch " << batch_id << " (" << buffer->photon_count << " photons, "
-                   << buffer->genstep_count << " gensteps)"
+            G4cout << "GPUTaskManager [std]: queued batch " << batch_id << " ("
+                   << buffer->photon_count << " photons, " << buffer->genstep_count
+                   << " gensteps)"
                    << " queue_size=" << task_queue_.size() << G4endl;
         }
         queue_not_empty_.notify_one();
@@ -341,14 +358,16 @@ class GPUTaskManager
 
     void workerLoop()
     {
-        G4cout << "GPUTaskManager [std]: worker thread started (tid=" << std::this_thread::get_id() << ")" << G4endl;
+        G4cout << "GPUTaskManager [std]: worker thread started (tid="
+               << std::this_thread::get_id() << ")" << G4endl;
 
         while (true)
         {
             GPUTask task;
             {
                 std::unique_lock<std::mutex> lock(queue_mutex_);
-                queue_not_empty_.wait(lock, [this]() { return !task_queue_.empty() || shutdown_; });
+                queue_not_empty_.wait(
+                    lock, [this]() { return !task_queue_.empty() || shutdown_; });
                 if (task_queue_.empty() && shutdown_)
                     break;
 
@@ -372,26 +391,30 @@ class GPUTaskManager
     void runBatch(int batch_id, std::shared_ptr<GenstepBuffer> buffer)
     {
         G4cout << "=== GPU Batch " << batch_id << " ==="
-               << " photons=" << buffer->photon_count << " gensteps=" << buffer->genstep_count << G4endl;
+               << " photons=" << buffer->photon_count
+               << " gensteps=" << buffer->genstep_count << G4endl;
 
-        G4CXOpticks *gx = G4CXOpticks::Get();
-        SEvt *sev = SEvt::Get_EGPU();
+        G4CXOpticks* gx = G4CXOpticks::Get();
+        SEvt*        sev = SEvt::Get_EGPU();
         if (!gx || !sev)
         {
-            G4cerr << "GPUTaskManager [std]: G4CXOpticks/SEvt not available" << G4endl;
+            G4cerr << "GPUTaskManager [std]: G4CXOpticks/SEvt not available"
+                   << G4endl;
             return;
         }
 
         sev->clear_genstep();
-        NP *gs_array = NP::Make<float>(buffer->gensteps.size(), 6, 4);
-        std::memcpy(gs_array->values<float>(), buffer->gensteps.data(), buffer->gensteps.size() * sizeof(quad6));
+        NP* gs_array = NP::Make<float>(buffer->gensteps.size(), 6, 4);
+        std::memcpy(gs_array->values<float>(), buffer->gensteps.data(),
+                    buffer->gensteps.size() * sizeof(quad6));
         sev->addGenstep(gs_array);
 
         auto t0 = std::chrono::high_resolution_clock::now();
         gx->simulate(buffer->event_id, false);
         cudaDeviceSynchronize();
         auto t1 = std::chrono::high_resolution_clock::now();
-        auto us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+        auto us =
+            std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
 
         unsigned num_hits = sev->GetNumHit(0);
         total_gpu_time_us_ += us;
@@ -407,12 +430,12 @@ class GPUTaskManager
         G4cout << "=== GPU Batch " << batch_id << " complete ===" << G4endl;
     }
 
-    void saveHits(int batch_id, SEvt *sev, unsigned num_hits)
+    void saveHits(int batch_id, SEvt* sev, unsigned num_hits)
     {
         std::ostringstream fname;
         fname << "gpu_hits_batch_" << batch_id << ".npy";
 
-        NP *arr = NP::Make<float>(num_hits, 4, 4);
+        NP* arr = NP::Make<float>(num_hits, 4, 4);
         for (unsigned idx = 0; idx < num_hits; idx++)
         {
             sphoton hit;
@@ -428,24 +451,27 @@ class GPUTaskManager
 // Genstep construction (bypass U4 / SEvt for async path)
 // ============================================================================
 
-static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons, G4double betaInverse,
-                                  G4double pmin, G4double pmax, G4double maxCos, G4double maxSin2,
-                                  G4double meanNumberOfPhotons1, G4double meanNumberOfPhotons2)
+static quad6 MakeGenstep_Cerenkov(const G4Track* aTrack, const G4Step* aStep,
+                                  G4int numPhotons, G4double betaInverse,
+                                  G4double pmin, G4double pmax, G4double maxCos,
+                                  G4double maxSin2,
+                                  G4double meanNumberOfPhotons1,
+                                  G4double meanNumberOfPhotons2)
 {
-    G4StepPoint *pre = aStep->GetPreStepPoint();
-    G4StepPoint *post = aStep->GetPostStepPoint();
-    G4ThreeVector x0 = pre->GetPosition();
-    G4double t0 = pre->GetGlobalTime();
-    G4ThreeVector dx = aStep->GetDeltaPosition();
-    const G4DynamicParticle *dp = aTrack->GetDynamicParticle();
-    const G4Material *mat = aTrack->GetMaterial();
+    G4StepPoint*             pre = aStep->GetPreStepPoint();
+    G4StepPoint*             post = aStep->GetPostStepPoint();
+    G4ThreeVector            x0 = pre->GetPosition();
+    G4double                 t0 = pre->GetGlobalTime();
+    G4ThreeVector            dx = aStep->GetDeltaPosition();
+    const G4DynamicParticle* dp = aTrack->GetDynamicParticle();
+    const G4Material*        mat = aTrack->GetMaterial();
 
     G4double Wmin_nm = h_Planck * c_light / pmax / nm;
     G4double Wmax_nm = h_Planck * c_light / pmin / nm;
 
     quad6 gs;
     gs.zero();
-    scerenkov *ck = (scerenkov *)(&gs);
+    scerenkov* ck = (scerenkov*)(&gs);
 
     ck->gentype = OpticksGenstep_G4Cerenkov_modified;
     ck->trackid = aTrack->GetTrackID();
@@ -479,21 +505,22 @@ static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4
     return gs;
 }
 
-static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons, G4int scnt,
-                                       G4double ScintillationTime)
+static quad6 MakeGenstep_Scintillation(const G4Track* aTrack,
+                                       const G4Step* aStep, G4int numPhotons,
+                                       G4int scnt, G4double ScintillationTime)
 {
-    G4StepPoint *pre = aStep->GetPreStepPoint();
-    G4StepPoint *post = aStep->GetPostStepPoint();
-    G4ThreeVector x0 = pre->GetPosition();
-    G4double t0 = pre->GetGlobalTime();
-    G4ThreeVector dx = aStep->GetDeltaPosition();
-    G4double meanV = (pre->GetVelocity() + post->GetVelocity()) * 0.5;
-    const G4DynamicParticle *dp = aTrack->GetDynamicParticle();
-    const G4Material *mat = aTrack->GetMaterial();
+    G4StepPoint*             pre = aStep->GetPreStepPoint();
+    G4StepPoint*             post = aStep->GetPostStepPoint();
+    G4ThreeVector            x0 = pre->GetPosition();
+    G4double                 t0 = pre->GetGlobalTime();
+    G4ThreeVector            dx = aStep->GetDeltaPosition();
+    G4double                 meanV = (pre->GetVelocity() + post->GetVelocity()) * 0.5;
+    const G4DynamicParticle* dp = aTrack->GetDynamicParticle();
+    const G4Material*        mat = aTrack->GetMaterial();
 
     quad6 gs;
     gs.zero();
-    sscint *sc = (sscint *)(&gs);
+    sscint* sc = (sscint*)(&gs);
 
     sc->gentype = OpticksGenstep_DsG4Scintillation_r4695;
     sc->trackid = aTrack->GetTrackID();
@@ -527,15 +554,20 @@ static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aSte
 struct PhotonHit : public G4VHit
 {
     PhotonHit() = default;
-    PhotonHit(unsigned id, G4double energy, G4double time, G4ThreeVector position, G4ThreeVector direction,
-              G4ThreeVector polarization)
-        : fid(id), fenergy(energy), ftime(time), fposition(position), fdirection(direction), fpolarization(polarization)
+    PhotonHit(unsigned id, G4double energy, G4double time, G4ThreeVector position,
+              G4ThreeVector direction, G4ThreeVector polarization) :
+        fid(id),
+        fenergy(energy),
+        ftime(time),
+        fposition(position),
+        fdirection(direction),
+        fpolarization(polarization)
     {
     }
 
-    unsigned fid{0};
-    G4double fenergy{0};
-    G4double ftime{0};
+    unsigned      fid{0};
+    G4double      fenergy{0};
+    G4double      ftime{0};
     G4ThreeVector fposition;
     G4ThreeVector fdirection;
     G4ThreeVector fpolarization;
@@ -545,39 +577,43 @@ using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
 
 struct PhotonSD : public G4VSensitiveDetector
 {
-    PhotonHitsCollection *fPhotonHitsCollection{nullptr};
-    G4int fHCID{-1};
-    G4int fTotalG4Hits{0};
+    PhotonHitsCollection* fPhotonHitsCollection{nullptr};
+    G4int                 fHCID{-1};
+    G4int                 fTotalG4Hits{0};
 
-    PhotonSD(const G4String &name) : G4VSensitiveDetector(name)
+    PhotonSD(const G4String& name) :
+        G4VSensitiveDetector(name)
     {
         collectionName.insert("photon_hits");
     }
 
-    void Initialize(G4HCofThisEvent *hce) override
+    void Initialize(G4HCofThisEvent* hce) override
     {
-        fPhotonHitsCollection = new PhotonHitsCollection(SensitiveDetectorName, collectionName[0]);
+        fPhotonHitsCollection =
+            new PhotonHitsCollection(SensitiveDetectorName, collectionName[0]);
         if (fHCID < 0)
             fHCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
         hce->AddHitsCollection(fHCID, fPhotonHitsCollection);
     }
 
-    G4bool ProcessHits(G4Step *aStep, G4TouchableHistory *) override
+    G4bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override
     {
-        G4Track *track = aStep->GetTrack();
+        G4Track* track = aStep->GetTrack();
         if (track->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
             return false;
 
-        G4double energy_eV = track->GetTotalEnergy() / CLHEP::eV;
-        PhotonHit *hit = new PhotonHit(0, energy_eV, track->GetGlobalTime(), aStep->GetPostStepPoint()->GetPosition(),
-                                       aStep->GetPostStepPoint()->GetMomentumDirection(),
-                                       aStep->GetPostStepPoint()->GetPolarization());
+        G4double   energy_eV = track->GetTotalEnergy() / CLHEP::eV;
+        PhotonHit* hit =
+            new PhotonHit(0, energy_eV, track->GetGlobalTime(),
+                          aStep->GetPostStepPoint()->GetPosition(),
+                          aStep->GetPostStepPoint()->GetMomentumDirection(),
+                          aStep->GetPostStepPoint()->GetPolarization());
         fPhotonHitsCollection->insert(hit);
         track->SetTrackStatus(fStopAndKill);
         return true;
     }
 
-    void EndOfEvent(G4HCofThisEvent *) override
+    void EndOfEvent(G4HCofThisEvent*) override
     {
         G4int n = fPhotonHitsCollection->entries();
         if (n <= 0)
@@ -586,13 +622,15 @@ struct PhotonSD : public G4VSensitiveDetector
         std::lock_guard<std::mutex> lock(g4hits_mutex);
         for (G4int i = 0; i < n; i++)
         {
-            PhotonHit *h = (*fPhotonHitsCollection)[i];
-            float wl = (h->fenergy > 0) ? static_cast<float>(1239.84198 / h->fenergy) : 0.f;
-            g4_accumulated_hits.push_back({float(h->fposition.x()), float(h->fposition.y()), float(h->fposition.z()),
-                                           float(h->ftime), float(h->fdirection.x()), float(h->fdirection.y()),
-                                           float(h->fdirection.z()), 0.f, float(h->fpolarization.x()),
-                                           float(h->fpolarization.y()), float(h->fpolarization.z()), wl, 0.f, 0.f, 0.f,
-                                           float(h->fid)});
+            PhotonHit* h = (*fPhotonHitsCollection)[i];
+            float      wl =
+                (h->fenergy > 0) ? static_cast<float>(1239.84198 / h->fenergy) : 0.f;
+            g4_accumulated_hits.push_back(
+                {float(h->fposition.x()), float(h->fposition.y()),
+                 float(h->fposition.z()), float(h->ftime), float(h->fdirection.x()),
+                 float(h->fdirection.y()), float(h->fdirection.z()), 0.f,
+                 float(h->fpolarization.x()), float(h->fpolarization.y()),
+                 float(h->fpolarization.z()), wl, 0.f, 0.f, 0.f, float(h->fid)});
         }
         fTotalG4Hits += n;
     }
@@ -610,38 +648,42 @@ struct PhotonSD : public G4VSensitiveDetector
 struct DetectorConstruction : G4VUserDetectorConstruction
 {
     std::filesystem::path gdml_file_;
-    G4GDMLParser parser_;
+    G4GDMLParser          parser_;
 
-    DetectorConstruction(std::filesystem::path gdml_file) : gdml_file_(gdml_file)
+    DetectorConstruction(std::filesystem::path gdml_file) :
+        gdml_file_(gdml_file)
     {
     }
 
-    G4VPhysicalVolume *Construct() override
+    G4VPhysicalVolume* Construct() override
     {
         parser_.Read(gdml_file_.string(), false);
-        G4VPhysicalVolume *world = parser_.GetWorldVolume();
+        G4VPhysicalVolume* world = parser_.GetWorldVolume();
         G4CXOpticks::SetGeometry(world);
 
-        G4LogicalVolumeStore *lvStore = G4LogicalVolumeStore::GetInstance();
+        G4LogicalVolumeStore*  lvStore = G4LogicalVolumeStore::GetInstance();
         static G4VisAttributes invisibleVisAttr(false);
         if (lvStore && !lvStore->empty())
         {
             for (auto lv : *lvStore)
             {
                 G4String lname = str_tolower(lv->GetName());
-                if (lname.find("detect") != std::string::npos || lname.find("sipm") != std::string::npos ||
-                    lname.find("sensor") != std::string::npos || lname.find("pmt") != std::string::npos ||
+                if (lname.find("detect") != std::string::npos ||
+                    lname.find("sipm") != std::string::npos ||
+                    lname.find("sensor") != std::string::npos ||
+                    lname.find("pmt") != std::string::npos ||
                     lname.find("arapuca") != std::string::npos)
                 {
                     G4String sdName = "PhotonDetector_" + lv->GetName();
-                    if (!G4SDManager::GetSDMpointer()->FindSensitiveDetector(sdName, false))
+                    if (!G4SDManager::GetSDMpointer()->FindSensitiveDetector(sdName,
+                                                                             false))
                     {
-                        PhotonSD *sd = new PhotonSD(sdName);
+                        PhotonSD* sd = new PhotonSD(sdName);
                         G4SDManager::GetSDMpointer()->AddNewDetector(sd);
                         lv->SetSensitiveDetector(sd);
                     }
                 }
-                G4VSolid *solid = lv->GetSolid();
+                G4VSolid* solid = lv->GetSolid();
                 if (solid && IsSubtractionSolid(solid))
                     lv->SetVisAttributes(&invisibleVisAttr);
             }
@@ -656,22 +698,23 @@ struct DetectorConstruction : G4VUserDetectorConstruction
 
 struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 {
-    SEvt *sev;
-    PrimaryGenerator(SEvt *sev) : sev(sev)
+    SEvt* sev;
+    PrimaryGenerator(SEvt* sev) :
+        sev(sev)
     {
     }
 
-    void GeneratePrimaries(G4Event *event) override
+    void GeneratePrimaries(G4Event* event) override
     {
         G4ThreeVector pos(0.0 * m, 0.0 * m, 0.0 * m);
-        G4double time_ns = 0;
+        G4double      time_ns = 0;
         G4ThreeVector dir(0, 0.2, 0.8);
 
-        G4PrimaryParticle *p = new G4PrimaryParticle(G4Electron::Definition());
+        G4PrimaryParticle* p = new G4PrimaryParticle(G4Electron::Definition());
         p->SetKineticEnergy(10 * MeV);
         p->SetMomentumDirection(dir);
 
-        G4PrimaryVertex *v = new G4PrimaryVertex(pos, time_ns);
+        G4PrimaryVertex* v = new G4PrimaryVertex(pos, time_ns);
         v->SetPrimary(p);
         event->AddPrimaryVertex(v);
     }
@@ -683,25 +726,26 @@ struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 
 struct EventAction : G4UserEventAction
 {
-    SEvt *sev;
+    SEvt* sev;
     G4int fTotalG4Hits{0};
 
-    EventAction(SEvt *sev) : sev(sev)
+    EventAction(SEvt* sev) :
+        sev(sev)
     {
     }
 
-    void EndOfEventAction(const G4Event *event) override
+    void EndOfEventAction(const G4Event* event) override
     {
-        G4HCofThisEvent *hce = event->GetHCofThisEvent();
+        G4HCofThisEvent* hce = event->GetHCofThisEvent();
         if (!hce)
             return;
         G4int n = hce->GetNumberOfCollections();
         for (G4int i = 0; i < n; i++)
         {
-            G4VHitsCollection *hc = hce->GetHC(i);
+            G4VHitsCollection* hc = hce->GetHC(i);
             if (!hc)
                 continue;
-            if (auto *phc = dynamic_cast<PhotonHitsCollection *>(hc))
+            if (auto* phc = dynamic_cast<PhotonHitsCollection*>(hc))
                 fTotalG4Hits += phc->entries();
             else
                 fTotalG4Hits += hc->GetSize();
@@ -720,20 +764,22 @@ struct EventAction : G4UserEventAction
 
 struct RunAction : G4UserRunAction
 {
-    EventAction *fEventAction;
-    GPUTaskManager *fGPUTaskMgr{nullptr};
+    EventAction*    fEventAction;
+    GPUTaskManager* fGPUTaskMgr{nullptr};
 
-    RunAction(EventAction *ea, GPUTaskManager *mgr = nullptr) : fEventAction(ea), fGPUTaskMgr(mgr)
+    RunAction(EventAction* ea, GPUTaskManager* mgr = nullptr) :
+        fEventAction(ea),
+        fGPUTaskMgr(mgr)
     {
     }
 
-    void BeginOfRunAction(const G4Run *) override
+    void BeginOfRunAction(const G4Run*) override
     {
         if (G4Threading::IsMasterThread() && fGPUTaskMgr)
             fGPUTaskMgr->start();
     }
 
-    void EndOfRunAction(const G4Run *) override
+    void EndOfRunAction(const G4Run*) override
     {
         if (!G4Threading::IsMasterThread())
             return;
@@ -743,39 +789,47 @@ struct RunAction : G4UserRunAction
             fGPUTaskMgr->flushRemaining(0);
 
             G4cout << "\n=== Async GPU Summary (std) ===" << G4endl;
-            G4cout << "Batches processed: " << fGPUTaskMgr->getCompletedBatches() << G4endl;
-            G4cout << "Total GPU photons: " << fGPUTaskMgr->getTotalPhotons() << G4endl;
+            G4cout << "Batches processed: " << fGPUTaskMgr->getCompletedBatches()
+                   << G4endl;
+            G4cout << "Total GPU photons: " << fGPUTaskMgr->getTotalPhotons()
+                   << G4endl;
             G4cout << "Total GPU hits:    " << fGPUTaskMgr->getTotalHits() << G4endl;
-            G4cout << "Total GPU time:    " << fGPUTaskMgr->getTotalGPUTime() << " s" << G4endl;
-            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits() << G4endl;
+            G4cout << "Total GPU time:    " << fGPUTaskMgr->getTotalGPUTime() << " s"
+                   << G4endl;
+            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits()
+                   << G4endl;
         }
         else
         {
-            G4CXOpticks *gx = G4CXOpticks::Get();
-            auto t0 = std::chrono::high_resolution_clock::now();
+            G4CXOpticks* gx = G4CXOpticks::Get();
+            auto         t0 = std::chrono::high_resolution_clock::now();
             gx->simulate(0, false);
             cudaDeviceSynchronize();
-            auto t1 = std::chrono::high_resolution_clock::now();
+            auto                          t1 = std::chrono::high_resolution_clock::now();
             std::chrono::duration<double> elapsed = t1 - t0;
 
-            SEvt *sev = SEvt::Get_EGPU();
+            SEvt*    sev = SEvt::Get_EGPU();
             unsigned num_hits = sev->GetNumHit(0);
 
             G4cout << "\n=== Sync GPU Summary ===" << G4endl;
             G4cout << "GPU sim time:      " << elapsed.count() << " s" << G4endl;
-            G4cout << "Gensteps:          " << sev->GetNumGenstepFromGenstep(0) << G4endl;
-            G4cout << "Photons collected: " << sev->GetNumPhotonCollected(0) << G4endl;
+            G4cout << "Gensteps:          " << sev->GetNumGenstepFromGenstep(0)
+                   << G4endl;
+            G4cout << "Photons collected: " << sev->GetNumPhotonCollected(0)
+                   << G4endl;
             G4cout << "GPU hits:          " << num_hits << G4endl;
-            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits() << G4endl;
+            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits()
+                   << G4endl;
 
             if (num_hits > 0)
             {
-                NP *gpu_h = NP::Make<float>(num_hits, 4, 4);
+                NP* gpu_h = NP::Make<float>(num_hits, 4, 4);
                 for (unsigned idx = 0; idx < num_hits; idx++)
                 {
                     sphoton hit;
                     sev->getHit(hit, idx);
-                    std::memcpy(gpu_h->bytes() + idx * sizeof(sphoton), &hit, sizeof(sphoton));
+                    std::memcpy(gpu_h->bytes() + idx * sizeof(sphoton), &hit,
+                                sizeof(sphoton));
                 }
                 gpu_h->save("gpu_hits.npy");
                 G4cout << "Saved GPU hits to gpu_hits.npy" << G4endl;
@@ -783,11 +837,12 @@ struct RunAction : G4UserRunAction
         }
 
         std::lock_guard<std::mutex> lock(g4hits_mutex);
-        size_t ng4 = g4_accumulated_hits.size();
+        size_t                      ng4 = g4_accumulated_hits.size();
         if (ng4 > 0)
         {
-            NP *g4h = NP::Make<float>(ng4, 4, 4);
-            std::memcpy(g4h->bytes(), g4_accumulated_hits.data(), ng4 * 16 * sizeof(float));
+            NP* g4h = NP::Make<float>(ng4, 4, 4);
+            std::memcpy(g4h->bytes(), g4_accumulated_hits.data(),
+                        ng4 * 16 * sizeof(float));
             g4h->save("g4_hits.npy");
             G4cout << "Saved G4 hits (" << ng4 << ") to g4_hits.npy" << G4endl;
         }
@@ -800,44 +855,50 @@ struct RunAction : G4UserRunAction
 
 struct SteppingAction : G4UserSteppingAction
 {
-    SEvt *sev;
-    GPUTaskManager *fGPUTaskMgr{nullptr};
+    SEvt*           sev;
+    GPUTaskManager* fGPUTaskMgr{nullptr};
 
-    SteppingAction(SEvt *sev, GPUTaskManager *mgr = nullptr) : sev(sev), fGPUTaskMgr(mgr)
+    SteppingAction(SEvt* sev, GPUTaskManager* mgr = nullptr) :
+        sev(sev),
+        fGPUTaskMgr(mgr)
     {
     }
 
-    void UserSteppingAction(const G4Step *aStep) override
+    void UserSteppingAction(const G4Step* aStep) override
     {
         // Cap optical photon step count so reflection loops can't run forever
-        if (aStep->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition() &&
+        if (aStep->GetTrack()->GetDefinition() ==
+                G4OpticalPhoton::OpticalPhotonDefinition() &&
             aStep->GetTrack()->GetCurrentStepNumber() > 10000)
             aStep->GetTrack()->SetTrackStatus(fStopAndKill);
 
-        G4SteppingManager *sm = G4EventManager::GetEventManager()->GetTrackingManager()->GetSteppingManager();
+        G4SteppingManager* sm = G4EventManager::GetEventManager()
+                                    ->GetTrackingManager()
+                                    ->GetSteppingManager();
         if (sm->GetfStepStatus() == fAtRestDoItProc)
             return;
 
-        G4ProcessVector *procPost = sm->GetfPostStepDoItVector();
-        size_t MAXofPostStepLoops = sm->GetMAXofPostStepLoops();
+        G4ProcessVector* procPost = sm->GetfPostStepDoItVector();
+        size_t           MAXofPostStepLoops = sm->GetMAXofPostStepLoops();
 
         for (size_t i = 0; i < MAXofPostStepLoops; i++)
         {
-            const G4String &pname = (*procPost)[i]->GetProcessName();
+            const G4String& pname = (*procPost)[i]->GetProcessName();
 
             if (pname == "Cerenkov")
             {
-                G4Track *track = aStep->GetTrack();
-                const G4DynamicParticle *dp = track->GetDynamicParticle();
-                G4double charge = dp->GetDefinition()->GetPDGCharge();
-                const G4Material *mat = track->GetMaterial();
-                G4MaterialPropertiesTable *MPT = mat->GetMaterialPropertiesTable();
-                G4MaterialPropertyVector *Rindex = MPT ? MPT->GetProperty(kRINDEX) : nullptr;
+                G4Track*                   track = aStep->GetTrack();
+                const G4DynamicParticle*   dp = track->GetDynamicParticle();
+                G4double                   charge = dp->GetDefinition()->GetPDGCharge();
+                const G4Material*          mat = track->GetMaterial();
+                G4MaterialPropertiesTable* MPT = mat->GetMaterialPropertiesTable();
+                G4MaterialPropertyVector*  Rindex =
+                    MPT ? MPT->GetProperty(kRINDEX) : nullptr;
                 if (!Rindex || Rindex->GetVectorLength() == 0)
                     return;
 
-                G4Cerenkov *proc = (G4Cerenkov *)(*procPost)[i];
-                G4int numPhotons = proc->GetNumPhotons();
+                G4Cerenkov* proc = (G4Cerenkov*)(*procPost)[i];
+                G4int       numPhotons = proc->GetNumPhotons();
                 if (numPhotons <= 0)
                     continue;
 
@@ -850,53 +911,61 @@ struct SteppingAction : G4UserSteppingAction
                 G4double BetaInverse = 1. / beta;
                 G4double maxCos = BetaInverse / nMax;
                 G4double maxSin2 = (1.0 - maxCos) * (1.0 + maxCos);
-                G4double mean1 = proc->GetAverageNumberOfPhotons(charge, beta1, mat, Rindex);
-                G4double mean2 = proc->GetAverageNumberOfPhotons(charge, beta2, mat, Rindex);
+                G4double mean1 =
+                    proc->GetAverageNumberOfPhotons(charge, beta1, mat, Rindex);
+                G4double mean2 =
+                    proc->GetAverageNumberOfPhotons(charge, beta2, mat, Rindex);
 
                 if (fGPUTaskMgr)
                 {
-                    const G4Event *ev = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+                    const G4Event* ev =
+                        G4EventManager::GetEventManager()->GetConstCurrentEvent();
                     if (!ev)
                         return;
-                    quad6 gs = MakeGenstep_Cerenkov(track, aStep, numPhotons, BetaInverse, Pmin, Pmax, maxCos, maxSin2,
-                                                    mean1, mean2);
+                    quad6 gs =
+                        MakeGenstep_Cerenkov(track, aStep, numPhotons, BetaInverse, Pmin,
+                                             Pmax, maxCos, maxSin2, mean1, mean2);
                     fGPUTaskMgr->addGenstep(gs, numPhotons, ev->GetEventID());
                 }
                 else
                 {
                     G4AutoLock lock(&genstep_mutex);
-                    U4::CollectGenstep_G4Cerenkov_modified(track, aStep, numPhotons, BetaInverse, Pmin, Pmax, maxCos,
-                                                           maxSin2, mean1, mean2);
+                    U4::CollectGenstep_G4Cerenkov_modified(track, aStep, numPhotons,
+                                                           BetaInverse, Pmin, Pmax,
+                                                           maxCos, maxSin2, mean1, mean2);
                 }
             }
             else if (pname == "Scintillation")
             {
-                G4Scintillation *proc = (G4Scintillation *)(*procPost)[i];
-                G4int numPhotons = proc->GetNumPhotons();
+                G4Scintillation* proc = (G4Scintillation*)(*procPost)[i];
+                G4int            numPhotons = proc->GetNumPhotons();
                 if (numPhotons <= 0)
                     continue;
 
-                G4Track *track = aStep->GetTrack();
-                const G4Material *mat = track->GetMaterial();
-                G4MaterialPropertiesTable *MPT = mat->GetMaterialPropertiesTable();
+                G4Track*                   track = aStep->GetTrack();
+                const G4Material*          mat = track->GetMaterial();
+                G4MaterialPropertiesTable* MPT = mat->GetMaterialPropertiesTable();
                 if (!MPT || !MPT->ConstPropertyExists(kSCINTILLATIONTIMECONSTANT1))
                     return;
 
-                const G4int tcKeys[3] = {kSCINTILLATIONTIMECONSTANT1, kSCINTILLATIONTIMECONSTANT2,
+                const G4int tcKeys[3] = {kSCINTILLATIONTIMECONSTANT1,
+                                         kSCINTILLATIONTIMECONSTANT2,
                                          kSCINTILLATIONTIMECONSTANT3};
-                const G4int yieldKeys[3] = {kSCINTILLATIONYIELD1, kSCINTILLATIONYIELD2, kSCINTILLATIONYIELD3};
+                const G4int yieldKeys[3] = {kSCINTILLATIONYIELD1, kSCINTILLATIONYIELD2,
+                                            kSCINTILLATIONYIELD3};
 
                 G4double tc[3] = {0, 0, 0};
                 G4double yield[3] = {0, 0, 0};
                 G4double yieldSum = 0;
-                G4int nComp = 0;
+                G4int    nComp = 0;
                 for (G4int c = 0; c < 3; c++)
                 {
                     if (MPT->ConstPropertyExists(tcKeys[c]))
                     {
                         tc[c] = MPT->GetConstProperty(tcKeys[c]);
-                        yield[c] = MPT->ConstPropertyExists(yieldKeys[c]) ? MPT->GetConstProperty(yieldKeys[c])
-                                                                          : (c == 0 ? 1.0 : 0.0);
+                        yield[c] = MPT->ConstPropertyExists(yieldKeys[c])
+                                       ? MPT->GetConstProperty(yieldKeys[c])
+                                       : (c == 0 ? 1.0 : 0.0);
                         yieldSum += yield[c];
                         nComp = c + 1;
                     }
@@ -904,18 +973,23 @@ struct SteppingAction : G4UserSteppingAction
 
                 if (fGPUTaskMgr)
                 {
-                    const G4Event *ev = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+                    const G4Event* ev =
+                        G4EventManager::GetEventManager()->GetConstCurrentEvent();
                     if (!ev)
                         return;
-                    int eventid = ev->GetEventID();
+                    int   eventid = ev->GetEventID();
                     G4int remaining = numPhotons;
                     for (G4int c = 0; c < nComp; c++)
                     {
-                        G4int n = (c == nComp - 1) ? remaining : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        G4int n =
+                            (c == nComp - 1)
+                                ? remaining
+                                : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
                         remaining -= n;
                         if (n > 0)
                         {
-                            quad6 gs = MakeGenstep_Scintillation(track, aStep, n, c + 1, tc[c]);
+                            quad6 gs =
+                                MakeGenstep_Scintillation(track, aStep, n, c + 1, tc[c]);
                             fGPUTaskMgr->addGenstep(gs, n, eventid);
                         }
                     }
@@ -923,13 +997,17 @@ struct SteppingAction : G4UserSteppingAction
                 else
                 {
                     G4AutoLock lock(&genstep_mutex);
-                    G4int remaining = numPhotons;
+                    G4int      remaining = numPhotons;
                     for (G4int c = 0; c < nComp; c++)
                     {
-                        G4int n = (c == nComp - 1) ? remaining : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        G4int n =
+                            (c == nComp - 1)
+                                ? remaining
+                                : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
                         remaining -= n;
                         if (n > 0)
-                            U4::CollectGenstep_DsG4Scintillation_r4695(track, aStep, n, c + 1, tc[c]);
+                            U4::CollectGenstep_DsG4Scintillation_r4695(track, aStep, n, c + 1,
+                                                                       tc[c]);
                     }
                 }
             }
@@ -943,16 +1021,17 @@ struct SteppingAction : G4UserSteppingAction
 
 struct TrackingAction : G4UserTrackingAction
 {
-    SEvt *sev;
-    TrackingAction(SEvt *sev) : sev(sev)
+    SEvt* sev;
+    TrackingAction(SEvt* sev) :
+        sev(sev)
     {
     }
 
-    void PreUserTrackingAction(const G4Track *) override
+    void PreUserTrackingAction(const G4Track*) override
     {
     }
 
-    void PostUserTrackingAction(const G4Track *) override
+    void PostUserTrackingAction(const G4Track*) override
     {
     }
 };
@@ -963,25 +1042,29 @@ struct TrackingAction : G4UserTrackingAction
 
 struct G4App
 {
-    SEvt *sev;
-    GPUTaskManager *gpu_task_mgr_;
+    SEvt*           sev;
+    GPUTaskManager* gpu_task_mgr_;
 
-    G4VUserDetectorConstruction *det_cons_;
-    G4VUserPrimaryGeneratorAction *prim_gen_;
-    EventAction *event_act_;
-    RunAction *run_act_;
-    SteppingAction *stepping_;
-    TrackingAction *tracking_;
+    G4VUserDetectorConstruction*   det_cons_;
+    G4VUserPrimaryGeneratorAction* prim_gen_;
+    EventAction*                   event_act_;
+    RunAction*                     run_act_;
+    SteppingAction*                stepping_;
+    TrackingAction*                tracking_;
 
-    G4App(std::filesystem::path gdml_file, bool enable_async = true)
-        : sev(SEvt::CreateOrReuse_EGPU()), gpu_task_mgr_(enable_async ? new GPUTaskManager() : nullptr),
-          det_cons_(new DetectorConstruction(gdml_file)), prim_gen_(new PrimaryGenerator(sev)),
-          event_act_(new EventAction(sev)), run_act_(new RunAction(event_act_, gpu_task_mgr_)),
-          stepping_(new SteppingAction(sev, gpu_task_mgr_)), tracking_(new TrackingAction(sev))
+    G4App(std::filesystem::path gdml_file, bool enable_async = true) :
+        sev(SEvt::CreateOrReuse_EGPU()),
+        gpu_task_mgr_(enable_async ? new GPUTaskManager() : nullptr),
+        det_cons_(new DetectorConstruction(gdml_file)),
+        prim_gen_(new PrimaryGenerator(sev)),
+        event_act_(new EventAction(sev)),
+        run_act_(new RunAction(event_act_, gpu_task_mgr_)),
+        stepping_(new SteppingAction(sev, gpu_task_mgr_)),
+        tracking_(new TrackingAction(sev))
     {
         if (gpu_task_mgr_)
-            G4cout << "G4App [std]: async GPU mode (threshold=" << gpu_task_mgr_->getThreshold() << " photons)"
-                   << G4endl;
+            G4cout << "G4App [std]: async GPU mode (threshold="
+                   << gpu_task_mgr_->getThreshold() << " photons)" << G4endl;
         else
             G4cout << "G4App [std]: sync GPU mode (end-of-run)" << G4endl;
     }

--- a/examples/async_gpu_std/async_gpu_std.h
+++ b/examples/async_gpu_std/async_gpu_std.h
@@ -1,0 +1,974 @@
+#pragma once
+//
+// async_gpu_std.h — Async CPU+GPU optical photon simulation, std-only.
+//
+// Same double-buffering pattern as examples/async_gpu_launch but without
+// G4TaskGroup / G4Mutex.  The GPU worker is a plain std::thread driven by
+// std::mutex + std::condition_variable + std::queue, with explicit
+// backpressure controlled by GPU_MAX_QUEUE_SIZE.
+//
+// Modes:
+//   --async   : double-buffered async GPU processing (default)
+//   --sync    : end-of-run GPU simulation (one batch)
+//
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include "G4AutoLock.hh"
+#include "G4BooleanSolid.hh"
+#include "G4Cerenkov.hh"
+#include "G4Electron.hh"
+#include "G4Event.hh"
+#include "G4EventManager.hh"
+#include "G4GDMLParser.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4OpBoundaryProcess.hh"
+#include "G4OpticalPhoton.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4PrimaryParticle.hh"
+#include "G4PrimaryVertex.hh"
+#include "G4RunManager.hh"
+#include "G4RunManagerFactory.hh"
+#include "G4SDManager.hh"
+#include "G4Scintillation.hh"
+#include "G4SubtractionSolid.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ThreeVector.hh"
+#include "G4Track.hh"
+#include "G4TrackStatus.hh"
+#include "G4UserEventAction.hh"
+#include "G4UserRunAction.hh"
+#include "G4UserSteppingAction.hh"
+#include "G4UserTrackingAction.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4VProcess.hh"
+#include "G4VUserDetectorConstruction.hh"
+#include "G4VUserPrimaryGeneratorAction.hh"
+
+#include "g4cx/G4CXOpticks.hh"
+#include "sysrap/NP.hh"
+#include "sysrap/OpticksGenstep.h"
+#include "sysrap/SEvt.hh"
+#include "sysrap/scerenkov.h"
+#include "sysrap/sgs.h"
+#include "sysrap/spho.h"
+#include "sysrap/sphoton.h"
+#include "sysrap/sscint.h"
+#include "u4/U4.hh"
+#include "u4/U4Random.hh"
+#include "u4/U4StepPoint.hh"
+#include "u4/U4Touchable.h"
+#include "u4/U4Track.h"
+
+namespace
+{
+G4Mutex genstep_mutex = G4MUTEX_INITIALIZER;        // sync-mode SEvt collection
+std::mutex g4hits_mutex;                            // accumulator across worker threads
+std::vector<std::array<float, 16>> g4_accumulated_hits;
+} // namespace
+
+// ============================================================================
+// Geometry helpers
+// ============================================================================
+
+bool IsSubtractionSolid(G4VSolid *solid)
+{
+    if (!solid)
+        return false;
+    if (dynamic_cast<G4SubtractionSolid *>(solid))
+        return true;
+    if (G4BooleanSolid *bs = dynamic_cast<G4BooleanSolid *>(solid))
+    {
+        if (IsSubtractionSolid(bs->GetConstituentSolid(0)) ||
+            IsSubtractionSolid(bs->GetConstituentSolid(1)))
+            return true;
+    }
+    return false;
+}
+
+std::string str_tolower(std::string s)
+{
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
+// ============================================================================
+// GenstepBuffer — accumulates gensteps for one GPU batch
+// ============================================================================
+
+struct GenstepBuffer
+{
+    std::vector<quad6> gensteps;
+    std::vector<sgs> labels;
+    int64_t photon_count = 0;
+    int64_t genstep_count = 0;
+    int event_id = 0;
+
+    void addGenstep(const quad6 &gs, int64_t numphotons)
+    {
+        sgs label;
+        label.index = gensteps.size();
+        label.photons = numphotons;
+        label.offset = photon_count;
+        label.gentype = gs.gentype();
+
+        gensteps.push_back(gs);
+        labels.push_back(label);
+        photon_count += numphotons;
+        genstep_count++;
+    }
+
+    bool empty() const { return gensteps.empty(); }
+    size_t size() const { return gensteps.size(); }
+};
+
+struct GPUTask
+{
+    int batch_id;
+    std::shared_ptr<GenstepBuffer> buffer;
+
+    GPUTask() : batch_id(-1), buffer(nullptr) {}
+    GPUTask(int bid, std::shared_ptr<GenstepBuffer> buf) : batch_id(bid), buffer(std::move(buf)) {}
+};
+
+// ============================================================================
+// GPUTaskManager — std::thread + std::queue worker, no G4Task
+//
+// CPU thread(s) push completed buffers into task_queue_ via submitBuffer()
+// when the photon threshold is reached.  A single worker std::thread pops
+// tasks and runs G4CXOpticks::simulate().  The queue has a fixed depth
+// (GPU_MAX_QUEUE_SIZE) so producers block when the GPU falls behind.
+// ============================================================================
+
+class GPUTaskManager
+{
+  public:
+    static constexpr int64_t DEFAULT_PHOTON_THRESHOLD = 10000000; // 10M photons
+    static constexpr size_t DEFAULT_MAX_QUEUE_SIZE = 3;
+
+  private:
+    int64_t photon_threshold_;
+    size_t max_queue_size_;
+
+    std::shared_ptr<GenstepBuffer> active_buffer_;
+    std::mutex buffer_mutex_;
+
+    std::queue<GPUTask> task_queue_;
+    std::mutex queue_mutex_;
+    std::condition_variable queue_not_full_;
+    std::condition_variable queue_not_empty_;
+    std::condition_variable queue_drained_;
+
+    std::thread worker_;
+    std::atomic<bool> shutdown_{false};
+    std::atomic<bool> running_{false};
+
+    std::atomic<int> batch_counter_{0};
+    std::atomic<int> completed_batches_{0};
+    std::atomic<uint64_t> total_hits_{0};
+    std::atomic<uint64_t> total_photons_{0};
+    std::atomic<uint64_t> total_gpu_time_us_{0};
+
+  public:
+    GPUTaskManager(int64_t threshold = DEFAULT_PHOTON_THRESHOLD,
+                   size_t max_queue = DEFAULT_MAX_QUEUE_SIZE)
+        : photon_threshold_(threshold),
+          max_queue_size_(max_queue),
+          active_buffer_(std::make_shared<GenstepBuffer>())
+    {
+        if (const char *e = std::getenv("GPU_PHOTON_FLUSH_THRESHOLD"))
+            photon_threshold_ = std::atoll(e);
+        if (const char *e = std::getenv("GPU_MAX_QUEUE_SIZE"))
+            max_queue_size_ = std::max(1, std::atoi(e));
+    }
+
+    ~GPUTaskManager() { shutdown(); }
+
+    void start()
+    {
+        if (running_.exchange(true))
+            return;
+        shutdown_ = false;
+        worker_ = std::thread(&GPUTaskManager::workerLoop, this);
+
+        G4cout << "GPUTaskManager [std]: started"
+               << " threshold=" << photon_threshold_
+               << " max_queue=" << max_queue_size_ << G4endl;
+    }
+
+    void shutdown()
+    {
+        if (!running_.exchange(false))
+            return;
+
+        // Flush any remaining gensteps in the active buffer
+        std::shared_ptr<GenstepBuffer> remainder;
+        {
+            std::lock_guard<std::mutex> lock(buffer_mutex_);
+            if (active_buffer_ && !active_buffer_->empty())
+            {
+                remainder = active_buffer_;
+                active_buffer_ = std::make_shared<GenstepBuffer>();
+            }
+        }
+        if (remainder)
+            submitBuffer(remainder);
+
+        {
+            std::lock_guard<std::mutex> lock(queue_mutex_);
+            shutdown_ = true;
+        }
+        queue_not_empty_.notify_all();
+        queue_not_full_.notify_all();
+
+        if (worker_.joinable())
+            worker_.join();
+
+        G4cout << "GPUTaskManager [std]: shutdown"
+               << " batches=" << completed_batches_.load()
+               << " photons=" << total_photons_.load()
+               << " hits=" << total_hits_.load()
+               << " gpu_time=" << (total_gpu_time_us_.load() / 1e6) << "s" << G4endl;
+    }
+
+    // Hot path — invoked from SteppingAction
+    void addGenstep(const quad6 &gs, int64_t numphotons, int eventID)
+    {
+        std::shared_ptr<GenstepBuffer> to_submit;
+        {
+            std::lock_guard<std::mutex> lock(buffer_mutex_);
+            active_buffer_->event_id = eventID;
+            active_buffer_->addGenstep(gs, numphotons);
+
+            if (active_buffer_->photon_count >= photon_threshold_)
+            {
+                to_submit = active_buffer_;
+                active_buffer_ = std::make_shared<GenstepBuffer>();
+            }
+        }
+        if (to_submit)
+            submitBuffer(to_submit);
+    }
+
+    void flushRemaining(int eventID)
+    {
+        std::shared_ptr<GenstepBuffer> to_submit;
+        {
+            std::lock_guard<std::mutex> lock(buffer_mutex_);
+            if (active_buffer_ && !active_buffer_->empty())
+            {
+                active_buffer_->event_id = eventID;
+                to_submit = active_buffer_;
+                active_buffer_ = std::make_shared<GenstepBuffer>();
+            }
+        }
+        if (to_submit)
+        {
+            G4cout << "GPUTaskManager [std]: final flush ("
+                   << to_submit->photon_count << " photons)" << G4endl;
+            submitBuffer(to_submit);
+        }
+        waitForDrain();
+    }
+
+    void waitForDrain()
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        queue_drained_.wait(lock, [this]() { return task_queue_.empty(); });
+    }
+
+    int getCompletedBatches() const { return completed_batches_.load(); }
+    uint64_t getTotalHits() const { return total_hits_.load(); }
+    uint64_t getTotalPhotons() const { return total_photons_.load(); }
+    int64_t getThreshold() const { return photon_threshold_; }
+    double getTotalGPUTime() const { return total_gpu_time_us_.load() / 1e6; }
+
+  private:
+    void submitBuffer(std::shared_ptr<GenstepBuffer> buffer)
+    {
+        if (!buffer || buffer->empty())
+            return;
+
+        int batch_id = batch_counter_.fetch_add(1);
+        GPUTask task(batch_id, buffer);
+
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            queue_not_full_.wait(lock, [this]() {
+                return task_queue_.size() < max_queue_size_ || shutdown_;
+            });
+            if (shutdown_)
+                return;
+
+            task_queue_.push(std::move(task));
+            G4cout << "GPUTaskManager [std]: queued batch " << batch_id
+                   << " (" << buffer->photon_count << " photons, "
+                   << buffer->genstep_count << " gensteps)"
+                   << " queue_size=" << task_queue_.size() << G4endl;
+        }
+        queue_not_empty_.notify_one();
+    }
+
+    void workerLoop()
+    {
+        G4cout << "GPUTaskManager [std]: worker thread started (tid="
+               << std::this_thread::get_id() << ")" << G4endl;
+
+        while (true)
+        {
+            GPUTask task;
+            {
+                std::unique_lock<std::mutex> lock(queue_mutex_);
+                queue_not_empty_.wait(lock, [this]() {
+                    return !task_queue_.empty() || shutdown_;
+                });
+                if (task_queue_.empty() && shutdown_)
+                    break;
+
+                task = std::move(task_queue_.front());
+                task_queue_.pop();
+            }
+            queue_not_full_.notify_one();
+
+            if (task.buffer)
+                runBatch(task.batch_id, task.buffer);
+
+            {
+                std::lock_guard<std::mutex> lock(queue_mutex_);
+                if (task_queue_.empty())
+                    queue_drained_.notify_all();
+            }
+        }
+        G4cout << "GPUTaskManager [std]: worker thread exiting" << G4endl;
+    }
+
+    void runBatch(int batch_id, std::shared_ptr<GenstepBuffer> buffer)
+    {
+        G4cout << "=== GPU Batch " << batch_id << " ==="
+               << " photons=" << buffer->photon_count
+               << " gensteps=" << buffer->genstep_count << G4endl;
+
+        G4CXOpticks *gx = G4CXOpticks::Get();
+        SEvt *sev = SEvt::Get_EGPU();
+        if (!gx || !sev)
+        {
+            G4cerr << "GPUTaskManager [std]: G4CXOpticks/SEvt not available" << G4endl;
+            return;
+        }
+
+        sev->clear_genstep();
+        NP *gs_array = NP::Make<float>(buffer->gensteps.size(), 6, 4);
+        std::memcpy(gs_array->values<float>(), buffer->gensteps.data(),
+                    buffer->gensteps.size() * sizeof(quad6));
+        sev->addGenstep(gs_array);
+
+        auto t0 = std::chrono::high_resolution_clock::now();
+        gx->simulate(buffer->event_id, false);
+        cudaDeviceSynchronize();
+        auto t1 = std::chrono::high_resolution_clock::now();
+        auto us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+
+        unsigned num_hits = sev->GetNumHit(0);
+        total_gpu_time_us_ += us;
+        total_hits_ += num_hits;
+        total_photons_ += buffer->photon_count;
+
+        G4cout << "  gpu_time=" << (us / 1e6) << "s hits=" << num_hits << G4endl;
+        if (num_hits > 0)
+            saveHits(batch_id, sev, num_hits);
+
+        gx->reset(buffer->event_id);
+        completed_batches_++;
+        G4cout << "=== GPU Batch " << batch_id << " complete ===" << G4endl;
+    }
+
+    void saveHits(int batch_id, SEvt *sev, unsigned num_hits)
+    {
+        std::ostringstream fname;
+        fname << "gpu_hits_batch_" << batch_id << ".npy";
+
+        NP *arr = NP::Make<float>(num_hits, 4, 4);
+        for (unsigned idx = 0; idx < num_hits; idx++)
+        {
+            sphoton hit;
+            sev->getHit(hit, idx);
+            std::memcpy(arr->bytes() + idx * sizeof(sphoton), &hit, sizeof(sphoton));
+        }
+        arr->save(fname.str().c_str());
+        G4cout << "  saved " << num_hits << " hits to " << fname.str() << G4endl;
+    }
+};
+
+// ============================================================================
+// Genstep construction (bypass U4 / SEvt for async path)
+// ============================================================================
+
+static quad6 MakeGenstep_Cerenkov(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons,
+                                  G4double betaInverse, G4double pmin, G4double pmax,
+                                  G4double maxCos, G4double maxSin2,
+                                  G4double meanNumberOfPhotons1, G4double meanNumberOfPhotons2)
+{
+    G4StepPoint *pre = aStep->GetPreStepPoint();
+    G4StepPoint *post = aStep->GetPostStepPoint();
+    G4ThreeVector x0 = pre->GetPosition();
+    G4double t0 = pre->GetGlobalTime();
+    G4ThreeVector dx = aStep->GetDeltaPosition();
+    const G4DynamicParticle *dp = aTrack->GetDynamicParticle();
+    const G4Material *mat = aTrack->GetMaterial();
+
+    G4double Wmin_nm = h_Planck * c_light / pmax / nm;
+    G4double Wmax_nm = h_Planck * c_light / pmin / nm;
+
+    quad6 gs;
+    gs.zero();
+    scerenkov *ck = (scerenkov *)(&gs);
+
+    ck->gentype = OpticksGenstep_G4Cerenkov_modified;
+    ck->trackid = aTrack->GetTrackID();
+    ck->matline = mat->GetIndex() + SEvt::G4_INDEX_OFFSET;
+    ck->numphoton = numPhotons;
+
+    ck->pos.x = x0.x();
+    ck->pos.y = x0.y();
+    ck->pos.z = x0.z();
+    ck->time = t0;
+
+    ck->DeltaPosition.x = dx.x();
+    ck->DeltaPosition.y = dx.y();
+    ck->DeltaPosition.z = dx.z();
+    ck->step_length = aStep->GetStepLength();
+
+    ck->code = dp->GetDefinition()->GetPDGEncoding();
+    ck->charge = dp->GetDefinition()->GetPDGCharge();
+    ck->weight = aTrack->GetWeight();
+    ck->preVelocity = pre->GetVelocity();
+
+    ck->BetaInverse = betaInverse;
+    ck->Wmin = Wmin_nm;
+    ck->Wmax = Wmax_nm;
+    ck->maxCos = maxCos;
+
+    ck->maxSin2 = maxSin2;
+    ck->MeanNumberOfPhotons1 = meanNumberOfPhotons1;
+    ck->MeanNumberOfPhotons2 = meanNumberOfPhotons2;
+    ck->postVelocity = post->GetVelocity();
+    return gs;
+}
+
+static quad6 MakeGenstep_Scintillation(const G4Track *aTrack, const G4Step *aStep, G4int numPhotons,
+                                       G4int scnt, G4double ScintillationTime)
+{
+    G4StepPoint *pre = aStep->GetPreStepPoint();
+    G4StepPoint *post = aStep->GetPostStepPoint();
+    G4ThreeVector x0 = pre->GetPosition();
+    G4double t0 = pre->GetGlobalTime();
+    G4ThreeVector dx = aStep->GetDeltaPosition();
+    G4double meanV = (pre->GetVelocity() + post->GetVelocity()) * 0.5;
+    const G4DynamicParticle *dp = aTrack->GetDynamicParticle();
+    const G4Material *mat = aTrack->GetMaterial();
+
+    quad6 gs;
+    gs.zero();
+    sscint *sc = (sscint *)(&gs);
+
+    sc->gentype = OpticksGenstep_DsG4Scintillation_r4695;
+    sc->trackid = aTrack->GetTrackID();
+    sc->matline = mat->GetIndex() + SEvt::G4_INDEX_OFFSET;
+    sc->numphoton = numPhotons;
+
+    sc->pos.x = x0.x();
+    sc->pos.y = x0.y();
+    sc->pos.z = x0.z();
+    sc->time = t0;
+
+    sc->DeltaPosition.x = dx.x();
+    sc->DeltaPosition.y = dx.y();
+    sc->DeltaPosition.z = dx.z();
+    sc->step_length = aStep->GetStepLength();
+
+    sc->code = dp->GetDefinition()->GetPDGEncoding();
+    sc->charge = dp->GetDefinition()->GetPDGCharge();
+    sc->weight = aTrack->GetWeight();
+    sc->meanVelocity = meanV;
+
+    sc->scnt = scnt;
+    sc->ScintillationTime = ScintillationTime;
+    return gs;
+}
+
+// ============================================================================
+// Sensitive detector and hits
+// ============================================================================
+
+struct PhotonHit : public G4VHit
+{
+    PhotonHit() = default;
+    PhotonHit(unsigned id, G4double energy, G4double time, G4ThreeVector position,
+              G4ThreeVector direction, G4ThreeVector polarization)
+        : fid(id), fenergy(energy), ftime(time), fposition(position), fdirection(direction),
+          fpolarization(polarization)
+    {
+    }
+
+    unsigned fid{0};
+    G4double fenergy{0};
+    G4double ftime{0};
+    G4ThreeVector fposition;
+    G4ThreeVector fdirection;
+    G4ThreeVector fpolarization;
+};
+
+using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
+
+struct PhotonSD : public G4VSensitiveDetector
+{
+    PhotonHitsCollection *fPhotonHitsCollection{nullptr};
+    G4int fHCID{-1};
+    G4int fTotalG4Hits{0};
+
+    PhotonSD(const G4String &name) : G4VSensitiveDetector(name)
+    {
+        collectionName.insert("photon_hits");
+    }
+
+    void Initialize(G4HCofThisEvent *hce) override
+    {
+        fPhotonHitsCollection = new PhotonHitsCollection(SensitiveDetectorName, collectionName[0]);
+        if (fHCID < 0)
+            fHCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
+        hce->AddHitsCollection(fHCID, fPhotonHitsCollection);
+    }
+
+    G4bool ProcessHits(G4Step *aStep, G4TouchableHistory *) override
+    {
+        G4Track *track = aStep->GetTrack();
+        if (track->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
+            return false;
+
+        G4double energy_eV = track->GetTotalEnergy() / CLHEP::eV;
+        PhotonHit *hit = new PhotonHit(0, energy_eV, track->GetGlobalTime(),
+                                       aStep->GetPostStepPoint()->GetPosition(),
+                                       aStep->GetPostStepPoint()->GetMomentumDirection(),
+                                       aStep->GetPostStepPoint()->GetPolarization());
+        fPhotonHitsCollection->insert(hit);
+        track->SetTrackStatus(fStopAndKill);
+        return true;
+    }
+
+    void EndOfEvent(G4HCofThisEvent *) override
+    {
+        G4int n = fPhotonHitsCollection->entries();
+        if (n <= 0)
+            return;
+
+        std::lock_guard<std::mutex> lock(g4hits_mutex);
+        for (G4int i = 0; i < n; i++)
+        {
+            PhotonHit *h = (*fPhotonHitsCollection)[i];
+            float wl = (h->fenergy > 0) ? static_cast<float>(1239.84198 / h->fenergy) : 0.f;
+            g4_accumulated_hits.push_back({float(h->fposition.x()), float(h->fposition.y()),
+                                           float(h->fposition.z()), float(h->ftime),
+                                           float(h->fdirection.x()), float(h->fdirection.y()),
+                                           float(h->fdirection.z()), 0.f,
+                                           float(h->fpolarization.x()), float(h->fpolarization.y()),
+                                           float(h->fpolarization.z()), wl,
+                                           0.f, 0.f, 0.f, float(h->fid)});
+        }
+        fTotalG4Hits += n;
+    }
+
+    G4int GetTotalG4Hits() const { return fTotalG4Hits; }
+};
+
+// ============================================================================
+// Detector construction
+// ============================================================================
+
+struct DetectorConstruction : G4VUserDetectorConstruction
+{
+    std::filesystem::path gdml_file_;
+    G4GDMLParser parser_;
+
+    DetectorConstruction(std::filesystem::path gdml_file) : gdml_file_(gdml_file) {}
+
+    G4VPhysicalVolume *Construct() override
+    {
+        parser_.Read(gdml_file_.string(), false);
+        G4VPhysicalVolume *world = parser_.GetWorldVolume();
+        G4CXOpticks::SetGeometry(world);
+
+        G4LogicalVolumeStore *lvStore = G4LogicalVolumeStore::GetInstance();
+        static G4VisAttributes invisibleVisAttr(false);
+        if (lvStore && !lvStore->empty())
+        {
+            for (auto lv : *lvStore)
+            {
+                G4String lname = str_tolower(lv->GetName());
+                if (lname.find("detect") != std::string::npos ||
+                    lname.find("sipm") != std::string::npos ||
+                    lname.find("sensor") != std::string::npos ||
+                    lname.find("pmt") != std::string::npos ||
+                    lname.find("arapuca") != std::string::npos)
+                {
+                    G4String sdName = "PhotonDetector_" + lv->GetName();
+                    if (!G4SDManager::GetSDMpointer()->FindSensitiveDetector(sdName, false))
+                    {
+                        PhotonSD *sd = new PhotonSD(sdName);
+                        G4SDManager::GetSDMpointer()->AddNewDetector(sd);
+                        lv->SetSensitiveDetector(sd);
+                    }
+                }
+                G4VSolid *solid = lv->GetSolid();
+                if (solid && IsSubtractionSolid(solid))
+                    lv->SetVisAttributes(&invisibleVisAttr);
+            }
+        }
+        return world;
+    }
+};
+
+// ============================================================================
+// Primary generator
+// ============================================================================
+
+struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
+{
+    SEvt *sev;
+    PrimaryGenerator(SEvt *sev) : sev(sev) {}
+
+    void GeneratePrimaries(G4Event *event) override
+    {
+        G4ThreeVector pos(0.0 * m, 0.0 * m, 0.0 * m);
+        G4double time_ns = 0;
+        G4ThreeVector dir(0, 0.2, 0.8);
+
+        G4PrimaryParticle *p = new G4PrimaryParticle(G4Electron::Definition());
+        p->SetKineticEnergy(10 * MeV);
+        p->SetMomentumDirection(dir);
+
+        G4PrimaryVertex *v = new G4PrimaryVertex(pos, time_ns);
+        v->SetPrimary(p);
+        event->AddPrimaryVertex(v);
+    }
+};
+
+// ============================================================================
+// Event action — count G4 hits across all collections
+// ============================================================================
+
+struct EventAction : G4UserEventAction
+{
+    SEvt *sev;
+    G4int fTotalG4Hits{0};
+
+    EventAction(SEvt *sev) : sev(sev) {}
+
+    void EndOfEventAction(const G4Event *event) override
+    {
+        G4HCofThisEvent *hce = event->GetHCofThisEvent();
+        if (!hce)
+            return;
+        G4int n = hce->GetNumberOfCollections();
+        for (G4int i = 0; i < n; i++)
+        {
+            G4VHitsCollection *hc = hce->GetHC(i);
+            if (!hc)
+                continue;
+            if (auto *phc = dynamic_cast<PhotonHitsCollection *>(hc))
+                fTotalG4Hits += phc->entries();
+            else
+                fTotalG4Hits += hc->GetSize();
+        }
+    }
+
+    G4int GetTotalG4Hits() const { return fTotalG4Hits; }
+};
+
+// ============================================================================
+// Run action — drives the GPU lifecycle (sync or async)
+// ============================================================================
+
+struct RunAction : G4UserRunAction
+{
+    EventAction *fEventAction;
+    GPUTaskManager *fGPUTaskMgr{nullptr};
+
+    RunAction(EventAction *ea, GPUTaskManager *mgr = nullptr) : fEventAction(ea), fGPUTaskMgr(mgr) {}
+
+    void BeginOfRunAction(const G4Run *) override
+    {
+        if (G4Threading::IsMasterThread() && fGPUTaskMgr)
+            fGPUTaskMgr->start();
+    }
+
+    void EndOfRunAction(const G4Run *) override
+    {
+        if (!G4Threading::IsMasterThread())
+            return;
+
+        if (fGPUTaskMgr)
+        {
+            fGPUTaskMgr->flushRemaining(0);
+
+            G4cout << "\n=== Async GPU Summary (std) ===" << G4endl;
+            G4cout << "Batches processed: " << fGPUTaskMgr->getCompletedBatches() << G4endl;
+            G4cout << "Total GPU photons: " << fGPUTaskMgr->getTotalPhotons() << G4endl;
+            G4cout << "Total GPU hits:    " << fGPUTaskMgr->getTotalHits() << G4endl;
+            G4cout << "Total GPU time:    " << fGPUTaskMgr->getTotalGPUTime() << " s" << G4endl;
+            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits() << G4endl;
+        }
+        else
+        {
+            G4CXOpticks *gx = G4CXOpticks::Get();
+            auto t0 = std::chrono::high_resolution_clock::now();
+            gx->simulate(0, false);
+            cudaDeviceSynchronize();
+            auto t1 = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<double> elapsed = t1 - t0;
+
+            SEvt *sev = SEvt::Get_EGPU();
+            unsigned num_hits = sev->GetNumHit(0);
+
+            G4cout << "\n=== Sync GPU Summary ===" << G4endl;
+            G4cout << "GPU sim time:      " << elapsed.count() << " s" << G4endl;
+            G4cout << "Gensteps:          " << sev->GetNumGenstepFromGenstep(0) << G4endl;
+            G4cout << "Photons collected: " << sev->GetNumPhotonCollected(0) << G4endl;
+            G4cout << "GPU hits:          " << num_hits << G4endl;
+            G4cout << "G4 hits:           " << fEventAction->GetTotalG4Hits() << G4endl;
+
+            if (num_hits > 0)
+            {
+                NP *gpu_h = NP::Make<float>(num_hits, 4, 4);
+                for (unsigned idx = 0; idx < num_hits; idx++)
+                {
+                    sphoton hit;
+                    sev->getHit(hit, idx);
+                    std::memcpy(gpu_h->bytes() + idx * sizeof(sphoton), &hit, sizeof(sphoton));
+                }
+                gpu_h->save("gpu_hits.npy");
+                G4cout << "Saved GPU hits to gpu_hits.npy" << G4endl;
+            }
+        }
+
+        std::lock_guard<std::mutex> lock(g4hits_mutex);
+        size_t ng4 = g4_accumulated_hits.size();
+        if (ng4 > 0)
+        {
+            NP *g4h = NP::Make<float>(ng4, 4, 4);
+            std::memcpy(g4h->bytes(), g4_accumulated_hits.data(), ng4 * 16 * sizeof(float));
+            g4h->save("g4_hits.npy");
+            G4cout << "Saved G4 hits (" << ng4 << ") to g4_hits.npy" << G4endl;
+        }
+    }
+};
+
+// ============================================================================
+// Stepping action — collect Cerenkov / scintillation gensteps
+// ============================================================================
+
+struct SteppingAction : G4UserSteppingAction
+{
+    SEvt *sev;
+    GPUTaskManager *fGPUTaskMgr{nullptr};
+
+    SteppingAction(SEvt *sev, GPUTaskManager *mgr = nullptr) : sev(sev), fGPUTaskMgr(mgr) {}
+
+    void UserSteppingAction(const G4Step *aStep) override
+    {
+        // Cap optical photon step count so reflection loops can't run forever
+        if (aStep->GetTrack()->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition() &&
+            aStep->GetTrack()->GetCurrentStepNumber() > 10000)
+            aStep->GetTrack()->SetTrackStatus(fStopAndKill);
+
+        G4SteppingManager *sm =
+            G4EventManager::GetEventManager()->GetTrackingManager()->GetSteppingManager();
+        if (sm->GetfStepStatus() == fAtRestDoItProc)
+            return;
+
+        G4ProcessVector *procPost = sm->GetfPostStepDoItVector();
+        size_t MAXofPostStepLoops = sm->GetMAXofPostStepLoops();
+
+        for (size_t i = 0; i < MAXofPostStepLoops; i++)
+        {
+            const G4String &pname = (*procPost)[i]->GetProcessName();
+
+            if (pname == "Cerenkov")
+            {
+                G4Track *track = aStep->GetTrack();
+                const G4DynamicParticle *dp = track->GetDynamicParticle();
+                G4double charge = dp->GetDefinition()->GetPDGCharge();
+                const G4Material *mat = track->GetMaterial();
+                G4MaterialPropertiesTable *MPT = mat->GetMaterialPropertiesTable();
+                G4MaterialPropertyVector *Rindex = MPT ? MPT->GetProperty(kRINDEX) : nullptr;
+                if (!Rindex || Rindex->GetVectorLength() == 0)
+                    return;
+
+                G4Cerenkov *proc = (G4Cerenkov *)(*procPost)[i];
+                G4int numPhotons = proc->GetNumPhotons();
+                if (numPhotons <= 0)
+                    continue;
+
+                G4double Pmin = Rindex->Energy(0);
+                G4double Pmax = Rindex->GetMaxEnergy();
+                G4double nMax = Rindex->GetMaxValue();
+                G4double beta1 = aStep->GetPreStepPoint()->GetBeta();
+                G4double beta2 = aStep->GetPostStepPoint()->GetBeta();
+                G4double beta = (beta1 + beta2) * 0.5;
+                G4double BetaInverse = 1. / beta;
+                G4double maxCos = BetaInverse / nMax;
+                G4double maxSin2 = (1.0 - maxCos) * (1.0 + maxCos);
+                G4double mean1 = proc->GetAverageNumberOfPhotons(charge, beta1, mat, Rindex);
+                G4double mean2 = proc->GetAverageNumberOfPhotons(charge, beta2, mat, Rindex);
+
+                if (fGPUTaskMgr)
+                {
+                    const G4Event *ev = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+                    if (!ev)
+                        return;
+                    quad6 gs = MakeGenstep_Cerenkov(track, aStep, numPhotons, BetaInverse,
+                                                   Pmin, Pmax, maxCos, maxSin2, mean1, mean2);
+                    fGPUTaskMgr->addGenstep(gs, numPhotons, ev->GetEventID());
+                }
+                else
+                {
+                    G4AutoLock lock(&genstep_mutex);
+                    U4::CollectGenstep_G4Cerenkov_modified(track, aStep, numPhotons, BetaInverse,
+                                                           Pmin, Pmax, maxCos, maxSin2, mean1, mean2);
+                }
+            }
+            else if (pname == "Scintillation")
+            {
+                G4Scintillation *proc = (G4Scintillation *)(*procPost)[i];
+                G4int numPhotons = proc->GetNumPhotons();
+                if (numPhotons <= 0)
+                    continue;
+
+                G4Track *track = aStep->GetTrack();
+                const G4Material *mat = track->GetMaterial();
+                G4MaterialPropertiesTable *MPT = mat->GetMaterialPropertiesTable();
+                if (!MPT || !MPT->ConstPropertyExists(kSCINTILLATIONTIMECONSTANT1))
+                    return;
+
+                const G4int tcKeys[3] = {kSCINTILLATIONTIMECONSTANT1, kSCINTILLATIONTIMECONSTANT2,
+                                         kSCINTILLATIONTIMECONSTANT3};
+                const G4int yieldKeys[3] = {kSCINTILLATIONYIELD1, kSCINTILLATIONYIELD2,
+                                            kSCINTILLATIONYIELD3};
+
+                G4double tc[3] = {0, 0, 0};
+                G4double yield[3] = {0, 0, 0};
+                G4double yieldSum = 0;
+                G4int nComp = 0;
+                for (G4int c = 0; c < 3; c++)
+                {
+                    if (MPT->ConstPropertyExists(tcKeys[c]))
+                    {
+                        tc[c] = MPT->GetConstProperty(tcKeys[c]);
+                        yield[c] = MPT->ConstPropertyExists(yieldKeys[c])
+                                       ? MPT->GetConstProperty(yieldKeys[c])
+                                       : (c == 0 ? 1.0 : 0.0);
+                        yieldSum += yield[c];
+                        nComp = c + 1;
+                    }
+                }
+
+                if (fGPUTaskMgr)
+                {
+                    const G4Event *ev = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+                    if (!ev)
+                        return;
+                    int eventid = ev->GetEventID();
+                    G4int remaining = numPhotons;
+                    for (G4int c = 0; c < nComp; c++)
+                    {
+                        G4int n = (c == nComp - 1)
+                                      ? remaining
+                                      : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        remaining -= n;
+                        if (n > 0)
+                        {
+                            quad6 gs = MakeGenstep_Scintillation(track, aStep, n, c + 1, tc[c]);
+                            fGPUTaskMgr->addGenstep(gs, n, eventid);
+                        }
+                    }
+                }
+                else
+                {
+                    G4AutoLock lock(&genstep_mutex);
+                    G4int remaining = numPhotons;
+                    for (G4int c = 0; c < nComp; c++)
+                    {
+                        G4int n = (c == nComp - 1)
+                                      ? remaining
+                                      : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
+                        remaining -= n;
+                        if (n > 0)
+                            U4::CollectGenstep_DsG4Scintillation_r4695(track, aStep, n, c + 1, tc[c]);
+                    }
+                }
+            }
+        }
+    }
+};
+
+// ============================================================================
+// Tracking action
+// ============================================================================
+
+struct TrackingAction : G4UserTrackingAction
+{
+    SEvt *sev;
+    TrackingAction(SEvt *sev) : sev(sev) {}
+
+    void PreUserTrackingAction(const G4Track *) override {}
+
+    void PostUserTrackingAction(const G4Track *) override {}
+};
+
+// ============================================================================
+// G4App — wires everything together
+// ============================================================================
+
+struct G4App
+{
+    SEvt *sev;
+    GPUTaskManager *gpu_task_mgr_;
+
+    G4VUserDetectorConstruction *det_cons_;
+    G4VUserPrimaryGeneratorAction *prim_gen_;
+    EventAction *event_act_;
+    RunAction *run_act_;
+    SteppingAction *stepping_;
+    TrackingAction *tracking_;
+
+    G4App(std::filesystem::path gdml_file, bool enable_async = true)
+        : sev(SEvt::CreateOrReuse_EGPU()),
+          gpu_task_mgr_(enable_async ? new GPUTaskManager() : nullptr),
+          det_cons_(new DetectorConstruction(gdml_file)),
+          prim_gen_(new PrimaryGenerator(sev)),
+          event_act_(new EventAction(sev)),
+          run_act_(new RunAction(event_act_, gpu_task_mgr_)),
+          stepping_(new SteppingAction(sev, gpu_task_mgr_)),
+          tracking_(new TrackingAction(sev))
+    {
+        if (gpu_task_mgr_)
+            G4cout << "G4App [std]: async GPU mode (threshold="
+                   << gpu_task_mgr_->getThreshold() << " photons)" << G4endl;
+        else
+            G4cout << "G4App [std]: sync GPU mode (end-of-run)" << G4endl;
+    }
+
+    ~G4App() { delete gpu_task_mgr_; }
+};

--- a/examples/async_gpu_std/run.mac
+++ b/examples/async_gpu_std/run.mac
@@ -1,0 +1,16 @@
+# run.mac — Geant4 macro for the async_gpu_std example.
+#
+# setStackPhotons false on both Cerenkov and Scintillation tells G4 not to
+# track the optical photons itself — they only flow through Opticks (which
+# is the entire point of this example).  Without this, G4 propagates each
+# optical photon on the CPU and per-event time is two orders of magnitude
+# higher.
+#
+# beamOn 100 produces ~24 M optical photons through the apex geometry,
+# enough work to make GPU vs CPU timing measurable.
+
+/run/verbose 1
+/run/initialize
+/process/optical/scintillation/setStackPhotons false
+/process/optical/cerenkov/setStackPhotons false
+/run/beamOn 100

--- a/examples/async_gpu_std/run.sh
+++ b/examples/async_gpu_std/run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# run.sh — run async_gpu_std example with apex.gdml
+#
+# Usage:
+#   ./run.sh [--sync]
+#   GPU_PHOTON_FLUSH_THRESHOLD=1000000 ./run.sh
+#   GPU_MAX_QUEUE_SIZE=2 ./run.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+GDML="${REPO_ROOT}/apex.gdml"
+MACRO="${REPO_ROOT}/tests/run.mac"
+MODE="${1:---async}"
+
+if [ ! -f "$GDML" ]; then
+    echo "ERROR: $GDML not found"
+    echo "Run from the eic-opticks root or ensure apex.gdml exists."
+    exit 1
+fi
+
+echo "=== async_gpu_std example (std-only worker thread) ==="
+echo "GDML:        $GDML"
+echo "Macro:       $MACRO"
+echo "Mode:        $MODE"
+echo "Threshold:   ${GPU_PHOTON_FLUSH_THRESHOLD:-10000000 (default)}"
+echo "Max queue:   ${GPU_MAX_QUEUE_SIZE:-3 (default)}"
+echo ""
+
+OPTICKS_MAX_BOUNCE=1000 \
+async_gpu_std \
+    -g "$GDML" \
+    -m "$MACRO" \
+    "$MODE"
+
+echo ""
+echo "=== Done ==="
+
+for f in gpu_hits*.npy g4_hits.npy; do
+    [ -f "$f" ] && echo "Output: $f ($(stat -c%s "$f") bytes)"
+done

--- a/examples/async_gpu_std/run.sh
+++ b/examples/async_gpu_std/run.sh
@@ -9,17 +9,17 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-GDML="${REPO_ROOT}/apex.gdml"
-MACRO="${REPO_ROOT}/tests/run.mac"
+GDML="${SCRIPT_DIR}/apex.gdml"
+MACRO="${SCRIPT_DIR}/run.mac"
 MODE="${1:---async}"
 
-if [ ! -f "$GDML" ]; then
-    echo "ERROR: $GDML not found"
-    echo "Run from the eic-opticks root or ensure apex.gdml exists."
-    exit 1
-fi
+for f in "$GDML" "$MACRO"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: $f not found"
+        exit 1
+    fi
+done
 
 echo "=== async_gpu_std example (std-only worker thread) ==="
 echo "GDML:        $GDML"


### PR DESCRIPTION
## Summary

  Adds `examples/async_gpu_std/`, a counterpart to `examples/async_gpu_launch` that demonstrates the same double-buffered async CPU+GPU optical photon pattern but **using only C++ stdlib primitives** _ no `G4TaskGroup`, no `G4Mutex`. The GPU worker is a plain `std::thread` driven by `std::mutex` +  `std::condition_variable` + a bounded `std::queue<GPUTask>`.

 ## What's in it

  | file | purpose |
  |---|---|
  | `async_gpu_std.h` | `GPUTaskManager` (worker thread, bounded queue, backpressure), Cerenkov + multi-component scintillation genstep paths, `PhotonSD`,
  sync/async `RunAction` |
  | `async_gpu_std.cpp` | `main()` with manual argv parsing, physics list, action initialization |
  | `CMakeLists.txt` | standalone `find_package(eic-opticks)` build (also pulls `glm` first to work around the missing `find_dependency(glm)` in the installed
   eic-opticks Config.cmake) |
  | `apex.gdml` | bundled detector geometry (no external references) |
  | `run.mac` | `setStackPhotons false` on Cerenkov + Scintillation, 100 beam-on events |
  | `run.sh` | reads inputs from the example dir; `--sync` / `--async` (default) flags |

  ## Architecture vs `async_gpu_launch`

  | concern | async_gpu_launch | async_gpu_std |
  |---|---|---|
  | worker thread | `G4TaskGroup<void,void>` | `std::thread` |
  | mutex | `G4Mutex` / `G4AutoLock` | `std::mutex` |
  | wakeups | implicit via task group | `std::condition_variable` |
  | queue | implicit | `std::queue<GPUTask>` (bounded) |
  | backpressure | none | `GPU_MAX_QUEUE_SIZE` (default 3) |

  Simulation behavior is otherwise identical _ Cerenkov + 3-component scintillation gensteps, sphoton `.npy` hit dumps per batch.