### PR TITLE
refactor(config): define Config defaults and expose propagation settings

### DIFF
--- a/config/8x8SiPM_crystal.json
+++ b/config/8x8SiPM_crystal.json
@@ -25,6 +25,7 @@
 
   "event": {
     "mode": "Minimal",
-    "maxslot": 1000000
+    "maxslot": 1000000,
+    "max_bounce": 31
   }
 }

--- a/config/8x8SiPM_crystal.json
+++ b/config/8x8SiPM_crystal.json
@@ -26,6 +26,9 @@
   "event": {
     "mode": "Minimal",
     "maxslot": 1000000,
-    "max_bounce": 31
+    "max_bounce": 31,
+    "propagate_epsilon": 0.05,
+    "propagate_epsilon0": 0.05,
+    "propagate_epsilon0_mask": "TO,CK,SI,SC,RE"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -26,6 +26,7 @@
   "event": {
     "mode": "DebugLite",
     "maxslot": 1000000,
+    "max_bounce": 31,
     "output_dir": "./"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -27,6 +27,9 @@
     "mode": "DebugLite",
     "maxslot": 1000000,
     "max_bounce": 31,
+    "propagate_epsilon": 0.05,
+    "propagate_epsilon0": 0.05,
+    "propagate_epsilon0_mask": "TO,CK,SI,SC,RE",
     "output_dir": "./"
   }
 }

--- a/config/sphere_leak.json
+++ b/config/sphere_leak.json
@@ -25,6 +25,7 @@
 
   "event": {
     "mode": "DebugLite",
-    "maxslot": 1000000
+    "maxslot": 1000000,
+    "max_bounce": 31
   }
 }

--- a/config/sphere_leak.json
+++ b/config/sphere_leak.json
@@ -26,6 +26,9 @@
   "event": {
     "mode": "DebugLite",
     "maxslot": 1000000,
-    "max_bounce": 31
+    "max_bounce": 31,
+    "propagate_epsilon": 0.05,
+    "propagate_epsilon0": 0.05,
+    "propagate_epsilon0_mask": "TO,CK,SI,SC,RE"
   }
 }

--- a/config/wls_test.json
+++ b/config/wls_test.json
@@ -25,6 +25,7 @@
 
   "event": {
     "mode": "DebugLite",
-    "maxslot": 1000000
+    "maxslot": 1000000,
+    "max_bounce": 31
   }
 }

--- a/config/wls_test.json
+++ b/config/wls_test.json
@@ -26,6 +26,9 @@
   "event": {
     "mode": "DebugLite",
     "maxslot": 1000000,
-    "max_bounce": 31
+    "max_bounce": 31,
+    "propagate_epsilon": 0.05,
+    "propagate_epsilon0": 0.05,
+    "propagate_epsilon0_mask": "TO,CK,SI,SC,RE"
   }
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -137,7 +137,13 @@ void AssignOutputDirIfPresent(const nlohmann::json& event, std::filesystem::path
 void AssignTorchGentypeIfPresent(const nlohmann::json& torch, unsigned& gentype)
 {
     if (const auto it = torch.find("gentype"); it != torch.end())
-        gentype = OpticksGenstep_::Type(it->get<std::string>());
+    {
+        const std::string gentype_name = it->get<std::string>();
+        if (OpticksGenstep_::Type(gentype_name) != OpticksGenstep_TORCH)
+            throw std::invalid_argument{"Invalid torch.gentype \"" + gentype_name + "\". Expected TORCH"};
+
+        gentype = OpticksGenstep_TORCH;
+    }
 }
 
 void AssignTorchTypeIfPresent(const nlohmann::json& torch, unsigned& type)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -261,6 +261,9 @@ void Config::ReadConfig(std::string filepath)
             AssignEventModeIfPresent(event_, event_mode);
             AssignIfPresent(event_, "maxslot", maxslot);
             AssignIfPresent(event_, "max_bounce", max_bounce);
+            AssignIfPresent(event_, "propagate_epsilon", propagate_epsilon);
+            AssignIfPresent(event_, "propagate_epsilon0", propagate_epsilon0);
+            AssignIfPresent(event_, "propagate_epsilon0_mask", propagate_epsilon0_mask);
             AssignOutputDirIfPresent(event_, output_dir);
         }
     }
@@ -282,6 +285,9 @@ void Config::Apply() const
     SEventConfig::SetEventMode(event_mode_name.c_str());
     SEventConfig::SetMaxSlot(maxslot);
     SEventConfig::SetMaxBounce(max_bounce);
