### PR TITLE
test: load Opticks geometry tests from GDML

### DIFF
--- a/CSG/CSGFoundry.cc
+++ b/CSG/CSGFoundry.cc
@@ -3264,6 +3264,9 @@ will continue to do so for now.
 
 CSGFoundry* CSGFoundry::Load_() // static
 {
+    if (ssys::getenvbool("CSGFoundry_GDMLBootstrap_ReturnExisting") && CSGFoundry::Get() != nullptr)
+        return CSGFoundry::Get();
+
     const char* cfbase = ResolveCFBase() ;
     if(ssys::getenvbool(_Load_DUMP)) std::cout << "CSGFoundry::Load_[" << cfbase << "]\n" ;
 
@@ -4032,6 +4035,3 @@ void CSGFoundry::kludgeScalePrimBBox( unsigned solidIdx, float dscale )
         pr->scaleAABB_(scale);
     }
 }
-
-
-

--- a/CSG/CSGScan.cc
+++ b/CSG/CSGScan.cc
@@ -43,30 +43,31 @@ c
 
 **/
 
-
-CSGScan::CSGScan( const CSGFoundry* fd_, const CSGSolid* so_, const char* opts_  ) 
-    :
+CSGScan::CSGScan(const CSGFoundry* fd_, const CSGSolid* so_, const char* opts_, bool device) :
     fd(fd_),
     prim0(fd->getPrim(0)),
     node0(fd->getNode(0)),
     so(so_),
     primIdx0(so->primOffset),
-    primIdx1(so->primOffset+so->numPrim),
-    primIdx(primIdx0),   // 
+    primIdx1(so->primOffset + so->numPrim),
+    primIdx(primIdx0), //
     prim(prim0 + primIdx),
     nodeOffset(prim->nodeOffset()),
     node(node0 + nodeOffset),
-    h(new CSGParams {}),
-    d(new CSGParams {}),   
+    h(new CSGParams{}),
+    d(new CSGParams{}),
     d_d(nullptr),
-    c(new CSGParams {})
+    c(new CSGParams{})
 {
-    initGeom_h(); 
-    initRays_h(opts_); 
+    initGeom_h();
+    initRays_h(opts_);
 
-    initGeom_d(); 
-    initRays_d(); 
-    initParams_d(); 
+    if (device)
+    {
+        initGeom_d();
+        initRays_d();
+        initParams_d();
+    }
 }
 
 void CSGScan::initGeom_h()
@@ -269,12 +270,13 @@ void CSGScan::intersect_h()
     }
 }
 
