### PR TITLE
refactor(u4): remove WITH_G4OPTICKS guards from Local_DsG4Scintillation

### DIFF
--- a/u4/Local_DsG4Scintillation.cc
+++ b/u4/Local_DsG4Scintillation.cc
@@ -84,21 +84,6 @@
 #include "G4Electron.hh"
 #include "globals.hh"
 
-#ifdef WITH_G4OPTICKS
-#include "G4Opticks.hh"
-#include "CGenstep.hh"
-#include "CTrack.hh"
-#include "CPhotonInfo.hh"
-#include "SLOG.hh"
-#endif
-
-
-
-#ifdef WITH_G4OPTICKS
-//const plog::Severity Local_DsG4Scintillation::LEVEL = SLOG::EnvLevel("Local_DsG4Scintillation", "DEBUG") ; 
-const plog::Severity Local_DsG4Scintillation::LEVEL = error ; 
-#endif
-
 
 #include "U4Stack.h"
 #include "SEvt.hh"
@@ -582,34 +567,9 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
   
      }
 
-//-------------------------------------------------//
-
-#ifdef WITH_G4OPTICKS
-
-    CPho ancestor = CPhotonInfo::Get(&aTrack); 
-    int ancestor_id = ancestor.get_id() ; 
-
-
-    /**
-    ancestor_id:-1 
-        normal case, meaning that aTrack was not a photon
-        so the generation loop will yield "primary" photons 
-        with id : gs.offset + i  
-             
-    ancestor_id>-1
-        aTrack is a photon that may be about to reemit (Num=0 or 1) 
-        ancestor_id is the absolute id of the primary parent photon, 
-        this id is retained thru any subsequent remission secondary generations
-    **/
-
-#endif
-
 #ifdef STANDALONE
     U4::GenPhotonAncestor(&aTrack);  
 #endif