+    SEventConfig::SetPropagateEpsilon(propagate_epsilon);
+    SEventConfig::SetPropagateEpsilon0(propagate_epsilon0);
+    SEventConfig::SetPropagateEpsilon0Mask(propagate_epsilon0_mask.c_str());
     SEventConfig::SetOutFold(output_dir_str.c_str());
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -119,7 +119,18 @@ void AssignFloat3IfPresent(const nlohmann::json& object, const char* key, float3
 void AssignNormalizedFloat3IfPresent(const nlohmann::json& object, const char* key, float3& value)
 {
     if (const auto it = object.find(key); it != object.end())
-        value = normalize(make_float3((*it)[0].get<float>(), (*it)[1].get<float>(), (*it)[2].get<float>()));
+    {
+        const float3 candidate = make_float3(
+            (*it)[0].get<float>(),
+            (*it)[1].get<float>(),
+            (*it)[2].get<float>());
+        constexpr float epsilon = 1e-12f;
+        const float     length_squared = candidate.x * candidate.x + candidate.y * candidate.y + candidate.z * candidate.z;
+        if (length_squared <= epsilon)
+            throw std::invalid_argument(std::string("Cannot normalize vector for key '") + key + "'");
+
+        value = normalize(candidate);
+    }
 }
 
 void AssignEventModeIfPresent(const nlohmann::json& event, EventMode& mode)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -111,6 +111,7 @@ Config::Config(std::string config_name) :
     name{config_name},
     event_mode{EventMode::Minimal},
     maxslot{0},
+    max_bounce{static_cast<int>(SEventConfig::MaxBounce())},
     output_dir{std::filesystem::current_path()},
     torch{}
 {
@@ -222,6 +223,8 @@ void Config::ReadConfig(std::string filepath)
 
         event_mode = ReadEventMode(event_);
         maxslot = event_["maxslot"].get<int>();
+        if (event_.contains("max_bounce"))
+            max_bounce = event_["max_bounce"].get<int>();
         output_dir = ReadOutputDir(event_);
     }
     catch (nlohmann::json::exception& e)
@@ -241,6 +244,7 @@ void Config::Apply() const
 
     SEventConfig::SetEventMode(event_mode_name.c_str());
     SEventConfig::SetMaxSlot(maxslot);
+    SEventConfig::SetMaxBounce(max_bounce);
     SEventConfig::SetOutFold(output_dir_str.c_str());
 }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -97,23 +97,59 @@ EventMode ReadEventMode(const nlohmann::json& event)
         "Invalid event.mode \"" + std::string{name} + "\". Expected one of: " + ValidEventModes()};
 }
 
-std::filesystem::path ReadOutputDir(const nlohmann::json& event)
+template <typename T>
+void AssignIfPresent(const nlohmann::json& object, const char* key, T& value)
 {
-    if (event.contains("output_dir"))
-        return event["output_dir"].get<std::string>();
+    if (const auto it = object.find(key); it != object.end())
+        value = it->get<T>();
+}
 
-    return std::filesystem::current_path();
+void AssignFloat2IfPresent(const nlohmann::json& object, const char* key, float2& value)
+{
+    if (const auto it = object.find(key); it != object.end())
+        value = make_float2((*it)[0].get<float>(), (*it)[1].get<float>());
+}
+
+void AssignFloat3IfPresent(const nlohmann::json& object, const char* key, float3& value)
+{
+    if (const auto it = object.find(key); it != object.end())
+        value = make_float3((*it)[0].get<float>(), (*it)[1].get<float>(), (*it)[2].get<float>());
+}
+
+void AssignNormalizedFloat3IfPresent(const nlohmann::json& object, const char* key, float3& value)
+{
+    if (const auto it = object.find(key); it != object.end())
+        value = normalize(make_float3((*it)[0].get<float>(), (*it)[1].get<float>(), (*it)[2].get<float>()));
+}
+
+void AssignEventModeIfPresent(const nlohmann::json& event, EventMode& mode)
+{
+    if (event.contains("mode"))
+        mode = ReadEventMode(event);
+}
+
+void AssignOutputDirIfPresent(const nlohmann::json& event, std::filesystem::path& output_dir)
+{
+    if (const auto it = event.find("output_dir"); it != event.end())
+        output_dir = it->get<std::string>();
+}
+
+void AssignTorchGentypeIfPresent(const nlohmann::json& torch, unsigned& gentype)
+{
+    if (const auto it = torch.find("gentype"); it != torch.end())
+        gentype = OpticksGenstep_::Type(it->get<std::string>());
+}
+
+void AssignTorchTypeIfPresent(const nlohmann::json& torch, unsigned& type)
+{
+    if (const auto it = torch.find("type"); it != torch.end())
+        type = storchtype::Type(it->get<std::string>());
 }
 
 } // namespace
 
 Config::Config(std::string config_name) :
