### PR TITLE
ci(spack): refresh the GHCR dependency buildcache from GitHub Actions

### DIFF
--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -1,0 +1,112 @@
+name: Build Push Spack Buildcache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - .github/workflows/build-push-spack-buildcache.yaml
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - .github/workflows/build-push-spack-buildcache.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name || github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  refresh-buildcache:
+    if: ${{ github.event_name != 'pull_request' || github.head_ref == 'build-spack-buildcache' }}
+    runs-on: ubuntu-latest
+    env:
+      SPACK_BASE_IMAGE: simphony-spack-base:buildcache-${{ github.run_id }}
+      SPACK_BASE_CACHE_SCOPE: spack-base-defaults
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Spack base image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          pull: true
+          load: true
+          target: spack-base
+          tags: ${{ env.SPACK_BASE_IMAGE }}
+          cache-from: type=gha,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
+          cache-to: type=gha,mode=max,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
+
+      # Keep the Spack install/publish phase in the workflow instead of a Dockerfile
+      # RUN step. BuildKit secrets could pass GHCR credentials into `docker build`,
+      # but registry writes are easier to reason about as explicit workflow side
+      # effects, and this keeps partial autopush progress plus cache verification
+      # separate from image layer creation.
+      - name: Populate dependency buildcache
+        run: |
+          docker run --rm \
+            -e REGISTRY_USER='${{ github.actor }}' \
+            -e REGISTRY_TOKEN='${{ secrets.GITHUB_TOKEN }}' \
+            '${{ env.SPACK_BASE_IMAGE }}' \
+            bash -lc '
+              set -euo pipefail
+
+              # Spack 1.x keeps the builtin package repo in the separate spack-packages git
+              # repository, so we can keep the Spack tool pinned while still floating package
+              # metadata to the latest builtin develop branch on each run.
+              spack repo update -b develop builtin
+              # Fetch the latest simphony package metadata from the external repo as well.
+              spack repo add https://github.com/BNLNPPS/spack-packages
+              # Use a dedicated GHCR package for the Spack OCI mirror so Docker cache cleanup
+              # jobs cannot prune buildcache artifacts behind the Spack mirror.
+              spack mirror add --autopush --unsigned --oci-username-variable REGISTRY_USER --oci-password-variable REGISTRY_TOKEN simphony-spack-buildcache "${SPACK_BUILDCACHE_MIRROR}"
+              spack external find --not-buildable --path /usr/local/cuda cuda
+
+              # Autopush dependencies as soon as source builds complete, so partial progress
+              # survives a failed long-running buildcache refresh.
+              spack install --only=dependencies --reuse --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+
+              # Keep the cache focused on dependencies; the PR workflow still builds simphony itself.
+              spack mirror set --no-autopush simphony-spack-buildcache
+              spack install --reuse --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+
+              # Autopush uploads OCI blobs immediately, but Spack still needs an updated
+              # index so later CI runs can discover the freshly published binaries.
+              spack buildcache update-index simphony-spack-buildcache
+            '
+
+      - name: Verify dependency buildcache
+        run: |
+          docker run --rm \
+            '${{ env.SPACK_BASE_IMAGE }}' \
+            bash -lc '
+              set -euo pipefail
+
+              # Match the publish step by floating the builtin spack-packages repo while keeping
+              # the Spack tool itself pinned in spack-base.
+              spack repo update -b develop builtin
+              # Fetch the latest simphony package metadata from the external repo as well.
+              spack repo add https://github.com/BNLNPPS/spack-packages
+              spack mirror add --unsigned simphony-spack-buildcache "${SPACK_BUILDCACHE_MIRROR}"
+              spack external find --not-buildable --path /usr/local/cuda cuda
+              spack install --only=dependencies --use-buildcache only simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+            '
+
+      - name: Cleanup local base image
+        if: ${{ always() }}
+        run: |
+          docker image rm -f '${{ env.SPACK_BASE_IMAGE }}' || true

--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -73,12 +73,14 @@ jobs:
               # survives a failed long-running buildcache refresh.
               spack install --only=dependencies --reuse --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
 
+              # Update the index after dependency autopush so partial progress is immediately discoverable.
+              spack buildcache update-index simphony-spack-buildcache
+
               # Keep the cache focused on dependencies; the PR workflow still builds simphony itself.
               spack mirror set --no-autopush simphony-spack-buildcache
               spack install --reuse --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
 
-              # Autopush uploads OCI blobs immediately, but Spack still needs an updated
-              # index so later CI runs can discover the freshly published binaries.
+              # Ensure the index is current after the full run as well.
               spack buildcache update-index simphony-spack-buildcache
             '
 

--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -110,3 +110,25 @@ jobs:
         if: ${{ always() }}
         run: |
           docker image rm -f '${{ env.SPACK_BASE_IMAGE }}' || true