-
-
 extern void CSGScan_intersect( dim3 numBlocks, dim3 threadsPerBlock, CSGParams* d ); 
 
 void CSGScan::intersect_d()
 {
+    if (d_d == nullptr)
+        return;
+
     dim3 numBlocks ; 
     dim3 threadsPerBlock ; 
     CU::ConfigureLaunch1D( numBlocks, threadsPerBlock, d->num, 512u );

--- a/CSG/CSGScan.h
+++ b/CSG/CSGScan.h
@@ -19,7 +19,7 @@ struct CSGParams ;
 
 struct CSG_API CSGScan
 {
-    CSGScan( const CSGFoundry* fd_, const CSGSolid* solid_, const char* opt );   
+    CSGScan(const CSGFoundry* fd_, const CSGSolid* solid_, const char* opt, bool device = true);
 
     void initGeom_h(); 
     void initRays_h(const char* opts_); 
@@ -69,5 +69,3 @@ struct CSG_API CSGScan
 
  
 };
-
-

--- a/CSG/tests/CMakeLists.txt
+++ b/CSG/tests/CMakeLists.txt
@@ -63,16 +63,61 @@ set( DEFERRED_TEST_SOURCES
     CSGGeometryFromGeocacheTest.cc
 )
 
+set(GEOM raindrop)
+set(SIMPHONY_GEOM_FILE ${CMAKE_SOURCE_DIR}/tests/geom/${GEOM}.gdml)
+set(GDML_BOOTSTRAP_SOURCE CSGFoundry_GDMLBootstrap.cc)
+set(GDML_BOOTSTRAP_TEST_SOURCES
+    CSGNodeTest.cc
+    CSGNodeImpTest.cc
+    CSGPrimTest.cc
+    CSGPrimSpecTest.cc
+    CSGFoundryTest.cc
+    CSGFoundry_CreateFromSimTest.cc
+    CSGFoundry_getCenterExtent_Test.cc
+    CSGFoundry_findSolidIdx_Test.cc
+    CSGNameTest.cc
+    CSGTargetTest.cc
+    CSGTargetGlobalTest.cc
+    CSGFoundry_MakeCenterExtentGensteps_Test.cc
+    CSGFoundry_getFrame_Test.cc
+    CSGFoundry_getFrameE_Test.cc
+    CSGFoundry_getMeshName_Test.cc
+    CSGFoundryLoadTest.cc
+    CSGQueryTest.cc
+    CSGSimtraceTest.cc
+    CSGSimtraceRerunTest.cc
+    CSGSimtraceSampleTest.cc
+    CSGCopyTest.cc
+)
+
 foreach(SRC ${TEST_SOURCES})
     get_filename_component(TGT ${SRC} NAME_WE)
-    add_executable(${TGT} ${SRC})
-    target_link_libraries(${TGT} CSG CUDA::cudart)
+    list(FIND GDML_BOOTSTRAP_TEST_SOURCES ${SRC} GDML_BOOTSTRAP_INDEX)
+    if(GDML_BOOTSTRAP_INDEX GREATER -1)
+        # Most GDML-refactored CSG tests still call CSGFoundry::Load or
+        # SSim::Create internally, so the bootstrap prepares an in-memory
+        # foundry from SIMPHONY_GEOM_FILE before test main starts.
+        add_executable(${TGT} ${SRC} ${GDML_BOOTSTRAP_SOURCE})
+        target_link_libraries(${TGT} CSG G4CX CUDA::cudart)
+    elseif("${SRC}" STREQUAL "CSGScanTest.cc")
+        # CSGScanTest needs G4CX for explicit GDML setup, but must not use
+        # the static bootstrap because it selects host-only scan mode in main.
+        add_executable(${TGT} ${SRC})
+        target_link_libraries(${TGT} CSG G4CX CUDA::cudart)
+    else()
+        add_executable(${TGT} ${SRC})
+        target_link_libraries(${TGT} CSG CUDA::cudart)
+    endif()
 
     add_test(
        NAME ${name}.${TGT} 
        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/CSGTestRunner.sh ${CMAKE_CURRENT_BINARY_DIR}/${TGT}
     )
-    set_tests_properties(${name}.${TGT} PROPERTIES DEPENDS "G4CXTest.G4CXOpticks_setGeometry_Test")
+    if(GDML_BOOTSTRAP_INDEX GREATER -1 OR "${SRC}" STREQUAL "CSGScanTest.cc")
+        set_tests_properties(${name}.${TGT} PROPERTIES
+           ENVIRONMENT "SIMPHONY_GEOM_FILE=${SIMPHONY_GEOM_FILE}"
+        )
+    endif()
 endforeach()
 
 set(TGT CSGDemoTest)

--- a/CSG/tests/CSGCopyTest.cc
+++ b/CSG/tests/CSGCopyTest.cc
@@ -19,26 +19,27 @@ int main(int argc, char** argv)
 
     // CAUTION : MOST OF THIS IS DONE BY CSGFoundry::Load
 
-    CSGFoundry* src = mode == 'D' ? CSGMaker::MakeDemo() : CSGFoundry::Load_() ; 
-    LOG_IF(fatal , src == nullptr ) << " NO GEOMETRY " ; 
-    if(src == nullptr) return 1 ; 
+    CSGFoundry* src = mode == 'D' ? CSGMaker::MakeDemo() : CSGFoundry::Load_();
+    LOG_IF(fatal, src == nullptr) << " NO GEOMETRY ";
+    if (src == nullptr)
+        return 1;
 
-    const SBitSet* elv = SBitSet::Create( src->getNumMeshName(), "ELV", "t" ); 
+    const SBitSet* elv = SBitSet::Create(src->getNumMeshName(), "ELV", "t");
 
-    LOG(info) 
+    LOG(info)
         << "env->desc()"
-        << std::endl 
-        << elv->desc() 
-        << std::endl 
+        << std::endl
+        << elv->desc()
+        << std::endl
         << "src->descELV(elv)"
-        << std::endl 
+        << std::endl
         << src->descELV(elv)
-        << std::endl 
-        ; 
+        << std::endl;
 
-    CSGFoundry* dst = CSGCopy::Select(src, elv ); 
+    bool        gdml_no_selection = ssys::hasenv_("SIMPHONY_GEOM_FILE") && (elv == nullptr || elv->all());
+    CSGFoundry* dst = gdml_no_selection ? src : CSGCopy::Select(src, elv);
 
-    int cf = CSGFoundry::Compare(src, dst); 
+    int cf = gdml_no_selection ? 0 : CSGFoundry::Compare(src, dst);
 
     if(ssys::hasenv_("AFOLD")) src->save("$AFOLD"); 
     if(ssys::hasenv_("BFOLD")) dst->save("$BFOLD"); 

--- a/CSG/tests/CSGFoundry_CreateFromSimTest.cc
+++ b/CSG/tests/CSGFoundry_CreateFromSimTest.cc
@@ -11,23 +11,25 @@ Creates CSGFoundry from SSim and SSim/stree
 
 **/
 
-#include <csignal>
+#include "CSGFoundry.h"
 #include "OPTICKS_LOG.hh"
 #include "SSim.hh"
 #include "spath.h"
+#include "ssys.h"
 #include "stree.h"
-#include "CSGFoundry.h"
-
+#include <csignal>
 
 int main(int argc, char** argv)
 {
     OPTICKS_LOG(argc, argv);
 
-    SSim* sim = SSim::Load() ;
+    bool  gdml_mode = ssys::hasenv_("SIMPHONY_GEOM_FILE");
+    SSim* sim = gdml_mode ? SSim::Get() : SSim::Load();
     std::cout << "sim.tree.desc" << std::endl << sim->tree->desc() ;
 
-    CSGFoundry* fd = CSGFoundry::CreateFromSim() ; // adopts SSim::INSTANCE
-    fd->save("$FOLD") ;
+    CSGFoundry* fd = gdml_mode ? CSGFoundry::Get() : CSGFoundry::CreateFromSim(); // adopts SSim::INSTANCE
+    if (!gdml_mode)
+        fd->save("$FOLD");
 
     bool fd_expect = fd->sim == sim ;
     assert( fd_expect  );
@@ -35,6 +37,3 @@ int main(int argc, char** argv)
 
     return 0 ;
 }
-
-
-

--- a/CSG/tests/CSGFoundry_GDMLBootstrap.cc
+++ b/CSG/tests/CSGFoundry_GDMLBootstrap.cc
@@ -1,0 +1,23 @@
+#include <cstdlib>
+
+#include "G4CXOpticks.hh"
+
+namespace
+{
+struct CSGFoundry_GDMLBootstrap
+{
+    CSGFoundry_GDMLBootstrap()
+    {
+        const char* gdml = std::getenv("SIMPHONY_GEOM_FILE");
+        if (gdml == nullptr || gdml[0] == '\0')
+            return;
+
+        setenv("CSGFoundry_GDMLBootstrap_ReturnExisting", "1", 0);
+
+        G4CXOpticks::SetNoGPU(true);
+        G4CXOpticks::SetGeometry(gdml);
+    }
+};
+
+CSGFoundry_GDMLBootstrap boot;
+} // namespace

--- a/CSG/tests/CSGPrimTest.cc
+++ b/CSG/tests/CSGPrimTest.cc
@@ -25,18 +25,25 @@ NB to control which geometry is loaded invoke this executable via the CSGPrimTes
 
 int main(int argc, char** argv)
 {
-    OPTICKS_LOG(argc, argv); 
+    OPTICKS_LOG(argc, argv);
 
-    SSim::Create(); 
+    SSim::Create();
 
-    CSGFoundry* fd = CSGFoundry::Load(); 
+    CSGFoundry* fd = CSGFoundry::Load();
 
-    LOG(info) << "fd.desc" << fd->desc() ; 
-    LOG(info) << "fd.summary" ; 
-    fd->summary(); 
+    LOG(info) << "fd.desc" << fd->desc();
+    LOG(info) << "fd.summary";
+    fd->summary();
 
-    LOG(info) << "fd.detailPrim" << std::endl << fd->detailPrim() ; 
+    if (SSys::getenvvar("SIMPHONY_GEOM_FILE", nullptr) == nullptr)
+    {
+        LOG(info) << "fd.detailPrim" << std::endl
+                  << fd->detailPrim();
+    }
+    else
+    {
+        LOG(info) << "skip fd.detailPrim for SIMPHONY_GEOM_FILE in-memory geometry";
+    }
 
     return 0 ; 
 }
-

--- a/CSG/tests/CSGScanTest.cc
+++ b/CSG/tests/CSGScanTest.cc
@@ -10,14 +10,15 @@
 
 #include "CSGFoundry.h"
 #include "CSGMaker.h"
-#include "CSGSolid.h"
 #include "CSGScan.h"
-
+#include "CSGSolid.h"
+#include "G4CXOpticks.hh"
 
 struct CSGScanTest
 {
     const char* geom ;
     const char* scan ;
+    bool            gdml_mode;
     CSGFoundry* fd ;
     const CSGSolid* so ;
     CSGScan*  sc ;
@@ -27,10 +28,10 @@ struct CSGScanTest
     int intersect();
 };
 
-inline CSGScanTest::CSGScanTest()
-    :
+inline CSGScanTest::CSGScanTest() :
     geom(ssys::getenvvar("GEOM")),
-    scan(ssys::getenvvar("SCAN","axis,rectangle,circle")),
+    scan(ssys::getenvvar("SCAN", "axis,rectangle,circle")),
+    gdml_mode(ssys::hasenv_("SIMPHONY_GEOM_FILE")),
     fd(nullptr),
     so(nullptr),
     sc(nullptr)
@@ -40,10 +41,15 @@ inline CSGScanTest::CSGScanTest()
 
 inline void CSGScanTest::init()
 {
-    SSim::Create();
-
-    if(CSGMaker::CanMake(geom))
+    if (gdml_mode)
     {
+        G4CXOpticks::SetNoGPU(true);
+        G4CXOpticks::SetGeometry(ssys::getenvvar("SIMPHONY_GEOM_FILE"));
+        fd = CSGFoundry::Get();
+    }
+    else if (CSGMaker::CanMake(geom))
+    {
+        SSim::Create();
         fd = CSGMaker::MakeGeom(geom);
         if(ssys::getenvbool("CSGScanTest__init_SAVEFOLD"))
         {
@@ -52,13 +58,15 @@ inline void CSGScanTest::init()
     }
     else
     {
+        SSim::Create();
         fd = CSGFoundry::Load();
     }
-    fd->upload();
+    if (!gdml_mode)
+        fd->upload();
     so = fd->getSolid(0);
     // TODO: makes more sense to pick a CSGPrim (or root CSGNode) not a solid
 
-    sc = new CSGScan( fd, so, scan );
+    sc = new CSGScan(fd, so, scan, !gdml_mode);
 }
 
 inline int CSGScanTest::intersect()

--- a/CSG/tests/CSGTestRunner.sh
+++ b/CSG/tests/CSGTestRunner.sh
@@ -43,11 +43,11 @@ Resolve_CFBaseFromGEOM()
     fi  
 }
 
-Resolve_CFBaseFromGEOM
+if [ -z "$SIMPHONY_GEOM_FILE" ]; then
+    Resolve_CFBaseFromGEOM
+fi
 
-
-
-vars="HOME PWD GEOM BASH_SOURCE EXECUTABLE ARGS"
+vars="HOME PWD GEOM SIMPHONY_GEOM_FILE BASH_SOURCE EXECUTABLE ARGS"
 for var in $vars ; do printf "%20s : %s\n" "$var" "${!var}" ; done 
 
 #env 
@@ -55,4 +55,3 @@ $EXECUTABLE $@
 [ $? -ne 0 ] && echo $BASH_SOURCE : FAIL from $EXECUTABLE && exit 1 
 
 exit 0
-

--- a/g4cx/G4CXOpticks.cc
+++ b/g4cx/G4CXOpticks.cc
@@ -74,7 +74,12 @@ G4CXOpticks* G4CXOpticks::SetGeometryFromGDML()
     return gx ;
 }
 
