### PR TITLE
fix(steppingaction): protect Scintillation genstep collection with ge…

### DIFF
--- a/examples/MC_Truth/GPUMCTruth.h
+++ b/examples/MC_Truth/GPUMCTruth.h
@@ -604,6 +604,7 @@ struct SteppingAction : G4UserSteppingAction
                         }
                         G4double SCINTILLATIONTIMECONSTANT1 = MPT->GetConstProperty(kSCINTILLATIONTIMECONSTANT1);
 
+                        G4AutoLock lock(&genstep_mutex);
                         U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, fNumPhotons, 1,
                                                                    SCINTILLATIONTIMECONSTANT1);
                     }

--- a/src/GPUCerenkov.h
+++ b/src/GPUCerenkov.h
@@ -500,6 +500,7 @@ struct SteppingAction : G4UserSteppingAction
                         }
                         G4double SCINTILLATIONTIMECONSTANT1 = MPT->GetConstProperty(kSCINTILLATIONTIMECONSTANT1);
 
+                        G4AutoLock lock(&genstep_mutex);
                         U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, fNumPhotons, 1,
                                                                    SCINTILLATIONTIMECONSTANT1);
                     }


### PR DESCRIPTION
…nstep_mutex

The Scintillation branches in src/GPUCerenkov.h and examples/MC_Truth/GPUMCTruth.h called U4::CollectGenstep_DsG4Scintillation_r4695 outside the genstep_mutex scope, while the adjacent Cerenkov branches were correctly protected. Concurrent worker writes to the process-global SEvt would race, causing crashes on beamOn>1 in MT mode with scintillating geometry.

Mirrors the fix applied to src/GPURaytrace.h in #272.