+
+  cleanup-buildcache-registry:
+    if: ${{ always() && needs.refresh-buildcache.result != 'skipped' }}
+    needs: refresh-buildcache
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Define cleanup targets
+        run: |
+          PACKAGE_NAME=$(echo "${{ github.event.repository.name }}-spack-buildcache" | tr '[:upper:]' '[:lower:]')
+          echo "PACKAGE_NAME=${PACKAGE_NAME}" >> "$GITHUB_ENV"
+
+      - name: Cleanup stale untagged GHCR versions
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: ${{ env.PACKAGE_NAME }}
+          # Keep a small buffer so the cleanup pass does not race just-published manifests.
+          delete-untagged: true
+          older-than: 1 day

--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -4,12 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - Dockerfile
-      - .github/workflows/build-push-spack-buildcache.yaml
   push:
     branches:
       - main
@@ -27,7 +21,6 @@ permissions:
 
 jobs:
   refresh-buildcache:
-    if: ${{ github.event_name != 'pull_request' || github.head_ref == 'build-spack-buildcache' }}
     runs-on: ubuntu-latest
     env:
       SPACK_BASE_IMAGE: simphony-spack-base:buildcache-${{ github.run_id }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@
 
 ARG OS=ubuntu24.04
 ARG CUDA_VERSION=13.0.2
-
-FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS base
-
 ARG OPTIX_VERSION=9.0.0
 ARG GEANT4_VERSION=11.4.1
 ARG CMAKE_VERSION=4.2.1
+ARG SPACK_BUILDCACHE_MIRROR=oci://ghcr.io/bnlnpps/simphony-spack-buildcache
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS base
+
+ARG OPTIX_VERSION
+ARG GEANT4_VERSION
+ARG CMAKE_VERSION
 ARG CMAKE_BUILD_JOBS
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -100,3 +104,35 @@ COPY . $OPTICKS_HOME
 
 RUN cmake -S $OPTICKS_HOME -B $OPTICKS_BUILD -DCMAKE_INSTALL_PREFIX=$OPTICKS_PREFIX -DCMAKE_BUILD_TYPE=Debug \
  && cmake --build $OPTICKS_BUILD --parallel "${CMAKE_BUILD_JOBS:-$(nproc)}" --target install
+
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS spack-base
+
+ARG OPTIX_VERSION
+ARG GEANT4_VERSION
+ARG SPACK_BUILDCACHE_MIRROR
+ARG SPACK_VERSION=1.1.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install Spack package manager
+RUN apt update \
+ && apt install -y build-essential ca-certificates coreutils curl gfortran git gpg lsb-release unzip zip python3 \
+ && apt clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/spack && curl -sL https://github.com/spack/spack/archive/v${SPACK_VERSION}.tar.gz | tar -xz --strip-components 1 -C /opt/spack
+RUN echo "source /opt/spack/share/spack/setup-env.sh" > /etc/profile.d/z09_source_spack_setup.sh
+RUN echo "source /etc/profile.d/z09_source_spack_setup.sh" >> /etc/bash.bashrc
+
+ENV BASH_ENV=/etc/profile.d/z09_source_spack_setup.sh
+ENV OPTICKS_HOME=/workspaces/simphony
+ENV OPTIX_VERSION=${OPTIX_VERSION}
+ENV GEANT4_VERSION=${GEANT4_VERSION}
+ENV SPACK_BUILDCACHE_MIRROR=${SPACK_BUILDCACHE_MIRROR}
+ENV PATH=/opt/spack/bin:${PATH}
+ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
+
+WORKDIR ${OPTICKS_HOME}
+
+SHELL ["/bin/bash", "-l", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN apt update \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /opt/spack && curl -sL https://github.com/spack/spack/archive/v${SPACK_VERSION}.tar.gz | tar -xz --strip-components 1 -C /opt/spack
+RUN mkdir -p /opt/spack && curl -fsSL https://github.com/spack/spack/archive/v${SPACK_VERSION}.tar.gz | tar -xz --strip-components 1 -C /opt/spack
 RUN echo "source /opt/spack/share/spack/setup-env.sh" > /etc/profile.d/z09_source_spack_setup.sh
 RUN echo "source /etc/profile.d/z09_source_spack_setup.sh" >> /etc/bash.bashrc
 


### PR DESCRIPTION
This workflow intentionally populates dependency binaries, but still builds `simphony` itself
without autopush to keep the mirror focused on reusable dependencies.

- add a scheduled/manual workflow to refresh the Spack dependency buildcache in GHCR
- add a lightweight `spack-base` Docker target used only to bootstrap the workflow runtime
- publish dependency binaries with Spack autopush, then verify the refreshed mirror from a clean container
- limit `push` triggers to the files that actually affect buildcache production

This job publishes binaries to GHCR, so it needs workflow-scoped credentials and clear publishing
semantics.

While Docker/BuildKit can pass secrets into `docker build`, putting `spack install` and registry
writes inside a Dockerfile would couple a stateful publish step to image layer creation. Keeping the
Spack commands in the workflow makes:
- GHCR auth explicit
- partial autopush progress survive a later failure
- post-publish verification easy to run in a fresh container

The Dockerfile stays responsible for building the runtime environment; the workflow stays
responsible for mutating the external buildcache.
