### PR TITLE
style: expand .clang-format with declaration alignment, pointer style, and loop formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,10 @@
 BasedOnStyle: Microsoft
-ColumnLimit: 0
-BreakTemplateDeclarations: MultiLine
-PackConstructorInitializers: Never
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+  AlignFunctionDeclarations: false
 BreakConstructorInitializers: AfterColon
+BreakTemplateDeclarations: MultiLine
+ColumnLimit: 0
+PackConstructorInitializers: Never

--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,9 @@ AlignConsecutiveDeclarations:
   AcrossEmptyLines: false
   AcrossComments: false
   AlignFunctionDeclarations: false
+AllowShortLoopsOnASingleLine: true
 BreakConstructorInitializers: AfterColon
 BreakTemplateDeclarations: MultiLine
 ColumnLimit: 0
 PackConstructorInitializers: Never
+PointerAlignment: Left


### PR DESCRIPTION
Expands `.clang-format` with three new formatting rules and reorders all keys alphabetically.

**New rules**

- `AlignConsecutiveDeclarations` — enabled with `AcrossEmptyLines: false`, `AcrossComments: false`, and `AlignFunctionDeclarations: false`. Aligns the names in consecutive variable/member declarations without crossing blank lines, comments, or function signatures.
- `AllowShortLoopsOnASingleLine: true` — permits simple `for`/`while` loops to stay on one line.
- `PointerAlignment: Left` — attaches `*` and `&` to the type rather than the variable name (e.g. `int* p` instead of `int *p`).

**Housekeeping**

`BreakConstructorInitializers: AfterColon` was already present; this PR moves it to its correct alphabetical position. No behavior changes for any pre-existing rule.