### PR TITLE
build(spack): improve Docker buildcache reuse

### DIFF
--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -69,16 +69,20 @@ jobs:
               spack mirror add --autopush --unsigned --oci-username-variable REGISTRY_USER --oci-password-variable REGISTRY_TOKEN simphony-spack-buildcache "${SPACK_BUILDCACHE_MIRROR}"
               spack external find --not-buildable --path /usr/local/cuda cuda
 
-              # Autopush dependencies as soon as source builds complete, so partial progress
-              # survives a failed long-running buildcache refresh.
-              spack install --only=dependencies --reuse --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+              # Print out concretized specs
+              spack spec --fresh -Il simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+
+              # Solve fresh against current package metadata, but still install exact matches
+              # from the mirror. Autopush dependencies as soon as source builds complete, so
+              # partial progress survives a failed long-running buildcache refresh.
+              spack install --only=dependencies --fresh --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
 
               # Update the index after dependency autopush so partial progress is immediately discoverable.
               spack buildcache update-index simphony-spack-buildcache
 
               # Keep the cache focused on dependencies, then build simphony itself from source.
               spack mirror set --no-autopush simphony-spack-buildcache
-              spack install --reuse --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+              spack install --fresh --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
               spack find --format "{name}{@version} {/hash}" simphony
               prefix="$(spack location -i simphony)"
               echo "Installed prefix: $prefix"
@@ -103,7 +107,7 @@ jobs:
               spack repo add https://github.com/BNLNPPS/spack-packages
               spack mirror add --unsigned simphony-spack-buildcache "${SPACK_BUILDCACHE_MIRROR}"
               spack external find --not-buildable --path /usr/local/cuda cuda
-              spack install --only=dependencies --use-buildcache only simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+              spack install --only=dependencies --fresh --use-buildcache only simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
             '
 
       - name: Cleanup local base image

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG OPTIX_VERSION=9.0.0
 ARG GEANT4_VERSION=11.4.1
 ARG CMAKE_VERSION=4.2.1
 ARG SPACK_BUILDCACHE_MIRROR=oci://ghcr.io/bnlnpps/simphony-spack-buildcache
+ARG SPACK_TARGET=x86_64_v2
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS base
 
@@ -111,6 +112,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS spack-base
 ARG OPTIX_VERSION
 ARG GEANT4_VERSION
 ARG SPACK_BUILDCACHE_MIRROR
+ARG SPACK_TARGET
 ARG SPACK_VERSION=1.1.1
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -130,12 +132,20 @@ ENV OPTICKS_HOME=/workspaces/simphony
 ENV OPTIX_VERSION=${OPTIX_VERSION}
 ENV GEANT4_VERSION=${GEANT4_VERSION}
 ENV SPACK_BUILDCACHE_MIRROR=${SPACK_BUILDCACHE_MIRROR}
+ENV SPACK_TARGET=${SPACK_TARGET}
 ENV PATH=/opt/spack/bin:${PATH}
 ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
 
 WORKDIR ${OPTICKS_HOME}
 
 SHELL ["/bin/bash", "-l", "-c"]
+
+RUN mkdir -p /root/.spack \
+ && cat > /root/.spack/packages.yaml <<EOF
+packages:
+  all:
+    target: [${SPACK_TARGET}]
+EOF
 
 
 FROM spack-base AS spack-no-env

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,10 +147,12 @@ RUN spack repo update -b develop builtin
 RUN spack repo add https://github.com/BNLNPPS/spack-packages
 RUN spack mirror add --unsigned simphony-buildcache "${SPACK_BUILDCACHE_MIRROR}"
 RUN spack external find --not-buildable --path /usr/local/cuda cuda
+# Print out concretized specs
+RUN spack spec --fresh -Il simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
 # Prefer dependency binaries when they exist, but let PR validation fall back to
 # source builds if the mirror lags behind the latest Spack package metadata.
-RUN spack install --only=dependencies --reuse --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
-RUN spack install --reuse --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+RUN spack install --only=dependencies --fresh --use-buildcache auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
+RUN spack install --fresh --use-buildcache package:never,dependencies:auto simphony ^geant4@${GEANT4_VERSION} ^optix-dev@${OPTIX_VERSION}
 RUN spack clean -a && rm -rf /root/.cache
 # Once simphony is installed it can be loaded in the user environment
 # $ spack load simphony


### PR DESCRIPTION
This updates the Spack-based Docker and buildcache flow so local `spack-no-env` builds are more likely to consume dependency binaries produced by the scheduled buildcache workflow.

## Changes

- Add a configurable `SPACK_TARGET`, defaulting to `x86_64_v2`, so the buildcache producer and Docker consumer use the same target baseline instead of depending on host microarchitecture detection.
- Write Spack `packages.yaml` in the `spack-base` image to apply that target consistently during concretization.
- Switch Spack installs from `--reuse` to `--fresh` in the buildcache workflow and Docker Spack stage, keeping solves aligned with current Spack package metadata.
- Keep dependency buildcache use enabled with `--use-buildcache auto` / `dependencies:auto`, so exact cached matches are still preferred while allowing rebuilds when dependencies genuinely change.
- Print the concretized `simphony` spec with hashes before install using `spack spec --fresh -Il ...`, making it easier to tell when dependency hashes change and binary caches will be rebuilt.

## Motivation

The dependency buildcache workflow is intended to track current Spack package metadata, but local Docker builds can miss the produced binaries when concretization differs across machines. A fixed target baseline and explicit fresh concretization make the behavior easier to reason about: the workflow can still rebuild when Spack packages change, while consumers have a better chance of matching the published dependency cache.