### PR TITLE
build(cmake): follow up #349 with DT_RPATH on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,18 @@ set(BUILD_SHARED_LIBS ON)
 
 include(GNUInstallDirs)
 include(CTest)
+include(CheckLinkerFlag)
 
 # Make installed binaries self-describing at runtime: append linked dependency
 # directories automatically
-if(UNIX AND NOT APPLE)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     # Prefer transitive DT_RPATH over DT_RUNPATH so container runtimes such as
     # Apptainer can resolve indirect dependencies reliably.
-    add_link_options("LINKER:--disable-new-dtags")
+    check_linker_flag(CXX "LINKER:--disable-new-dtags" SIMPHONY_HAVE_DISABLE_NEW_DTAGS)
+    if(SIMPHONY_HAVE_DISABLE_NEW_DTAGS)
+        add_link_options("LINKER:--disable-new-dtags")
+    endif()
 endif()
 
 # used by src/config.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,13 @@ set(BUILD_SHARED_LIBS ON)
 include(GNUInstallDirs)
 include(CTest)
 
-# Make installed binaries self-describing at runtime:
-# - use $ORIGIN so executables/libraries can find Simphony's own shared libs
-# - append linked dependency directories automatically (for Geant4, etc.)
+# Make installed binaries self-describing at runtime: append linked dependency
+# directories automatically
 if(UNIX AND NOT APPLE)
-    set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    # Prefer transitive DT_RPATH over DT_RUNPATH so container runtimes such as
+    # Apptainer can resolve indirect dependencies reliably.
+    add_link_options("LINKER:--disable-new-dtags")
 endif()
 
 # used by src/config.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,12 @@ include(GNUInstallDirs)
 include(CTest)
 include(CheckLinkerFlag)
 
-# Make installed binaries self-describing at runtime: append linked dependency
-# directories automatically
+# Make installed binaries self-describing at runtime:
+# - use $ORIGIN so executables/libraries can find Simphony's own shared libs
+# - append linked dependency directories automatically
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(CMAKE_BUILD_RPATH_USE_ORIGIN ON)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN;\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     # Prefer transitive DT_RPATH over DT_RUNPATH so container runtimes such as
     # Apptainer can resolve indirect dependencies reliably.


### PR DESCRIPTION
This is a follow-up fix to https://github.com/BNLNPPS/simphony/pull/349.

The earlier install-RPATH change improved shared-library discovery, but
Apptainer still failed to resolve indirect Geant4 dependencies from release
images because the binaries were emitted with DT_RUNPATH. Force DT_RPATH on
Linux via --disable-new-dtags so transitive runtime lookup works reliably.

Apptainer was failing to resolve indirect Geant4 libraries from the release
image, while the same binaries worked once linked with `DT_RPATH` instead of
`DT_RUNPATH`.