### PR TITLE
test(qudarap): cap max_slot in QEvt_Lifecycle_Test to avoid VRAM OOM

### DIFF
--- a/qudarap/tests/QEvt_Lifecycle_Test.cc
+++ b/qudarap/tests/QEvt_Lifecycle_Test.cc
@@ -87,6 +87,7 @@ int main(int argc, char** argv)
     bool overwrite = false ;
     //ssys::setenvvar("OPTICKS_INPUT_PHOTON", "RainXZ_Z230_10k_f8.npy", overwrite );
     SEventConfig::SetInputPhoton("RainXZ_Z230_10k_f8.npy");
+    SEventConfig::SetMaxSlot(1000000); // cap slots: lifecycle test only needs the 10k input photons, not VRAM-scale
 
     ssys::setenvvar("GEOM", "TEST_CC", overwrite );
 


### PR DESCRIPTION
QEvt_Lifecycle_Test left max_slot at the default (0), which SEventConfig:: SetDevice sizes to a fraction of total VRAM (~192M slots / ~12 GB on a 24 GB card). On a shared or otherwise occupied GPU that allocation OOMs in QEvt::device_alloc_photon, making the test flaky in CI. The test only processes the 10k input photons in RainXZ_Z230_10k_f8.npy, so cap max_slot at 1M (~64 MB), which is deterministic and independent of GPU occupancy.