-    name{config_name},
-    event_mode{EventMode::Minimal},
-    maxslot{0},
-    max_bounce{static_cast<int>(SEventConfig::MaxBounce())},
-    output_dir{std::filesystem::current_path()},
-    torch{}
+    name{config_name}
 {
     ReadConfig(Locate(name + ".json"));
     Apply();
@@ -196,36 +232,37 @@ void Config::ReadConfig(std::string filepath)
         std::ifstream ifs(filepath);
         ifs >> json;
 
-        if (json.contains("torch"))
+        if (const auto it = json.find("torch"); it != json.end())
         {
-            nlohmann::json torch_ = json["torch"];
+            const nlohmann::json& torch_ = *it;
 
-            torch = {
-                .gentype = OpticksGenstep_::Type(torch_["gentype"]),
-                .trackid = torch_["trackid"],
-                .matline = torch_["matline"],
-                .numphoton = torch_["numphoton"],
-                .pos = make_float3(torch_["pos"][0], torch_["pos"][1], torch_["pos"][2]),
-                .time = torch_["time"],
-                .mom = normalize(make_float3(torch_["mom"][0], torch_["mom"][1], torch_["mom"][2])),
-                .weight = torch_["weight"],
-                .pol = make_float3(torch_["pol"][0], torch_["pol"][1], torch_["pol"][2]),
-                .wavelength = torch_["wavelength"],
-                .zenith = make_float2(torch_["zenith"][0], torch_["zenith"][1]),
-                .azimuth = make_float2(torch_["azimuth"][0], torch_["azimuth"][1]),
-                .radius = torch_["radius"],
-                .distance = torch_["distance"],
-                .mode = torch_["mode"],
-                .type = storchtype::Type(torch_["type"])};
+            AssignTorchGentypeIfPresent(torch_, torch.gentype);
+            AssignIfPresent(torch_, "trackid", torch.trackid);
+            AssignIfPresent(torch_, "matline", torch.matline);
+            AssignIfPresent(torch_, "numphoton", torch.numphoton);
+            AssignFloat3IfPresent(torch_, "pos", torch.pos);
+            AssignIfPresent(torch_, "time", torch.time);
+            AssignNormalizedFloat3IfPresent(torch_, "mom", torch.mom);
+            AssignIfPresent(torch_, "weight", torch.weight);
+            AssignFloat3IfPresent(torch_, "pol", torch.pol);
+            AssignIfPresent(torch_, "wavelength", torch.wavelength);
+            AssignFloat2IfPresent(torch_, "zenith", torch.zenith);
+            AssignFloat2IfPresent(torch_, "azimuth", torch.azimuth);
+            AssignIfPresent(torch_, "radius", torch.radius);
+            AssignIfPresent(torch_, "distance", torch.distance);
+            AssignIfPresent(torch_, "mode", torch.mode);
+            AssignTorchTypeIfPresent(torch_, torch.type);
         }
 
-        nlohmann::json event_ = json["event"];
+        if (const auto it = json.find("event"); it != json.end())
+        {
+            const nlohmann::json& event_ = *it;
 
-        event_mode = ReadEventMode(event_);
-        maxslot = event_["maxslot"].get<int>();
-        if (event_.contains("max_bounce"))
-            max_bounce = event_["max_bounce"].get<int>();
-        output_dir = ReadOutputDir(event_);
+            AssignEventModeIfPresent(event_, event_mode);
+            AssignIfPresent(event_, "maxslot", maxslot);
+            AssignIfPresent(event_, "max_bounce", max_bounce);
+            AssignOutputDirIfPresent(event_, output_dir);
+        }
     }
     catch (nlohmann::json::exception& e)
     {

--- a/src/config.h
+++ b/src/config.h
@@ -43,7 +43,7 @@ class Config
     EventMode event_mode{EventMode::DebugLite};
 
     /// Maximum event slots applied to SEventConfig.
-    int maxslot{1000000};
+    int maxslot{0};
 
     /// Maximum photon bounce count.
     int max_bounce{31};

--- a/src/config.h
+++ b/src/config.h
@@ -48,6 +48,15 @@ class Config
     /// Maximum photon bounce count.
     int max_bounce{31};
 
+    /// Ray offset after boundary crossing.
+    float propagate_epsilon{0.05f};
+
+    /// Ray offset after bulk interaction.
+    float propagate_epsilon0{0.05f};
+
+    /// Flag mask selecting which bulk interactions use propagate_epsilon0.
+    std::string propagate_epsilon0_mask{"TO,CK,SI,SC,RE"};
+
     /// Base directory for event output folders.
     std::filesystem::path output_dir{std::filesystem::current_path()};
 

--- a/src/config.h
+++ b/src/config.h
@@ -40,7 +40,7 @@ class Config
     std::string name{"dev"};
 
     /// Event persistence mode applied to SEventConfig.
-    EventMode event_mode{EventMode::DebugLite};
+    EventMode event_mode{EventMode::Minimal};
 
     /// Maximum event slots applied to SEventConfig.
     int maxslot{0};

--- a/src/config.h
+++ b/src/config.h
@@ -45,6 +45,9 @@ class Config
     /// Maximum event slots applied to SEventConfig.
     int maxslot;
 
+    /// Maximum photon bounce count.
+    int max_bounce;
+
     /// Base directory for event output folders.
     std::filesystem::path output_dir;
 

--- a/src/config.h
+++ b/src/config.h
@@ -4,8 +4,8 @@
 #include <string>
 #include <vector>
 
-#include "sysrap/srng.h"
 #include "sysrap/storch.h"
+#include "torch.h"
 
 namespace gphox
 {
@@ -37,21 +37,21 @@ class Config
     static std::string PtxPath(const std::string& ptx_name = "CSGOptiX7.ptx");
 
     /// A unique name associated with this Config
-    std::string name;
+    std::string name{"dev"};
 
     /// Event persistence mode applied to SEventConfig.
-    EventMode event_mode;
+    EventMode event_mode{EventMode::DebugLite};
 
     /// Maximum event slots applied to SEventConfig.
-    int maxslot;
+    int maxslot{1000000};
 
     /// Maximum photon bounce count.
-    int max_bounce;
+    int max_bounce{31};
 
     /// Base directory for event output folders.
-    std::filesystem::path output_dir;
+    std::filesystem::path output_dir{std::filesystem::current_path()};
 
-    storch torch;
+    storch torch{default_torch};
 
   private:
     std::string Locate(std::string filename) const;

--- a/src/torch.cpp
+++ b/src/torch.cpp
@@ -20,7 +20,7 @@ vector<sphoton> generate_photons(const storch& torch, unsigned int num_photons, 
     int             unused = -1;
     qtorch          qt{.t = torch};
 
-    for (int i = 0; i < num_photons; i++)
+    for (unsigned int i = 0; i < num_photons; i++)
     {
         sphoton photon;
         storch::generate(photon, rng, qt.q, unused, unused);

--- a/src/torch.cpp
+++ b/src/torch.cpp
@@ -1,9 +1,10 @@
 #include <curand_kernel.h>
 
+#include "sysrap/srng.h"
+#include "sysrap/storch.h"
 #include "torch.h"
 
 using namespace std;
-
 
 vector<sphoton> generate_photons(const storch& torch, unsigned int num_photons, unsigned int seed)
 {
@@ -16,8 +17,8 @@ vector<sphoton> generate_photons(const storch& torch, unsigned int num_photons, 
     }
 
     vector<sphoton> photons;
-    int unused = -1;
-    qtorch qt{.t = torch};
+    int             unused = -1;
+    qtorch          qt{.t = torch};
 
     for (int i = 0; i < num_photons; i++)
     {

--- a/src/torch.h
+++ b/src/torch.h
@@ -2,35 +2,33 @@
 
 #include <vector>
 
+#include "sysrap/scuda.h"
 #include "sysrap/sphoton.h"
-#include "sysrap/srng.h"
 #include "sysrap/storch.h"
 
-
-constexpr storch default_torch{
+inline const storch default_torch{
     .gentype = OpticksGenstep_TORCH,
     .trackid = 0,
     .matline = 0,
     .numphoton = 100,
-    
+
     // Assign default values for position, time, momentum, and other attributes
     .pos = {-10.0f, -30.0f, -90.0f},
     .time = 0.0f,
-    
-    .mom = float3{0.0f, 0.3f, 1.0f},
+
+    .mom = normalize(make_float3(0.0f, 0.3f, 1.0f)),
     .weight = 0.0f,
-    
+
     .pol = {1.0f, 0.0f, 0.0f},
     .wavelength = 420.0f,
-    
+
     .zenith = {0.0f, 1.0f},
     .azimuth = {0.0f, 1.0f},
-    
+
     .radius = 15.0f,
     .distance = 0.0f,
     .mode = 255,
     .type = T_DISC,
 };
-
 
 std::vector<sphoton> generate_photons(const storch& torch = default_torch, unsigned int num_photons = 0, unsigned int seed = 0);

--- a/sysrap/smath.h
+++ b/sysrap/smath.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "scuda.h"
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
    #define SMATH_METHOD __device__
@@ -168,4 +169,3 @@ inline SMATH_METHOD float smath::erfcinvf(float u2)
     return 0.f ; 
 #endif
 }
-


### PR DESCRIPTION
This PR refactors `gphox::Config` so defaults are defined on the class and JSON config files act as
partial overrides instead of requiring fully populated `event` and `torch` blocks.

It also exposes additional Opticks event propagation settings through `Config` and applies them via
`SEventConfig`.

## Why

- keeps defaults in one obvious place
- makes config files more tolerant of missing keys
- lets app-level config control propagation settings without relying only on env vars
- preserves current default behavior while making overrides clearer and easier to extend
