### PR TITLE
chore(license): use unmodified Apache text from Apache

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,3 @@
-   Copyright (C) 2019 The Opticks Authors. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -188,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019, The Opticks Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
```
curl -L https://www.apache.org/licenses/LICENSE-2.0.txt -o LICENSE.txt
```

That appendix is not the repository’s actual copyright declaration. It is Apache’s example showing
how someone may apply the license to individual files.

LICENSE.txt  = the generic Apache-2.0 license text
NOTICE.txt   = project attribution / upstream attribution
source files = file-level copyright + SPDX + modification notices
