### PR TITLE
build(cmake): configure install RPATH for shared library discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ set(BUILD_SHARED_LIBS ON)
 include(GNUInstallDirs)
 include(CTest)
 
+# Make installed binaries self-describing at runtime:
+# - use $ORIGIN so executables/libraries can find Simphony's own shared libs
+# - append linked dependency directories automatically (for Geant4, etc.)
+if(UNIX AND NOT APPLE)
+    set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif()
+
 # used by src/config.h.in
 set(GPHOX_INSTALL_FULL_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/${PROJECT_NAME}")
 


### PR DESCRIPTION
Configure Linux install RPATH so installed Simphony binaries can resolve shared libraries more
reliably after installation.

This change:
- uses `$ORIGIN`-based install RPATH so installed executables and libraries can find Simphony's own
  shared libraries
- enables `CMAKE_INSTALL_RPATH_USE_LINK_PATH` so CMake automatically appends linked dependency
  directories, such as the Geant4 install path

This is the most CMake-native, automatic approach for making installed binaries more self-contained
at runtime, especially in packaged/containerized environments.

- This should help with missing library lookup in installed environments, including the Apptainer
  image case.
- It does **not** address cases where Apptainer host bind mounts shadow container paths, so
  `--no-mount bind-paths` may still be required on some systems.