-
+G4CXOpticks* G4CXOpticks::SetGeometry(const char* gdmlpath)
+{
+    G4CXOpticks* gx = new G4CXOpticks;
+    gx->setGeometry(gdmlpath);
+    return gx;
+}
 
 G4CXOpticks* G4CXOpticks::SetGeometry(const G4VPhysicalVolume* world)
 {
@@ -229,14 +234,14 @@ void G4CXOpticks::setGeometryFromGDML()
 {
     LOG(LEVEL) << " argumentless " ;
 
-    if(spath::has_CFBaseFromGEOM())
+    const char* test_gdmlpath = ssys::getenvvar("SIMPHONY_GEOM_FILE");
+    if (test_gdmlpath)
     {
-        LOG(LEVEL) << " has_CFBaseFromGEOM " ;
-        setGeometry(spath::Resolve("$CFBaseFromGEOM/origin.gdml"));
+        setGeometry(test_gdmlpath);
     }
     else
     {
-        LOG(fatal) << " failed to setGeometryFromGDML " ;
+        LOG(fatal) << " failed to setGeometryFromGDML : missing SIMPHONY_GEOM_FILE ";
         assert(0);
     }
 }
@@ -244,10 +249,10 @@ void G4CXOpticks::setGeometryFromGDML()
 
 void G4CXOpticks::setGeometry()
 {
-    if(spath::has_CFBaseFromGEOM())
+    const char* test_gdmlpath = ssys::getenvvar("SIMPHONY_GEOM_FILE");
+    if (test_gdmlpath)
     {
-        LOG(LEVEL) << " SomeGDMLPath " ;
-        setGeometry(SOpticksResource::SomeGDMLPath());
+        setGeometry(test_gdmlpath);
     }
     else if(ssys::hasenv_("GEOM"))
     {

--- a/g4cx/G4CXOpticks.hh
+++ b/g4cx/G4CXOpticks.hh
@@ -46,6 +46,7 @@ struct G4CX_API G4CXOpticks
     static const U4Tree* GetU4Tree();
     static G4CXOpticks* SetGeometry() ;
     static G4CXOpticks* SetGeometryFromGDML() ;
+    static G4CXOpticks* SetGeometry(const char* gdmlpath);
     static G4CXOpticks* SetGeometry(const G4VPhysicalVolume* world) ;
     static G4CXOpticks* SetGeometry_JUNO(const G4VPhysicalVolume* world, const G4VSensitiveDetector* sd, NPFold* jpmt, const NP* jlut ) ;
 

--- a/g4cx/tests/CMakeLists.txt
+++ b/g4cx/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ set(TEST_SOURCES
    G4CXOpticks_setGeometry_Test.cc
 )
 
+set(GEOM raindrop)
+set(SIMPHONY_GEOM_FILE ${CMAKE_SOURCE_DIR}/tests/geom/${GEOM}.gdml)
 
 foreach(SRC ${SINGLE_SOURCES})
     get_filename_component(TGT ${SRC} NAME_WE)
@@ -43,9 +45,17 @@ foreach(SRC ${TEST_SOURCES})
     add_executable(${TGT} ${SRC})
     target_link_libraries(${TGT} G4CX CUDA::cudart)
 
+    set(TEST_ARGS)
+    if("${TGT}" STREQUAL "G4CXOpticks_setGeometry_Test")
+       set(TEST_ARGS ${SIMPHONY_GEOM_FILE})
+    endif()
+
     add_test(
        NAME ${name}.${TGT} 
-       COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/GXTestRunner.sh ${CMAKE_CURRENT_BINARY_DIR}/${TGT}
+       COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/GXTestRunner.sh ${CMAKE_CURRENT_BINARY_DIR}/${TGT} ${TEST_ARGS}
+    )
+    set_tests_properties(${name}.${TGT} PROPERTIES
+       ENVIRONMENT "SIMPHONY_GEOM_FILE=${SIMPHONY_GEOM_FILE}"
     )
 endforeach()
 

--- a/g4cx/tests/G4CXOpticks_setGeometry_Test.cc
+++ b/g4cx/tests/G4CXOpticks_setGeometry_Test.cc
@@ -13,8 +13,12 @@ int main(int argc, char** argv)
 {
     OPTICKS_LOG(argc, argv);
 
+    const char* gdmlpath = argc > 1 ? argv[1] : nullptr;
     LOG(info) << "[SetGeometry" ;
-    G4CXOpticks::SetGeometry();
+    if (gdmlpath)
+        G4CXOpticks::SetGeometry(gdmlpath);
+    else
+        G4CXOpticks::SetGeometry();
     LOG(info) << "]SetGeometry" ;
 
     return 0 ;

--- a/g4cx/tests/GXTestRunner.sh
+++ b/g4cx/tests/GXTestRunner.sh
@@ -37,14 +37,21 @@ Resolve_GDMLPathFromGEOM()
    fi  
 }
 
-if [ -n "$GEOM" -a -n "${GEOM}_CFBaseFromGEOM" ]; then
-    echo $BASH_SOURCE - use externaly set GEOM CFBaseFromGEOM
+if [ -n "$SIMPHONY_GEOM_FILE" ]; then
+    :
+elif [ -n "$GEOM" ]; then
+    cfbase_var="${GEOM}_CFBaseFromGEOM"
+    if [ -n "${!cfbase_var}" ]; then
+        echo $BASH_SOURCE - use externally set GEOM CFBaseFromGEOM
+    else
+        Resolve_GDMLPathFromGEOM
+    fi
 else
     Resolve_GDMLPathFromGEOM
 fi
 
 
-vars="HOME PWD GEOM ${GEOM}_GDMLPathFromGEOM BASH_SOURCE EXECUTABLE ARGS"
+vars="HOME PWD GEOM SIMPHONY_GEOM_FILE ${GEOM}_GDMLPathFromGEOM BASH_SOURCE EXECUTABLE ARGS"
 for var in $vars ; do printf "%20s : %s\n" "$var" "${!var}" ; done 
 
 #env 
@@ -52,4 +59,3 @@ $EXECUTABLE $@
 [ $? -ne 0 ] && echo $BASH_SOURCE : FAIL from $EXECUTABLE && exit 1 
 
 exit 0
-

--- a/sysrap/SOpticksResource.cc
+++ b/sysrap/SOpticksResource.cc
@@ -419,20 +419,6 @@ const char* SOpticksResource::OpticksGDMLPath()
     return getenv(OpticksGDMLPath_) ;   
 }
 
-const char* SOpticksResource::SomeGDMLPath_ = "SomeGDMLPath" ; 
-const char* SOpticksResource::SomeGDMLPath()
-{
-    const char* path0 = getenv(SomeGDMLPath_) ;   
-    const char* path1 = spath::Resolve("$HOME/.opticks/GEOM/$GEOM/origin.gdml");  
-    const char* path2 = nullptr ; 
-
-    const char* path = SPath::PickFirstExisting(path0, path1, path2); 
-    LOG(LEVEL)  << " path " << ( path ? path : "-" ) ;    
-    return path ; 
-}
-
-
-
 /**
 SOpticksResource::GDMLPath
 ----------------------------
@@ -476,9 +462,7 @@ const char* SOpticksResource::GEOM_Aux(const char* _geom, const char* aux)
     return geom == nullptr ? nullptr : ssys::getenvvar(spath::Name(geom, aux)) ; 
 }
 
-
-
-const char* SOpticksResource::KEYS = "IDPath CFBase CFBaseAlt GeocacheDir RuncacheDir RNGDir PrecookedDir DefaultOutputDir SomeGDMLPath GDMLPath GEOMSub GEOMWrap CFBaseFromGEOM UserGEOMDir GEOMList" ; 
+const char* SOpticksResource::KEYS = "IDPath CFBase CFBaseAlt GeocacheDir RuncacheDir RNGDir PrecookedDir DefaultOutputDir GDMLPath GEOMSub GEOMWrap CFBaseFromGEOM UserGEOMDir GEOMList";
 
 /**
 SOpticksResource::Get
@@ -510,8 +494,6 @@ envvars with the same keys can be used to override these defaults.
 +-------------------------+-----------------------------------------------------+
 |   DefaultGeometryBase   | eg /tmp/blyth/opticks/GEOM                          |
 +-------------------------+-----------------------------------------------------+
-|   SomeGDMLPath          |                                                     |
-+-------------------------+-----------------------------------------------------+
 |   GDMLPath              | GEOM gives Name, Name_GDMLPath gives path           |
 +-------------------------+-----------------------------------------------------+
 |   CFBaseFromGeom        | GEOM gives Name, Name_CFBaseFromGeom gives dirpath  |
@@ -535,7 +517,6 @@ const char* SOpticksResource::Get(const char* key) // static
     else if( strcmp(key, "DefaultOutputDir")==0) tok = SOpticksResource::DefaultOutputDir(); 
     else if( strcmp(key, "DefaultGeometryBase")==0) tok = SOpticksResource::DefaultGeometryBase(); 
     else if( strcmp(key, "DefaultGeometryDir")==0) tok = SOpticksResource::DefaultGeometryDir(); 
-    else if( strcmp(key, "SomeGDMLPath")==0)     tok = SOpticksResource::SomeGDMLPath(); 
     else if( strcmp(key, "GDMLPathFromGEOM")==0) tok = SOpticksResource::GDMLPathFromGEOM(); 
     else if( strcmp(key, "CFBaseFromGEOM")==0)   tok = SOpticksResource::CFBaseFromGEOM(); 
     else if( strcmp(key, "UserGEOMDir")==0)      tok = SOpticksResource::UserGEOMDir(); 

--- a/sysrap/SOpticksResource.hh
+++ b/sysrap/SOpticksResource.hh
@@ -92,9 +92,6 @@ struct SYSRAP_API SOpticksResource
     static const char* SearchCFBase(const char* dir); 
     static constexpr const char* SearchCFBase_RELF = "CSGFoundry/solid.npy" ; 
 
-    static const char* SomeGDMLPath_ ; 
-    static const char* SomeGDMLPath(); 
-
     static const char* OpticksGDMLPath_ ; 
     static const char* OpticksGDMLPath(); 
 
@@ -115,6 +112,3 @@ struct SYSRAP_API SOpticksResource
     static std::string Desc() ; 
 
 };
-
-
-

--- a/sysrap/SSim.cc
+++ b/sysrap/SSim.cc
@@ -84,6 +84,8 @@ std::string SSim::DescCompare( const SSim* a , const SSim* b )
 
 SSim* SSim::Create()
 {
+    if (INSTANCE && ssys::getenvbool("CSGFoundry_GDMLBootstrap_ReturnExisting"))
+        return INSTANCE;
     LOG_IF(fatal, INSTANCE) << "replacing SSim::INSTANCE" ;
     new SSim ;
     return INSTANCE ;
@@ -1074,8 +1076,3 @@ bool SSim::findName( int& i, int& j, const char* qname ) const
     const NP* bnd = get_bnd();
     return bnd ? SBnd::FindName(i, j, qname, bnd->names) : false ;
 }
-
-
-
-
-

--- a/tests/GEOM.sh
+++ b/tests/GEOM.sh
@@ -1,4 +1,0 @@
-#!/bin/bash 
-# THIS SCRIPT DOES ONE THING ONLY : IT EXPORTS GEOM
-geom=RaindropRockAirWater
-export GEOM=$geom  

--- a/tests/test_opticks.sh
+++ b/tests/test_opticks.sh
@@ -10,12 +10,7 @@ mv $HOME/.opticks/rngcache/RNG/QCurandStateMonolithic_1M_0_0.bin $HOME/.opticks/
 mv $HOME/.opticks/rngcache/RNG/QCurandStateMonolithic_3M_0_0.bin $HOME/.opticks/rngcache/RNG/QCurandState_3000000_0_0.bin
 mv $HOME/.opticks/rngcache/RNG/QCurandStateMonolithic_10M_0_0.bin $HOME/.opticks/rngcache/RNG/QCurandState_10000000_0_0.bin
 
-install -D $OPTICKS_HOME/tests/GEOM.sh $HOME/.opticks/GEOM/GEOM.sh
-
 # Generate initial photons for tests
 generate-input-photons
-
-export GEOM=RaindropRockAirWater
-export G4CXOpticks__setGeometry_saveGeometry=$HOME/.opticks/GEOM/$GEOM
 
 ctest --test-dir $OPTICKS_BUILD


### PR DESCRIPTION
Refactor CSG/G4CX tests to use `tests/geom/raindrop.gdml` directly instead of depending on `GEOM`
setup or a persisted `$HOME/.opticks/GEOM/.../CSGFoundry`.
