### PR TITLE
fix: correct size_t format specifiers in CUDA logging

### DIFF
--- a/qudarap/QEvt.cu
+++ b/qudarap/QEvt.cu
@@ -101,7 +101,7 @@ extern "C" unsigned QEvt_count_genstep_photons(sevent* evt)
 
 #ifdef DEBUG_QEVENT
     //thrust::for_each( gs_pho.begin(), gs_pho.end(), printf_functor() );
-    printf("//QEvt_count_genstep_photons evt.num_genstep %d evt.num_seed %d evt.max_photon %d \n", evt->num_genstep, evt->num_seed, evt->max_photon );
+    printf("//QEvt_count_genstep_photons evt.num_genstep %zu evt.num_seed %zu evt.max_photon %zu \n", evt->num_genstep, evt->num_seed, evt->max_photon );
 #endif
     assert( evt->num_seed <= evt->max_photon );
 
@@ -141,7 +141,7 @@ ACTUALLY THIS IS DUE TO A A LIMITATION OF IEXPAND, see sysrap/iexpand.h::
 extern "C" void QEvt_fill_seed_buffer(sevent* evt )
 {
 #ifdef DEBUG_QEVENT
-    printf("//QEvt_fill_seed_buffer evt.num_genstep %d evt.num_seed %d evt.max_photon %d \n", evt->num_genstep, evt->num_seed, evt->max_photon );
+    printf("//QEvt_fill_seed_buffer evt.num_genstep %zu evt.num_seed %zu evt.max_photon %zu \n", evt->num_genstep, evt->num_seed, evt->max_photon );
 #endif
 
     assert( evt->seed && evt->num_seed > 0 );
@@ -198,18 +198,18 @@ extern "C" void QEvt_count_genstep_photons_and_fill_seed_buffer(sevent* evt )
     evt->num_seed = thrust::reduce(gs_pho.begin(), gs_pho.end() );
 
 #ifdef DEBUG_QEVENT
-    printf("//QEvt_count_genstep_photons_and_fill_seed_buffer evt.num_genstep %d evt.num_seed %d evt.max_photon %d \n", evt->num_genstep, evt->num_seed, evt->max_photon );
+    printf("//QEvt_count_genstep_photons_and_fill_seed_buffer evt.num_genstep %zu evt.num_seed %zu evt.max_photon %zu \n", evt->num_genstep, evt->num_seed, evt->max_photon );
 #endif
 
     bool expect_seed =  evt->seed && evt->num_seed > 0 ;
-    if(!expect_seed) printf("//QEvt_count_genstep_photons_and_fill_seed_buffer  evt.seed %s  evt.num_seed %d \n",  (evt->seed ? "YES" : "NO " ), evt->num_seed );
+    if(!expect_seed) printf("//QEvt_count_genstep_photons_and_fill_seed_buffer  evt.seed %s  evt.num_seed %zu \n",  (evt->seed ? "YES" : "NO " ), evt->num_seed );
     assert( expect_seed );
 
     bool num_seed_ok = evt->num_seed <= evt->max_photon ;
 
     if( num_seed_ok == false )
     {
-        printf("//QEvt_count_genstep_photons_and_fill_seed_buffer FAIL evt.num_seed %d evt.max_photon %d num_seed_ok %d \n", evt->num_seed, evt->max_photon, num_seed_ok  );
+        printf("//QEvt_count_genstep_photons_and_fill_seed_buffer FAIL evt.num_seed %zu evt.max_photon %zu num_seed_ok %d \n", evt->num_seed, evt->max_photon, num_seed_ok  );
     }
 
     assert( num_seed_ok );

--- a/sysrap/SPM.cu
+++ b/sysrap/SPM.cu
@@ -145,8 +145,7 @@ template<typename T> void SPM::merge_partial_select(
     using reduce_op     = typename T::reduce_op;
     using key_functor   = typename T::key_functor;
 
-
-    printf("[SPM::merge_partial_select num_in %d select_flagmask %d time_window %7.3f \n", num_in, select_flagmask, time_window );
+    printf("[SPM::merge_partial_select num_in %zu select_flagmask %#x time_window %7.3f \n", num_in, select_flagmask, time_window);
 
     if (num_in == 0) { *d_out = nullptr; if (num_out) *num_out = 0; return; }
 
@@ -284,7 +283,7 @@ template<typename T> void SPM::merge_partial_select(
 
     float select_frac = float(num_selected)/float(num_in);
     float merge_frac = float(merged)/float(num_selected) ;
-    printf("]SPM::merge_partial_select select_flagmask %d time_window %7.3f in %d selected %d merged %d selected/in %7.3f merged/selected %7.3f \n",
+    printf("]SPM::merge_partial_select select_flagmask %#x time_window %7.3f in %zu selected %zu merged %zu selected/in %7.3f merged/selected %7.3f \n",
                 select_flagmask, time_window, num_in, num_selected, merged, select_frac, merge_frac );
 
 }
@@ -325,5 +324,4 @@ void SPM::free_async(void* d_ptr, cudaStream_t stream)  // static
 {
     if (d_ptr) cudaFreeAsync(d_ptr, stream);
 }
-
 


### PR DESCRIPTION
- replace incorrect `%d` format specifiers with `%zu` for `size_t` event and merge counters
- update `sysrap/SPM.cu` logging to print `select_flagmask` as hex with `%#x`
- clean up related debug/error prints in `qudarap/QEvt.cu` so the same warning pattern does not remain nearby

Fixes #231
Fixes #366