-
-
-//-------------------------------------------------//
 
     for(G4int scnt = 0 ; scnt < nscnt ; scnt++){
 
@@ -639,18 +599,6 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
 
         G4int NumPhoton =  NumVec[scnt] ; 
 
-
-#ifdef WITH_G4OPTICKS
-        if(flagReemission) assert( NumPhoton == 0 || NumPhoton == 1);   // expecting only 0 or 1 remission photons
-        bool is_opticks_genstep = NumPhoton > 0 && !flagReemission ; 
-
-        CGenstep gs ; 
-        if(is_opticks_genstep && (m_opticksMode & 1))
-        {
-            gs = G4Opticks::Get()->collectGenstep_Local_DsG4Scintillation_r4695( &aTrack, &aStep, NumPhoton, scnt, ScintillationTime); 
-        }
-#endif
-
 #ifdef STANDALONE
         if(flagReemission) assert( NumPhoton == 0 || NumPhoton == 1);   // expecting only 0 or 1 remission photons
         bool is_opticks_genstep = NumPhoton > 0 && !flagReemission ; 
@@ -665,9 +613,7 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
          {
 
          for(G4int i = 0 ; i < NumPhoton ; i++) {
-#ifdef WITH_G4OPTICKS
-           G4Opticks::Get()->setAlignIndex( ancestor_id > -1 ? ancestor_id : gs.offset + i );  // aka photon_id
-#endif
+
 #ifdef STANDALONE
            U4::GenPhotonBegin(i); 
 #endif
@@ -845,11 +791,6 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
             if ( verboseLevel > 0 ) {
               G4cout << " aSecondaryTrack->SetWeight( " << weight<< " ) ; aSecondaryTrack->GetWeight() = " << aSecondaryTrack->GetWeight() << G4endl;}        
 
-#ifdef WITH_G4OPTICKS
-           aSecondaryTrack->SetUserInformation(CPhotonInfo::MakeScintillation(gs, i, ancestor ));  
-           G4Opticks::Get()->setAlignIndex(-1);
-#endif
-
 #ifdef STANDALONE
            U4::GenPhotonEnd(i, aSecondaryTrack);  
 #endif
@@ -874,55 +815,6 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
 
     return change ; 
 }
-
-
-
-#ifdef WITH_G4OPTICKS
-G4MaterialPropertyVector* Local_DsG4Scintillation::getMaterialProperty(const char* name, G4int materialIndex)
-{
-    const G4MaterialTable* theMaterialTable = G4Material::GetMaterialTable();
-    G4int numOfMaterials = G4Material::GetNumberOfMaterials();
-    assert( materialIndex < numOfMaterials ); 
-
-    G4Material* aMaterial = (*theMaterialTable)[materialIndex];
-    G4MaterialPropertiesTable* aMaterialPropertiesTable = aMaterial->GetMaterialPropertiesTable();
-    G4MaterialPropertyVector* prop = aMaterialPropertiesTable ? aMaterialPropertiesTable->GetProperty(name) : nullptr ;  
-    return prop ; 
-}
-
-G4PhysicsOrderedFreeVector* Local_DsG4Scintillation::getScintillationIntegral(G4int scnt, G4int materialIndex) const
-{
-    G4PhysicsOrderedFreeVector* ScintillationIntegral = NULL;
-
-    if ( scnt == 0 ){
-          ScintillationIntegral =
-                (G4PhysicsOrderedFreeVector*)((*theFastIntegralTable)(materialIndex));
-    }
-    else{
-          ScintillationIntegral =
-                (G4PhysicsOrderedFreeVector*)((*theSlowIntegralTable)(materialIndex));
-    }         
-
-    return ScintillationIntegral ; 
-}
-
-
-G4double Local_DsG4Scintillation::getSampledEnergy(G4int scnt, G4int materialIndex) const 
-{
-    G4PhysicsOrderedFreeVector* ScintillationIntegral = getScintillationIntegral(scnt, materialIndex); 
-    G4double CIIvalue = G4UniformRand()*ScintillationIntegral->GetMaxValue();
-    G4double sampledEnergy = ScintillationIntegral->GetEnergy(CIIvalue);
-    return sampledEnergy ; 
-}
-
-G4double Local_DsG4Scintillation::getSampledWavelength(G4int scnt, G4int materialIndex) const
-{
-    G4double sampledEnergy = getSampledEnergy(scnt, materialIndex ); 
-    G4double wavelength = h_Planck*c_light/sampledEnergy ; 
-    G4double wavelength_nm = wavelength/nm ; 
-    return wavelength_nm ; 
-}
-#endif
 
 
 // BuildThePhysicsTable for the scintillation process

--- a/u4/Local_DsG4Scintillation.hh
+++ b/u4/Local_DsG4Scintillation.hh
@@ -69,11 +69,6 @@
 #ifndef Local_DsG4Scintillation_h
 #define Local_DsG4Scintillation_h 1
 
-
-#ifdef WITH_G4OPTICKS
-#include "plog/Severity.h"
-#endif
-
 #include "globals.hh"
 #include "templates.hh"
 #include "Randomize.hh"
@@ -110,11 +105,6 @@ class G4UIdirectory;
 
 class Local_DsG4Scintillation : public G4VRestDiscreteProcess, public G4UImessenger
 { //too lazy to create another UImessenger class
-
-private:
-#ifdef WITH_G4OPTICKS
-     static const plog::Severity LEVEL ; 
-#endif
 
 public:
      static const bool FLOAT ; 
@@ -193,13 +183,6 @@ public: // With description
 
        void SetUseFastMu300nsTrick(const G4bool fastMu300nsTrick);
        G4bool GetUseFastMu300nsTrick() const;
-
-#ifdef WITH_G4OPTICKS
-       G4MaterialPropertyVector* getMaterialProperty(const char* name, G4int materialIndex) ;
-       G4PhysicsOrderedFreeVector* getScintillationIntegral(G4int scnt, G4int materialIndex) const;
-       G4double getSampledEnergy(G4int scnt, G4int materialIndex) const ;
-       G4double getSampledWavelength(G4int scnt, G4int materialIndex) const ;
-#endif
 
         void SetScintillationExcitationRatio(const G4double excitationratio);
         // Called to set the scintillation exciation ratio, needed when


### PR DESCRIPTION
This PR removes the `WITH_G4OPTICKS`-guarded code paths from `Local_DsG4Scintillation` and
simplifies the class around the remaining Opticks-aware scintillation flow.

`Local_DsG4Scintillation` now carries a small amount of legacy conditional compilation that makes
the scintillation path harder to follow and maintain. This change consolidates the implementation by
removing the old macro-gated branches and leaving a single supported path in this class.

- reduces conditional compilation in the scintillation process
- removes legacy photon ancestry/alignment handling tied to the old `WITH_G4OPTICKS` integration
- no broader file-level changes outside `u4/Local_DsG4Scintillation.{cc,hh}`
