### PR TITLE
feat(config): route SEvt output directory through app config

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -25,6 +25,7 @@
 
   "event": {
     "mode": "DebugLite",
-    "maxslot": 1000000
+    "maxslot": 1000000,
+    "output_dir": "/tmp"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,6 +26,6 @@
   "event": {
     "mode": "DebugLite",
     "maxslot": 1000000,
-    "output_dir": "/tmp"
+    "output_dir": "./"
   }
 }

--- a/src/GPUCerenkov.cpp
+++ b/src/GPUCerenkov.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    gphox::Config cfg(config_name);
+    gphox::Config(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPUCerenkov.cpp
+++ b/src/GPUCerenkov.cpp
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    gphox::Config(config_name);
+    gphox::Config{config_name};
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPUCerenkov.cpp
+++ b/src/GPUCerenkov.cpp
@@ -13,6 +13,7 @@
 #include "sysrap/OPTICKS_LOG.hh"
 
 #include "GPUCerenkov.h"
+#include "config.h"
 
 #include "G4RunManager.hh"
 #include "G4RunManagerFactory.hh"
@@ -56,7 +57,7 @@ int main(int argc, char **argv)
 
     argparse::ArgumentParser program("GPUCerenkov", "0.0.0");
 
-    string gdml_file, macro_name;
+    string gdml_file, config_name, macro_name;
     bool interactive;
 
     program.add_argument("-g", "--gdml")
@@ -64,6 +65,12 @@ int main(int argc, char **argv)
         .default_value(string("geom.gdml"))
         .nargs(1)
         .store_into(gdml_file);
+
+    program.add_argument("-c", "--config")
+        .help("the name of a config file")
+        .default_value(string("dev"))
+        .nargs(1)
+        .store_into(config_name);
 
     program.add_argument("-m", "--macro")
         .help("path to G4 macro")
@@ -86,6 +93,8 @@ int main(int argc, char **argv)
         cerr << program;
         exit(EXIT_FAILURE);
     }
