### PR TITLE
chore(devcontainer): install clang-format, clangd, and clang-tidy

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,11 @@
       "ghcr.io/bnlnpps/eic-opticks:base"
     ]
   },
+  "features": {
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "clang-format-20,clangd-20,clang-tidy-20"
+    }
+  },
   "remoteEnv": {
     "CODEX_HOME": "${containerWorkspaceFolder}/.codex"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,9 +13,7 @@
     ]
   },
   "features": {
-    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-      "packages": "clang-format-20,clangd-20,clang-tidy-20"
-    }
+    "./features/llvm": {}
   },
   "remoteEnv": {
     "CODEX_HOME": "${containerWorkspaceFolder}/.codex"

--- a/.devcontainer/features/llvm/devcontainer-feature.json
+++ b/.devcontainer/features/llvm/devcontainer-feature.json
@@ -1,0 +1,16 @@
+{
+  "name": "LLVM Toolchain",
+  "id": "llvm",
+  "version": "1.0.0",
+  "description": "Installs LLVM toolchain packages (clang-format, clangd, clang-tidy) from the official LLVM APT repository",
+  "options": {
+    "version": {
+      "type": "string",
+      "default": "latest",
+      "description": "LLVM version to install, e.g. 18, 20, 23, or latest."
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
+}

--- a/.devcontainer/features/llvm/install.sh
+++ b/.devcontainer/features/llvm/install.sh
@@ -17,14 +17,9 @@ install -d -m 0755 /etc/apt/keyrings
 
 wget -qO /etc/apt/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
 
-if [ "${LLVM_REQUESTED_VERSION}" = "latest" ] || [ -z "${LLVM_REQUESTED_VERSION}" ]; then
-    LLVM_APT_SUITE="llvm-toolchain-${VERSION_CODENAME}"
-else
-    LLVM_APT_SUITE="llvm-toolchain-${VERSION_CODENAME}-${LLVM_REQUESTED_VERSION}"
-fi
-
+# Use the generic apt.llvm.org suite.
 cat > /etc/apt/sources.list.d/llvm.list <<EOF
-deb [signed-by=/etc/apt/keyrings/apt.llvm.org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ ${LLVM_APT_SUITE} main
+deb [signed-by=/etc/apt/keyrings/apt.llvm.org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME} main
 EOF
 
 apt-get update -y

--- a/.devcontainer/features/llvm/install.sh
+++ b/.devcontainer/features/llvm/install.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+# Devcontainer feature option:
+# "version" in devcontainer-feature.json becomes VERSION here.
+LLVM_REQUESTED_VERSION="${VERSION:-latest}"
+
+. /etc/os-release
+
+apt-get update -y
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    gnupg \
+    wget
+
+install -d -m 0755 /etc/apt/keyrings
+
+wget -qO /etc/apt/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
+
+# Use the generic apt.llvm.org suite.
+cat > /etc/apt/sources.list.d/llvm.list <<EOF
+deb [signed-by=/etc/apt/keyrings/apt.llvm.org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME} main
+EOF
+
+apt-get update -y
+
+if [ "${LLVM_REQUESTED_VERSION}" = "latest" ] || [ -z "${LLVM_REQUESTED_VERSION}" ]; then
+    LLVM_VERSION="$(
+        apt-cache search '^clang-format-[0-9]+$' \
+            | awk '{print $1}' \
+            | sed 's/^clang-format-//' \
+            | sort -V \
+            | tail -n 1
+    )"
+
+    if [ -z "${LLVM_VERSION}" ]; then
+        echo "ERROR: Could not determine latest available LLVM version." >&2
+        exit 1
+    fi
+else
+    LLVM_VERSION="${LLVM_REQUESTED_VERSION}"
+fi
+
+echo "Using LLVM version: ${LLVM_VERSION}"
+
+apt-get install -y --no-install-recommends \
+    clang-format-${LLVM_VERSION} \
+    clangd-${LLVM_VERSION} \
+    clang-tidy-${LLVM_VERSION}
+
+ln -sf /usr/bin/clang-format-${LLVM_VERSION} /usr/local/bin/clang-format
+ln -sf /usr/bin/clangd-${LLVM_VERSION} /usr/local/bin/clangd
+ln -sf /usr/bin/clang-tidy-${LLVM_VERSION} /usr/local/bin/clang-tidy
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/features/llvm/install.sh
+++ b/.devcontainer/features/llvm/install.sh
@@ -17,9 +17,14 @@ install -d -m 0755 /etc/apt/keyrings
 
 wget -qO /etc/apt/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key
 
-# Use the generic apt.llvm.org suite.
+if [ "${LLVM_REQUESTED_VERSION}" = "latest" ] || [ -z "${LLVM_REQUESTED_VERSION}" ]; then
+    LLVM_APT_SUITE="llvm-toolchain-${VERSION_CODENAME}"
+else
+    LLVM_APT_SUITE="llvm-toolchain-${VERSION_CODENAME}-${LLVM_REQUESTED_VERSION}"
+fi
+
 cat > /etc/apt/sources.list.d/llvm.list <<EOF
-deb [signed-by=/etc/apt/keyrings/apt.llvm.org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ llvm-toolchain-${VERSION_CODENAME} main
+deb [signed-by=/etc/apt/keyrings/apt.llvm.org.asc] https://apt.llvm.org/${VERSION_CODENAME}/ ${LLVM_APT_SUITE} main
 EOF
 
 apt-get update -y


### PR DESCRIPTION
Adds a local devcontainer Feature (.devcontainer/features/llvm) intended to install LLVM C/C++ tooling (clang-format, clangd, clang-tidy) via the official apt.llvm.org APT repository, and wires it into the repo’s devcontainer configuration for out-of-the-box tooling availability.
