### PR TITLE
fix(sysrap): avoid throwing from SOPTIX_BuildInput_IA destructor

### DIFF
--- a/sysrap/CUDA_CHECK.h
+++ b/sysrap/CUDA_CHECK.h
@@ -23,13 +23,8 @@ inline void CUDA_Log_NoThrow(cudaError_t error, const char* call, const char* fi
 {
     if (error != cudaSuccess)
     {
-        std::stringstream ss;
-        ss << "CUDA call (" << call << " ) failed with error: '"
-           << cudaGetErrorString(error)
-           << "' (" << file << ":" << line << ")\n";
-
-        const std::string msg = ss.str();
-        std::fputs(msg.c_str(), stderr);
+        std::fprintf(stderr, "CUDA call (%s) failed with error: '%s' (%s:%d)\n",
+                     call, cudaGetErrorString(error), file, line);
     }
 }
 

--- a/sysrap/CUDA_CHECK.h
+++ b/sysrap/CUDA_CHECK.h
@@ -1,9 +1,9 @@
 #pragma once
 
-
-#include <stdexcept>
+#include <cstdio>
+#include <cuda_runtime.h>
 #include <sstream>
-
+#include <stdexcept>
 
 #define CUDA_CHECK( call )                                                     \
     do                                                                         \
@@ -19,6 +19,26 @@
         }                                                                      \
     } while( 0 )
 
+inline void CUDA_Log_NoThrow(cudaError_t error, const char* call, const char* file, int line) noexcept
+{
+    if (error != cudaSuccess)
+    {
+        std::stringstream ss;
+        ss << "CUDA call (" << call << " ) failed with error: '"
+           << cudaGetErrorString(error)
+           << "' (" << file << ":" << line << ")\n";
+
+        const std::string msg = ss.str();
+        std::fputs(msg.c_str(), stderr);
+    }
+}
+
+#define CUDA_CHECK_NOEXCEPT(call)                           \
+    do                                                      \
+    {                                                       \
+        cudaError_t error = call;                           \
+        CUDA_Log_NoThrow(error, #call, __FILE__, __LINE__); \
+    } while (0)
 
 #define CUDA_SYNC_CHECK()                                                      \
     do                                                                         \
@@ -45,5 +65,3 @@ class CUDA_Exception : public std::runtime_error
      { }
 
 };
-
-

--- a/sysrap/SOPTIX_BuildInput_IA.h
+++ b/sysrap/SOPTIX_BuildInput_IA.h
@@ -1,5 +1,6 @@
 #pragma once
- 
+
+#include "CUDA_CHECK.h"
 #include "SOPTIX_BuildInput.h"
 
 struct SOPTIX_BuildInput_IA : public SOPTIX_BuildInput
@@ -10,9 +11,13 @@ struct SOPTIX_BuildInput_IA : public SOPTIX_BuildInput
     CUdeviceptr                instances_buffer;
 
     SOPTIX_BuildInput_IA(std::vector<OptixInstance>& _instances);
-    ~SOPTIX_BuildInput_IA() override
+    ~SOPTIX_BuildInput_IA() noexcept override
     {
-        CUDA_CHECK(cudaFree(reinterpret_cast<void*>(instances_buffer)));
+        if (instances_buffer != 0)
+        {
+            // Destructors cannot allow CUDA cleanup failures to escape.
+            CUDA_CHECK_NOEXCEPT(cudaFree(reinterpret_cast<void*>(instances_buffer)));
+        }
     }
 };
 
@@ -38,6 +43,3 @@ inline SOPTIX_BuildInput_IA::SOPTIX_BuildInput_IA(std::vector<OptixInstance>& _i
     instanceArray.instances = instances_buffer ;  
     instanceArray.numInstances = instances.size() ; 
 }
-
-
-


### PR DESCRIPTION
Fix the `-Wterminate` warning reported in #367 by removing the throwing CUDA error path from `SOPTIX_BuildInput_IA` destructor cleanup.

- added a non-throwing CUDA cleanup helper in `sysrap/CUDA_CHECK.h`
- changed `SOPTIX_BuildInput_IA::~SOPTIX_BuildInput_IA()` to `noexcept`
- switched destructor cleanup from `CUDA_CHECK(...)` to `CUDA_CHECK_NOEXCEPT(...)`
- skipped the `cudaFree(...)` call when `instances_buffer == 0`

`CUDA_CHECK(...)` throws `CUDA_Exception` on failure. Using it inside a destructor is unsafe because C++ destructors are `noexcept` by default, so an escaping exception would call `std::terminate`. The compiler warned about that exact case.

Regular CUDA call sites still throw as before, but destructor cleanup now logs failures without throwing, which removes the warning and keeps cleanup exception-safe.

Closes #367