+
+    gphox::Config cfg(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPUPhotonFileSource.cpp
+++ b/src/GPUPhotonFileSource.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
 
-    gphox::Config cfg(config_name);
+    gphox::Config(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPUPhotonFileSource.cpp
+++ b/src/GPUPhotonFileSource.cpp
@@ -14,6 +14,7 @@
 #include "sysrap/OPTICKS_LOG.hh"
 
 #include "GPUPhotonFileSource.h"
+#include "config.h"
 
 using namespace std;
 
@@ -23,7 +24,7 @@ int main(int argc, char **argv)
 
     argparse::ArgumentParser program("GPUPhotonFileSource", "0.0.0");
 
-    string gdml_file, macro_name, photon_file;
+    string gdml_file, config_name, macro_name, photon_file;
     bool interactive;
 
     program.add_argument("-g", "--gdml")
@@ -31,6 +32,12 @@ int main(int argc, char **argv)
         .default_value(string("geom.gdml"))
         .nargs(1)
         .store_into(gdml_file);
+
+    program.add_argument("-c", "--config")
+        .help("the name of a config file")
+        .default_value(string("dev"))
+        .nargs(1)
+        .store_into(config_name);
 
     program.add_argument("-p", "--photons")
         .help("path to input photon text file (one photon per line: pos_x pos_y pos_z time mom_x mom_y mom_z pol_x "
@@ -74,6 +81,8 @@ int main(int argc, char **argv)
     }
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
+
+    gphox::Config cfg(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPUPhotonFileSource.cpp
+++ b/src/GPUPhotonFileSource.cpp
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
 
-    gphox::Config(config_name);
+    gphox::Config{config_name};
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPURaytrace.cpp
+++ b/src/GPURaytrace.cpp
@@ -13,6 +13,7 @@
 #include "sysrap/OPTICKS_LOG.hh"
 
 #include "GPURaytrace.h"
+#include "config.h"
 
 #include "G4RunManager.hh"
 #include "G4RunManagerFactory.hh"
@@ -53,7 +54,7 @@ int main(int argc, char **argv)
 
     argparse::ArgumentParser program("GPURaytrace", "0.0.0");
 
-    string gdml_file, macro_name;
+    string gdml_file, config_name, macro_name;
     bool interactive;
 
     program.add_argument("-g", "--gdml")
@@ -61,6 +62,12 @@ int main(int argc, char **argv)
         .default_value(string("geom.gdml"))
         .nargs(1)
         .store_into(gdml_file);
+
+    program.add_argument("-c", "--config")
+        .help("the name of a config file")
+        .default_value(string("dev"))
+        .nargs(1)
+        .store_into(config_name);
 
     program.add_argument("-m", "--macro")
         .help("path to G4 macro")
@@ -97,6 +104,8 @@ int main(int argc, char **argv)
     }
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
+
+    gphox::Config cfg(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPURaytrace.cpp
+++ b/src/GPURaytrace.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
 
-    gphox::Config cfg(config_name);
+    gphox::Config(config_name);
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/GPURaytrace.cpp
+++ b/src/GPURaytrace.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     CLHEP::HepRandom::setTheSeed(seed);
     G4cout << "Random seed set to: " << seed << G4endl;
 
-    gphox::Config(config_name);
+    gphox::Config{config_name};
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,8 +1,13 @@
+#include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <ranges>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <sys/stat.h>
 #include <vector>
 
@@ -20,6 +25,38 @@ using namespace std;
 
 constexpr const char *GPHOX_PTX_PATH_ENV = "CSGOptiX__optixpath";
 
+namespace
+{
+
+struct EventModeInfo
+{
+    EventMode        mode;
+    std::string_view name;
+};
+
+inline constexpr std::array EventModeInfos{
+    EventModeInfo{EventMode::DebugHeavy, "DebugHeavy"},
+    EventModeInfo{EventMode::DebugLite, "DebugLite"},
+    EventModeInfo{EventMode::Nothing, "Nothing"},
+    EventModeInfo{EventMode::Minimal, "Minimal"},
+    EventModeInfo{EventMode::Hit, "Hit"},
+    EventModeInfo{EventMode::HitPhoton, "HitPhoton"},
+    EventModeInfo{EventMode::HitPhotonSeq, "HitPhotonSeq"},
+    EventModeInfo{EventMode::HitSeq, "HitSeq"},
+};
+
+auto FindEventMode(EventMode mode)
+{
+    return std::ranges::find(EventModeInfos, mode, &EventModeInfo::mode);
+}
+
+auto FindEventMode(std::string_view name)
+{
+    return std::ranges::find(EventModeInfos, name, &EventModeInfo::name);
+}
+
+} // namespace
+
 bool FileExists(const std::string &path)
 {
     if (path.empty())
@@ -28,10 +65,27 @@ bool FileExists(const std::string &path)
     return std::filesystem::exists(path, ec) && !ec;
 }
 
+std::filesystem::path Config::DefaultOutputDir()
+{
+    return std::filesystem::current_path();
+}
+
+std::filesystem::path ReadOutputDir(const nlohmann::json& event)
+{
+    if (event.contains("output_dir"))
+        return event["output_dir"].get<std::string>();
+
+    return Config::DefaultOutputDir();
+}
+
 Config::Config(std::string config_name) :
-  name{std::getenv("GPHOX_CONFIG") ? std::getenv("GPHOX_CONFIG") : config_name}
+    name{config_name},
+    event_mode{EventMode::Minimal},
+    maxslot{0},
+    output_dir{DefaultOutputDir()}
 {
   ReadConfig(Locate(name + ".json"));
+  Apply();
 }
 
 std::string Config::PtxPath(const std::string &ptx_name)
@@ -99,6 +153,36 @@ std::string Config::Locate(std::string filename) const
   return filepath;
 }
 
+EventMode Config::ParseEventMode(std::string_view name)
+{
+    const auto it = FindEventMode(name);
+    if (it != EventModeInfos.end())
+        return it->mode;
+
+    throw std::invalid_argument(
+        "Invalid event.mode \"" + std::string{name} + "\". Expected one of: " + ValidEventModes());
+}
+
+std::string Config::ValidEventModes()
+{
+    std::string names;
+    for (const auto& info : EventModeInfos)
+    {
+        if (!names.empty())
+            names += ", ";
+        names += info.name;
+    }
+    return names;
+}
+
+std::string_view Config::EventModeName(EventMode mode)
+{
+    const auto it = FindEventMode(mode);
+    if (it != EventModeInfos.end())
+        return it->name;
+
+    return "Minimal";
+}
 
 /**
  * Expects a valid filepath.
@@ -111,36 +195,53 @@ void Config::ReadConfig(std::string filepath)
     std::ifstream ifs(filepath);
     ifs >> json;
 
-    nlohmann::json torch_ = json["torch"];
+    if (json.contains("torch"))
+    {
+        nlohmann::json torch_ = json["torch"];
 
-    torch = {
-      .gentype = OpticksGenstep_::Type(torch_["gentype"]),
-      .trackid = torch_["trackid"],
-      .matline = torch_["matline"],
-      .numphoton = torch_["numphoton"],
-      .pos = make_float3(torch_["pos"][0], torch_["pos"][1], torch_["pos"][2]),
-      .time = torch_["time"],
-      .mom = normalize(make_float3(torch_["mom"][0], torch_["mom"][1], torch_["mom"][2])),
-      .weight = torch_["weight"],
-      .pol = make_float3(torch_["pol"][0], torch_["pol"][1], torch_["pol"][2]),
-      .wavelength = torch_["wavelength"],
-      .zenith = make_float2(torch_["zenith"][0], torch_["zenith"][1]),
-      .azimuth = make_float2(torch_["azimuth"][0], torch_["azimuth"][1]),
-      .radius = torch_["radius"],
-      .distance = torch_["distance"],
-      .mode = torch_["mode"],
-      .type = storchtype::Type(torch_["type"])
-    };
+        torch = {
+            .gentype = OpticksGenstep_::Type(torch_["gentype"]),
+            .trackid = torch_["trackid"],
+            .matline = torch_["matline"],
+            .numphoton = torch_["numphoton"],
+            .pos = make_float3(torch_["pos"][0], torch_["pos"][1], torch_["pos"][2]),
+            .time = torch_["time"],
+            .mom = normalize(make_float3(torch_["mom"][0], torch_["mom"][1], torch_["mom"][2])),
+            .weight = torch_["weight"],
+            .pol = make_float3(torch_["pol"][0], torch_["pol"][1], torch_["pol"][2]),
+            .wavelength = torch_["wavelength"],
+            .zenith = make_float2(torch_["zenith"][0], torch_["zenith"][1]),
+            .azimuth = make_float2(torch_["azimuth"][0], torch_["azimuth"][1]),
+            .radius = torch_["radius"],
+            .distance = torch_["distance"],
+            .mode = torch_["mode"],
+            .type = storchtype::Type(torch_["type"])};
+    }
 
     nlohmann::json event_ = json["event"];
 
-    SEventConfig::SetEventMode( string(event_["mode"]).c_str() );
-    SEventConfig::SetMaxSlot( event_["maxslot"] );
+    event_mode = ParseEventMode(event_["mode"].get<std::string>());
+    maxslot = event_["maxslot"].get<int>();
+    output_dir = ReadOutputDir(event_);
   }
   catch (nlohmann::json::exception& e) {
     std::string errmsg{"Failed reading config parameters from " + filepath + "\n" + e.what()};
     throw std::runtime_error{errmsg};
   }
+  catch (std::exception& e)
+  {
+      std::string errmsg{"Failed reading config parameters from " + filepath + "\n" + e.what()};
+      throw std::runtime_error{errmsg};
+  }
 }
 
+void Config::Apply() const
+{
+    const std::string event_mode_name{EventModeName(event_mode)};
+    const std::string output_dir_str = output_dir.string();
+
+    SEventConfig::SetEventMode(event_mode_name.c_str());
+    SEventConfig::SetMaxSlot(maxslot);
+    SEventConfig::SetOutFold(output_dir_str.c_str());
+}
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -56,8 +56,6 @@ auto FindEventMode(std::string_view name)
     return std::ranges::find(EventModeInfos, name, &EventModeInfo::name);
 }
 
-} // namespace
-
 bool FileExists(const std::string& path)
 {
     if (path.empty())
@@ -66,9 +64,37 @@ bool FileExists(const std::string& path)
     return std::filesystem::exists(path, ec) && !ec;
 }
 
-std::filesystem::path Config::DefaultOutputDir()
+std::string ValidEventModes()
 {
-    return std::filesystem::current_path();
+    std::string names;
+    for (const auto& info : EventModeInfos)
+    {
+        if (!names.empty())
+            names += ", ";
+        names += info.name;
+    }
+    return names;
+}
+
+std::string_view EventModeName(EventMode mode)
+{
+    const auto it = FindEventMode(mode);
+    if (it != EventModeInfos.end())
+        return it->name;
+
+    return "Minimal";
+}
+
+EventMode ReadEventMode(const nlohmann::json& event)
+{
+    std::string name = event["mode"].get<std::string>();
+
+    const auto it = FindEventMode(name);
+    if (it != EventModeInfos.end())
+        return it->mode;
+
+    throw std::invalid_argument{
+        "Invalid event.mode \"" + std::string{name} + "\". Expected one of: " + ValidEventModes()};
 }
 
 std::filesystem::path ReadOutputDir(const nlohmann::json& event)
@@ -76,14 +102,16 @@ std::filesystem::path ReadOutputDir(const nlohmann::json& event)
     if (event.contains("output_dir"))
         return event["output_dir"].get<std::string>();
 
-    return Config::DefaultOutputDir();
+    return std::filesystem::current_path();
 }
+
+} // namespace
 
 Config::Config(std::string config_name) :
     name{config_name},
     event_mode{EventMode::Minimal},
     maxslot{0},
-    output_dir{DefaultOutputDir()},
+    output_dir{std::filesystem::current_path()},
     torch{}
 {
     ReadConfig(Locate(name + ".json"));
@@ -155,37 +183,6 @@ std::string Config::Locate(std::string filename) const
     return filepath;
 }
 
-EventMode Config::ParseEventMode(std::string_view name)
-{
-    const auto it = FindEventMode(name);
-    if (it != EventModeInfos.end())
-        return it->mode;
-
-    throw std::invalid_argument(
-        "Invalid event.mode \"" + std::string{name} + "\". Expected one of: " + ValidEventModes());
-}
-
-std::string Config::ValidEventModes()
-{
-    std::string names;
-    for (const auto& info : EventModeInfos)
-    {
-        if (!names.empty())
-            names += ", ";
-        names += info.name;
-    }
-    return names;
-}
-
-std::string_view Config::EventModeName(EventMode mode)
-{
-    const auto it = FindEventMode(mode);
-    if (it != EventModeInfos.end())
-        return it->name;
-
-    return "Minimal";
-}
-
 /**
  * Expects a valid filepath.
  */
@@ -223,7 +220,7 @@ void Config::ReadConfig(std::string filepath)
 
         nlohmann::json event_ = json["event"];
 
-        event_mode = ParseEventMode(event_["mode"].get<std::string>());
+        event_mode = ReadEventMode(event_);
         maxslot = event_["maxslot"].get<int>();
         output_dir = ReadOutputDir(event_);
     }
@@ -246,4 +243,5 @@ void Config::Apply() const
     SEventConfig::SetMaxSlot(maxslot);
     SEventConfig::SetOutFold(output_dir_str.c_str());
 }
