### PR TITLE
refactor(dd4hep): remove redundant cudaDeviceSynchronize in OpticsEvent

### DIFF
--- a/dd4hepplugins/OpticsEvent.cc
+++ b/dd4hepplugins/OpticsEvent.cc
@@ -10,7 +10,6 @@
 #include <G4Event.hh>
 
 #include <chrono>
-#include <cuda_runtime.h>
 
 #include <G4CXOpticks.hh>
 #include <NP.hh>
@@ -94,7 +93,6 @@ void OpticsEvent::end(G4Event const *event)
     {
         auto sim_t0 = std::chrono::high_resolution_clock::now();
         gx->simulate(eventID, /*reset=*/false);
-        cudaDeviceSynchronize();
         auto sim_t1 = std::chrono::high_resolution_clock::now();
         double simulate_ms = std::chrono::duration<double, std::milli>(sim_t1 - sim_t0).count();
 


### PR DESCRIPTION
`OpticsEvent::end` calls `cudaDeviceSynchronize()` immediately after G4CXOpticks::simulate(), but simulate() already drains the device internally, CSGOptiX::simulate_launch follows every optixLaunch with `CUDA_SYNC_CHECK()` . Tested, works.