+
 } // namespace gphox

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,19 +11,20 @@
 #include <sys/stat.h>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include <cuda_runtime.h>
+#include <nlohmann/json.hpp>
 
 #include "sysrap/SEventConfig.hh"
 
 #include "config.h"
 #include "config_path.h"
 
-namespace gphox {
+namespace gphox
+{
 
 using namespace std;
 
-constexpr const char *GPHOX_PTX_PATH_ENV = "CSGOptiX__optixpath";
+constexpr const char* GPHOX_PTX_PATH_ENV = "CSGOptiX__optixpath";
 
 namespace
 {
@@ -57,7 +58,7 @@ auto FindEventMode(std::string_view name)
 
 } // namespace
 
-bool FileExists(const std::string &path)
+bool FileExists(const std::string& path)
 {
     if (path.empty())
         return false;
@@ -85,13 +86,13 @@ Config::Config(std::string config_name) :
     output_dir{DefaultOutputDir()},
     torch{}
 {
-  ReadConfig(Locate(name + ".json"));
-  Apply();
+    ReadConfig(Locate(name + ".json"));
+    Apply();
 }
 
-std::string Config::PtxPath(const std::string &ptx_name)
+std::string Config::PtxPath(const std::string& ptx_name)
 {
-    const char *env_path = std::getenv(GPHOX_PTX_PATH_ENV);
+    const char* env_path = std::getenv(GPHOX_PTX_PATH_ENV);
     if (env_path && FileExists(env_path))
         return env_path;
 
@@ -109,49 +110,49 @@ std::string Config::PtxPath(const std::string &ptx_name)
 
 std::string Config::Locate(std::string filename) const
 {
-  std::vector<std::string> search_paths;
+    std::vector<std::string> search_paths;
 
-  const std::string user_dir{std::getenv("GPHOX_CONFIG_DIR") ? std::getenv("GPHOX_CONFIG_DIR") : ""};
+    const std::string user_dir{std::getenv("GPHOX_CONFIG_DIR") ? std::getenv("GPHOX_CONFIG_DIR") : ""};
 
-  if (user_dir.empty())
-  {
-    std::string paths(GPHOX_CONFIG_SEARCH_PATHS);
-
-    size_t last = 0;
-    size_t next = 0;
-    while ((next = paths.find(':', last)) != std::string::npos)
+    if (user_dir.empty())
     {
-      search_paths.push_back(paths.substr(last, next-last));
-      last = next + 1;
+        std::string paths(GPHOX_CONFIG_SEARCH_PATHS);
+
+        size_t last = 0;
+        size_t next = 0;
+        while ((next = paths.find(':', last)) != std::string::npos)
+        {
+            search_paths.push_back(paths.substr(last, next - last));
+            last = next + 1;
+        }
+
+        search_paths.push_back(paths.substr(last));
+    }
+    else
+    {
+        search_paths.push_back(user_dir);
     }
 
-    search_paths.push_back(paths.substr(last));
-  }
-  else
-  {
-    search_paths.push_back(user_dir);
-  }
-
-  struct stat buffer;
-  std::string filepath{""};
-  for (std::string path : search_paths)
-  {
-    std::string fpath{path + "/" + filename};
-    if (stat(fpath.c_str(), &buffer) == 0)
+    struct stat buffer;
+    std::string filepath{""};
+    for (std::string path : search_paths)
     {
-      filepath = fpath;
-      break;
+        std::string fpath{path + "/" + filename};
+        if (stat(fpath.c_str(), &buffer) == 0)
+        {
+            filepath = fpath;
+            break;
+        }
     }
-  }
 
-  if (filepath.empty())
-  {
-    std::string errmsg{"Could not find config file \"" + filename + "\" in "};
-    for (std::string path : search_paths) errmsg += (path + ":");
-    throw std::runtime_error(errmsg);
-  }
+    if (filepath.empty())
+    {
+        std::string errmsg{"Could not find config file \"" + filename + "\" in "};
+        for (std::string path : search_paths) errmsg += (path + ":");
+        throw std::runtime_error(errmsg);
+    }
 
-  return filepath;
+    return filepath;
 }
 
 EventMode Config::ParseEventMode(std::string_view name)
@@ -190,49 +191,50 @@ std::string_view Config::EventModeName(EventMode mode)
  */
 void Config::ReadConfig(std::string filepath)
 {
-  nlohmann::json json;
+    nlohmann::json json;
 
-  try {
-    std::ifstream ifs(filepath);
-    ifs >> json;
-
-    if (json.contains("torch"))
+    try
     {
-        nlohmann::json torch_ = json["torch"];
+        std::ifstream ifs(filepath);
+        ifs >> json;
 
-        torch = {
-            .gentype = OpticksGenstep_::Type(torch_["gentype"]),
-            .trackid = torch_["trackid"],
-            .matline = torch_["matline"],
-            .numphoton = torch_["numphoton"],
-            .pos = make_float3(torch_["pos"][0], torch_["pos"][1], torch_["pos"][2]),
-            .time = torch_["time"],
-            .mom = normalize(make_float3(torch_["mom"][0], torch_["mom"][1], torch_["mom"][2])),
-            .weight = torch_["weight"],
-            .pol = make_float3(torch_["pol"][0], torch_["pol"][1], torch_["pol"][2]),
-            .wavelength = torch_["wavelength"],
-            .zenith = make_float2(torch_["zenith"][0], torch_["zenith"][1]),
-            .azimuth = make_float2(torch_["azimuth"][0], torch_["azimuth"][1]),
-            .radius = torch_["radius"],
-            .distance = torch_["distance"],
-            .mode = torch_["mode"],
-            .type = storchtype::Type(torch_["type"])};
+        if (json.contains("torch"))
+        {
+            nlohmann::json torch_ = json["torch"];
+
+            torch = {
+                .gentype = OpticksGenstep_::Type(torch_["gentype"]),
+                .trackid = torch_["trackid"],
+                .matline = torch_["matline"],
+                .numphoton = torch_["numphoton"],
+                .pos = make_float3(torch_["pos"][0], torch_["pos"][1], torch_["pos"][2]),
+                .time = torch_["time"],
+                .mom = normalize(make_float3(torch_["mom"][0], torch_["mom"][1], torch_["mom"][2])),
+                .weight = torch_["weight"],
+                .pol = make_float3(torch_["pol"][0], torch_["pol"][1], torch_["pol"][2]),
+                .wavelength = torch_["wavelength"],
+                .zenith = make_float2(torch_["zenith"][0], torch_["zenith"][1]),
+                .azimuth = make_float2(torch_["azimuth"][0], torch_["azimuth"][1]),
+                .radius = torch_["radius"],
+                .distance = torch_["distance"],
+                .mode = torch_["mode"],
+                .type = storchtype::Type(torch_["type"])};
+        }
+
+        nlohmann::json event_ = json["event"];
+
+        event_mode = ParseEventMode(event_["mode"].get<std::string>());
+        maxslot = event_["maxslot"].get<int>();
+        output_dir = ReadOutputDir(event_);
     }
-
-    nlohmann::json event_ = json["event"];
-
-    event_mode = ParseEventMode(event_["mode"].get<std::string>());
-    maxslot = event_["maxslot"].get<int>();
-    output_dir = ReadOutputDir(event_);
-  }
-  catch (nlohmann::json::exception& e)
-  {
-      throw std::runtime_error{"Failed reading config parameters from " + filepath + "\n" + e.what()};
-  }
-  catch (std::invalid_argument& e)
-  {
-      throw std::runtime_error{"Invalid config value in " + filepath + "\n" + e.what()};
-  }
+    catch (nlohmann::json::exception& e)
+    {
+        throw std::runtime_error{"Failed reading config parameters from " + filepath + "\n" + e.what()};
+    }
+    catch (std::invalid_argument& e)
+    {
+        throw std::runtime_error{"Invalid config value in " + filepath + "\n" + e.what()};
+    }
 }
 
 void Config::Apply() const
@@ -244,4 +246,4 @@ void Config::Apply() const
     SEventConfig::SetMaxSlot(maxslot);
     SEventConfig::SetOutFold(output_dir_str.c_str());
 }
-}
+} // namespace gphox

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -225,14 +225,13 @@ void Config::ReadConfig(std::string filepath)
     maxslot = event_["maxslot"].get<int>();
     output_dir = ReadOutputDir(event_);
   }
-  catch (nlohmann::json::exception& e) {
-    std::string errmsg{"Failed reading config parameters from " + filepath + "\n" + e.what()};
-    throw std::runtime_error{errmsg};
-  }
-  catch (std::exception& e)
+  catch (nlohmann::json::exception& e)
   {
-      std::string errmsg{"Failed reading config parameters from " + filepath + "\n" + e.what()};
-      throw std::runtime_error{errmsg};
+      throw std::runtime_error{"Failed reading config parameters from " + filepath + "\n" + e.what()};
+  }
+  catch (std::invalid_argument& e)
+  {
+      throw std::runtime_error{"Invalid config value in " + filepath + "\n" + e.what()};
   }
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -82,7 +82,8 @@ Config::Config(std::string config_name) :
     name{config_name},
     event_mode{EventMode::Minimal},
     maxslot{0},
-    output_dir{DefaultOutputDir()}
+    output_dir{DefaultOutputDir()},
+    torch{}
 {
   ReadConfig(Locate(name + ".json"));
   Apply();

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "sysrap/srng.h"
@@ -9,9 +10,24 @@
 
 namespace gphox {
 
+enum class EventMode
+{
+    DebugHeavy,
+    DebugLite,
+    Nothing,
+    Minimal,
+    Hit,
+    HitPhoton,
+    HitPhotonSeq,
+    HitSeq
+};
 
 /**
  * Provides access to all configuration types and data.
+ *
+ * Config is the authoritative source for app-level event output policy.
+ * Lower-level Opticks code still consumes this through SEventConfig after
+ * Config::Apply has synchronized the selected values.
  */
 class Config
 {
@@ -19,10 +35,25 @@ class Config
 
   Config(std::string config_name = "dev");
 
+  void Apply() const;
+
+  static std::filesystem::path DefaultOutputDir();
+  static EventMode ParseEventMode(std::string_view name);
+  static std::string ValidEventModes();
+  static std::string_view EventModeName(EventMode mode);
   static std::string PtxPath(const std::string &ptx_name = "CSGOptiX7.ptx");
 
   /// A unique name associated with this Config
   std::string name;
+
+  /// Event persistence mode applied to SEventConfig.
+  EventMode event_mode;
+
+  /// Maximum event slots applied to SEventConfig.
+  int maxslot;
+
+  /// Base directory for event output folders.
+  std::filesystem::path output_dir;
 
   storch torch;
 

--- a/src/config.h
+++ b/src/config.h
@@ -8,7 +8,8 @@
 #include "sysrap/srng.h"
 #include "sysrap/storch.h"
 
-namespace gphox {
+namespace gphox
+{
 
 enum class EventMode
 {
@@ -31,36 +32,34 @@ enum class EventMode
  */
 class Config
 {
- public:
+  public:
+    Config(std::string config_name = "dev");
 
-  Config(std::string config_name = "dev");
+    void Apply() const;
 
-  void Apply() const;
+    static std::filesystem::path DefaultOutputDir();
+    static EventMode ParseEventMode(std::string_view name);
+    static std::string ValidEventModes();
+    static std::string_view EventModeName(EventMode mode);
+    static std::string PtxPath(const std::string& ptx_name = "CSGOptiX7.ptx");
 
-  static std::filesystem::path DefaultOutputDir();
-  static EventMode ParseEventMode(std::string_view name);
-  static std::string ValidEventModes();
-  static std::string_view EventModeName(EventMode mode);
-  static std::string PtxPath(const std::string &ptx_name = "CSGOptiX7.ptx");
+    /// A unique name associated with this Config
+    std::string name;
 
-  /// A unique name associated with this Config
-  std::string name;
+    /// Event persistence mode applied to SEventConfig.
+    EventMode event_mode;
 
-  /// Event persistence mode applied to SEventConfig.
-  EventMode event_mode;
+    /// Maximum event slots applied to SEventConfig.
+    int maxslot;
 
-  /// Maximum event slots applied to SEventConfig.
-  int maxslot;
+    /// Base directory for event output folders.
+    std::filesystem::path output_dir;
 
-  /// Base directory for event output folders.
-  std::filesystem::path output_dir;
+    storch torch;
 
-  storch torch;
-
- private:
-
-  std::string Locate(std::string filename) const;
-  void ReadConfig(std::string filepath);
+  private:
+    std::string Locate(std::string filename) const;
+    void ReadConfig(std::string filepath);
 };
 
-}
+} // namespace gphox

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,6 @@
 
 #include <filesystem>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "sysrap/srng.h"
@@ -35,12 +34,6 @@ class Config
   public:
     Config(std::string config_name = "dev");
 
-    void Apply() const;
-
-    static std::filesystem::path DefaultOutputDir();
-    static EventMode ParseEventMode(std::string_view name);
-    static std::string ValidEventModes();
-    static std::string_view EventModeName(EventMode mode);
     static std::string PtxPath(const std::string& ptx_name = "CSGOptiX7.ptx");
 
     /// A unique name associated with this Config
@@ -60,6 +53,7 @@ class Config
   private:
     std::string Locate(std::string filename) const;
     void ReadConfig(std::string filepath);
+    void Apply() const;
 };
 
 } // namespace gphox

--- a/sysrap/SEvt.cc
+++ b/sysrap/SEvt.cc
@@ -4224,13 +4224,13 @@ bool SEvt::hasInstance() const
     return instance != MISSING_INSTANCE ;
 }
 
-
 /**
 SEvt::DefaultBase
 -------------------
 
 If argument is defined it is used, otherwise::
 
+   Config-applied SEventConfig::OutFold() when explicitly overridden, otherwise
    $TMP/GEOM/$GEOM/$ExecutableName
 
 Note that when Opticks is used from python the OPTICKS_SCRIPT
@@ -4242,11 +4242,27 @@ ExecutableName of "python3.11" or whatever.
 const char* SEvt::DefaultBase(const char* base_) // static
 {
     const char* base = nullptr ;
+    const char* outfold = SEventConfig::OutFold();
+
+    bool use_outfold =
+        base_ == nullptr &&
+        outfold != nullptr &&
+        strcmp(outfold, SEventConfig::_OutFoldDefault) != 0;
+
     int64_t mode_save = SEventConfig::ModeSave();
-    if( mode_save == 0 )
+    if (base_ != nullptr)
+    {
+        base = base_;
+    }
+    else if (use_outfold)
+    {
+        // Honor explicit OutFold overrides from config/env for SEvt event folders.
+        base = outfold;
+    }
+    else if (mode_save == 0)
     {
         // controlled dir approach : good for campaigns
-        base = base_ ? base_ : spath::DefaultOutputDir() ;
+        base = spath::DefaultOutputDir();
     }
     else if( mode_save == 1 )
     {
@@ -4462,8 +4478,8 @@ or the directory argument provided.
 
 The FALLBACK_DIR which is used for the SEvt::DefaultDir is obtained from SEventConfig::OutFold
 which is normally "$DefaultOutputDir" $TMP/GEOM/$GEOM/ExecutableName
-This can be overriden using SEventConfig::SetOutFold or by setting the
-envvar OPTICKS_OUT_FOLD.
+This can be overridden using SEventConfig::SetOutFold or by setting the
+envvar OPTICKS_OUT_FOLD, which are now honored directly by SEvt::DefaultBase.
 
 It is normally much easier to use the default of "$DefaultOutputDir" as this
 takes care of lots of the bookkeeping automatically.

--- a/tests/compare_ab.py
+++ b/tests/compare_ab.py
@@ -18,7 +18,7 @@ def expected_diff_for_version(version):
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "--base",
-    default="/tmp",
+    default="./",
     help="directory containing the ALL... event folders",
 )
 args = parser.parse_args()

--- a/tests/compare_ab.py
+++ b/tests/compare_ab.py
@@ -1,5 +1,7 @@
+import argparse
 import numpy as np
 
+from pathlib import Path
 from optiphy.geant4_version import detect_geant4_version, geant4_series
 
 
@@ -13,11 +15,20 @@ def expected_diff_for_version(version):
     return EXPECTED_DIFF[geant4_series(version)]
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--base",
+    default="/tmp",
+    help="directory containing the ALL... event folders",
+)
+args = parser.parse_args()
+
+base = Path(args.base)
 geant4_version = detect_geant4_version()
 expected_diff = expected_diff_for_version(geant4_version)
 
-a = np.load("/tmp/fakeuser/opticks/GEOM/fakegeom/simg4ox/ALL0_no_opticks_event_name/A000/record.npy")
-b = np.load("/tmp/fakeuser/opticks/GEOM/fakegeom/simg4ox/ALL0_no_opticks_event_name/B000/f000/record.npy")
+a = np.load(base / "ALL0_no_opticks_event_name/A000/record.npy")
+b = np.load(base / "ALL0_no_opticks_event_name/B000/f000/record.npy")
 
 print(a.shape)
 print(b.shape)

--- a/tests/test_GPUPhotonFileSource.sh
+++ b/tests/test_GPUPhotonFileSource.sh
@@ -31,7 +31,7 @@ cat > "$PHOTON_FILE" <<'EOF'
 EOF
 
 echo "Running GPUPhotonFileSource with seed $SEED ..."
-OUTPUT=$(USER=fakeuser GEOM=fakegeom GPUPhotonFileSource \
+OUTPUT=$(GPUPhotonFileSource \
     -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
     -p "$PHOTON_FILE" \
     -m "$OPTICKS_HOME/tests/run.mac" \
@@ -99,7 +99,7 @@ cat > "$PHOTON_FILE" <<'EOF'
 EOF
 
 echo "Running GPUPhotonFileSource ..."
-OUTPUT=$(USER=fakeuser GEOM=fakegeom GPUPhotonFileSource \
+OUTPUT=$(GPUPhotonFileSource \
     -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
     -p "$PHOTON_FILE" \
     -m "$OPTICKS_HOME/tests/run.mac" \

--- a/tests/test_GPUPhotonSource_8x8SiPM.sh
+++ b/tests/test_GPUPhotonSource_8x8SiPM.sh
@@ -41,7 +41,7 @@ echo "=== Test: GPUPhotonSource with 8x8SiPM_w_CSI_optial_grease.gdml ==="
 echo "Config: 1000 photons inside crystal at (-8.7, -8.7, 4.0)mm, 420nm, disc r=0.5mm"
 echo "Running GPUPhotonSource with seed $SEED ..."
 
-OUTPUT=$(USER=fakeuser GEOM=fakegeom GPUPhotonSource \
+OUTPUT=$(GPUPhotonSource \
     -g "$OPTICKS_HOME/tests/geom/8x8SiPM_w_CSI_optial_grease.gdml" \
     -c 8x8SiPM_crystal \
     -m "$OPTICKS_HOME/tests/run.mac" \

--- a/tests/test_GPURaytrace.sh
+++ b/tests/test_GPURaytrace.sh
@@ -67,7 +67,7 @@ echo "=== Test 1: Cerenkov only (opticks_raindrop.gdml) ==="
 set_expected_hits cerenkov
 
 echo "Running GPURaytrace with seed $SEED ..."
-OUTPUT=$(USER=fakeuser GEOM=fakegeom GPURaytrace \
+OUTPUT=$(GPURaytrace \
     -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
     -m "$OPTICKS_HOME/tests/run.mac" \
     -s "$SEED" 2>&1)
@@ -87,7 +87,7 @@ echo "=== Test 2: Cerenkov + Scintillation (opticks_raindrop_with_scintillation.
 set_expected_hits cerenkov_scintillation
 
 echo "Running GPURaytrace with seed $SEED ..."
-OUTPUT=$(USER=fakeuser GEOM=fakegeom GPURaytrace \
+OUTPUT=$(GPURaytrace \
     -g "$OPTICKS_HOME/tests/geom/opticks_raindrop_with_scintillation.gdml" \
     -m "$OPTICKS_HOME/tests/run.mac" \
     -s "$SEED" 2>&1)

--- a/tests/test_simg4ox.sh
+++ b/tests/test_simg4ox.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-USER=fakeuser GEOM=fakegeom simg4ox -g $OPTICKS_HOME/tests/geom/raindrop.gdml -m $OPTICKS_HOME/tests/run.mac
-python $OPTICKS_HOME/tests/compare_ab.py
+set -e
+
+simg4ox -g "$OPTICKS_HOME/tests/geom/raindrop.gdml" -m "$OPTICKS_HOME/tests/run.mac"
+python "$OPTICKS_HOME/tests/compare_ab.py"


### PR DESCRIPTION
This PR makes `gphox::Config` the authoritative source for runtime configuration parameters that are applied to supported binaries execution. The main focus is refactoring event runtime controls, especially `event.mode` and `event.output_dir`, so they are read from the app config JSON and then synchronized into `SEventConfig` from one place.

- Added `--config` support to the affected binaries so runtime behavior can be selected via config file.
- Updated tests/scripts to use the config-controlled output location instead of relying on fake `USER`/`GEOM` environment setup.
- Eliminated the need to set `USER` and `GEOM` environment variables for the supported binaries/tests that now route output through `Config`.
