### PR TITLE
refactor: remove OPTICKS_* env var dependencies from test workflows

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Run tests
         run: |
-          docker run --rm --gpus 'device=1' ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} bash -lc 'ctest --test-dir "$OPTICKS_BUILD" --output-on-failure'
+          docker run --rm --gpus 'device=1' ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} bash -lc 'ctest --test-dir "$SIMPHONY_BUILD" --output-on-failure'
           docker run --rm --gpus 'device=1' ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} tests/test_simg4ox.sh
           docker run --rm --gpus 'device=1' ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} tests/test_GPURaytrace.sh
           docker run --rm --gpus 'device=1' ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} tests/test_triangulated.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,19 +69,19 @@ EOF
 RUN cat /etc/bash.nonint >> /etc/bash.bashrc
 
 ENV BASH_ENV=/etc/bash.nonint
-ENV OPTICKS_PREFIX=/opt/simphony
-ENV OPTICKS_HOME=/workspaces/simphony
-ENV OPTICKS_BUILD=/opt/simphony/build
-ENV LD_LIBRARY_PATH=${OPTICKS_PREFIX}/lib:${LD_LIBRARY_PATH}
-ENV VIRTUAL_ENV=${OPTICKS_HOME}/.venv
-ENV PATH=${OPTICKS_PREFIX}/bin:${VIRTUAL_ENV}/bin:${PATH}
+ENV SIMPHONY_PREFIX=/opt/simphony
+ENV SIMPHONY_HOME=/workspaces/simphony
+ENV SIMPHONY_BUILD=/opt/simphony/build
+ENV LD_LIBRARY_PATH=${SIMPHONY_PREFIX}/lib:${LD_LIBRARY_PATH}
+ENV VIRTUAL_ENV=${SIMPHONY_HOME}/.venv
+ENV PATH=${SIMPHONY_PREFIX}/bin:${VIRTUAL_ENV}/bin:${PATH}
 ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
 
-WORKDIR $OPTICKS_HOME
+WORKDIR $SIMPHONY_HOME
 
 # Install Python dependencies
-COPY pyproject.toml uv.lock $OPTICKS_HOME/
-COPY optiphy $OPTICKS_HOME/optiphy
+COPY pyproject.toml uv.lock $SIMPHONY_HOME/
+COPY optiphy $SIMPHONY_HOME/optiphy
 RUN uv sync
 
 
@@ -89,10 +89,10 @@ FROM base AS release
 
 ARG CMAKE_BUILD_JOBS
 
-COPY . $OPTICKS_HOME
+COPY . $SIMPHONY_HOME
 
-RUN cmake -S $OPTICKS_HOME -B $OPTICKS_BUILD -DCMAKE_INSTALL_PREFIX=$OPTICKS_PREFIX -DCMAKE_BUILD_TYPE=Release \
- && cmake --build $OPTICKS_BUILD --parallel "${CMAKE_BUILD_JOBS:-$(nproc)}" --target install
+RUN cmake -S $SIMPHONY_HOME -B $SIMPHONY_BUILD -DCMAKE_INSTALL_PREFIX=$SIMPHONY_PREFIX -DCMAKE_BUILD_TYPE=Release \
+ && cmake --build $SIMPHONY_BUILD --parallel "${CMAKE_BUILD_JOBS:-$(nproc)}" --target install
 
 
 FROM base AS develop
@@ -101,10 +101,10 @@ ARG CMAKE_BUILD_JOBS
 
 RUN apt update && apt install -y x11-apps mesa-utils vim
 
-COPY . $OPTICKS_HOME
+COPY . $SIMPHONY_HOME
 
-RUN cmake -S $OPTICKS_HOME -B $OPTICKS_BUILD -DCMAKE_INSTALL_PREFIX=$OPTICKS_PREFIX -DCMAKE_BUILD_TYPE=Debug \
- && cmake --build $OPTICKS_BUILD --parallel "${CMAKE_BUILD_JOBS:-$(nproc)}" --target install
+RUN cmake -S $SIMPHONY_HOME -B $SIMPHONY_BUILD -DCMAKE_INSTALL_PREFIX=$SIMPHONY_PREFIX -DCMAKE_BUILD_TYPE=Debug \
+ && cmake --build $SIMPHONY_BUILD --parallel "${CMAKE_BUILD_JOBS:-$(nproc)}" --target install
 
 
 FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS spack-base
@@ -128,7 +128,9 @@ RUN echo "source /opt/spack/share/spack/setup-env.sh" > /etc/profile.d/z09_sourc
 RUN echo "source /etc/profile.d/z09_source_spack_setup.sh" >> /etc/bash.bashrc
 
 ENV BASH_ENV=/etc/profile.d/z09_source_spack_setup.sh
-ENV OPTICKS_HOME=/workspaces/simphony
+ENV SIMPHONY_PREFIX=/opt/simphony
+ENV SIMPHONY_HOME=/workspaces/simphony
+ENV SIMPHONY_BUILD=/opt/simphony/build
 ENV OPTIX_VERSION=${OPTIX_VERSION}
 ENV GEANT4_VERSION=${GEANT4_VERSION}
 ENV SPACK_BUILDCACHE_MIRROR=${SPACK_BUILDCACHE_MIRROR}
@@ -136,7 +138,7 @@ ENV SPACK_TARGET=${SPACK_TARGET}
 ENV PATH=/opt/spack/bin:${PATH}
 ENV NVIDIA_DRIVER_CAPABILITIES=graphics,compute,utility
 
-WORKDIR ${OPTICKS_HOME}
+WORKDIR ${SIMPHONY_HOME}
 
 SHELL ["/bin/bash", "-l", "-c"]
 
@@ -150,7 +152,7 @@ EOF
 
 FROM spack-base AS spack-no-env
 
-WORKDIR ${OPTICKS_HOME}
+WORKDIR ${SIMPHONY_HOME}
 
 # Intentionally track the latest Spack repo state in CI to catch packaging regressions.
 RUN spack repo update -b develop builtin

--- a/docs/performance-and-debugging.md
+++ b/docs/performance-and-debugging.md
@@ -13,14 +13,17 @@ photons are simulated on the GPU with Simphony and the GPU simulation time is
 saved.
 
 ```shell
-mkdir -p /tmp/out/dev
-mkdir -p /tmp/out/rel
+cd simphony/
 
-docker build -t simphony:perf-dev --target=develop
-docker run --rm -t -v /tmp/out:/tmp/out simphony:perf-dev run-performance -o /tmp/out/dev
+mkdir -p /tmp/out/develop
+docker build -t simphony:develop --target=develop .
+docker run --rm -t -v /tmp/out:/tmp/out simphony:develop \
+    run-performance -g tests/geom/opticks_raindrop.gdml -o /tmp/out/develop
 
-docker build -t simphony:perf-rel --target=release
-docker run --rm -t -v /tmp/out:/tmp/out simphony:perf-rel run-performance -o /tmp/out/rel
+mkdir -p /tmp/out/release
+docker build -t simphony:release --target=release .
+docker run --rm -t -v /tmp/out:/tmp/out simphony:release \
+    run-performance -g tests/geom/opticks_raindrop.gdml -o /tmp/out/release
 ```
 
 ## Debug analysis with `optiphy/ana/photon_history_summary.py`

--- a/optiphy/tools/run_performance.py
+++ b/optiphy/tools/run_performance.py
@@ -79,6 +79,9 @@ def main():
                     logfile.write(f"--- STDERR ---\n{stderr}\n")
                     logfile.flush()
 
+                    if result.returncode != 0:
+                        raise subprocess.CalledProcessError(result.returncode, cmd, output=stdout, stderr=stderr)
+
                     # Save simulation time for true run only
                     if flag == 'true':
                         sim_time_true = parse_sim_time(stdout + stderr)

--- a/optiphy/tools/run_performance.py
+++ b/optiphy/tools/run_performance.py
@@ -1,7 +1,9 @@
 import argparse
-import subprocess
-import re
 import os
+import re
+import subprocess
+import tempfile
+import time
 from pathlib import Path
 
 run_mac_template = """
@@ -13,23 +15,7 @@ run_mac_template = """
 """
 
 os.environ["OPTICKS_EVENT_MODE"] = "Minimal"
-
-def get_opticks_home():
-    """Get OPTICKS_HOME from environment, warn if not set."""
-    opticks_home = os.environ.get("OPTICKS_HOME")
-    if opticks_home is None:
-        print("Warning: $OPTICKS_HOME is not defined, so this script should be called from the simphony directory.")
-        return Path(".")
-    return Path(opticks_home)
-
-def parse_real_time(time_str):
-    # Parses 'real\t0m41.149s' to seconds
-    match = re.search(r'real\s+(\d+)m([\d.]+)s', time_str)
-    if match:
-        minutes = int(match.group(1))
-        seconds = float(match.group(2))
-        return minutes * 60 + seconds
-    return None
+SIMPHONY_GEOM_FILE_ENV = "SIMPHONY_GEOM_FILE"
 
 def parse_sim_time(output):
     match = re.search(r"Simulation time:\s*([\d.]+)\s*seconds", output)
@@ -37,76 +23,78 @@ def parse_sim_time(output):
         return float(match.group(1))
     return None
 
+def resolve_gdml_path(cli_gdml: Path | None) -> Path:
+    """Resolve the GDML path from CLI or environment."""
+    if cli_gdml is not None:
+        return cli_gdml
+
+    env_gdml = os.environ.get(SIMPHONY_GEOM_FILE_ENV)
+    if env_gdml:
+        return Path(env_gdml)
+
+    raise ValueError(
+        f"Provide --gdml or set {SIMPHONY_GEOM_FILE_ENV} to the test geometry path."
+    )
+
 def main():
-    opticks_home = get_opticks_home()
-    
     parser = argparse.ArgumentParser()
-    parser.add_argument('-g', '--gdml', type=Path, default=None, help="Path to a custom GDML geometry file (relative to current directory)")
+    parser.add_argument('-g', '--gdml', type=Path, default=None, help=f"Path to the GDML geometry file. If omitted, uses ${SIMPHONY_GEOM_FILE_ENV}.")
     parser.add_argument('-o', '--outpath', type=Path, default=Path('./'), help="Path where the output file will be saved")
     args = parser.parse_args()
 
-    # If gdml not provided, use default path relative to OPTICKS_HOME
-    if args.gdml is None:
-        gdml_path = opticks_home / 'tests/geom/opticks_raindrop.gdml'
-    else:
-        # User-provided path is used as-is (relative to current directory or absolute)
-        gdml_path = args.gdml
+    try:
+        gdml_path = resolve_gdml_path(args.gdml)
+    except ValueError as err:
+        parser.error(str(err))
 
-    # run.mac is created in OPTICKS_HOME
-    run_mac_path = opticks_home / "run.mac"
+    out_dir = args.outpath.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    geant_file = args.outpath / "timing_geant.txt"
-    optix_file = args.outpath / "timing_optix.txt"
-    log_file = args.outpath / "g4logs.txt"
+    geant_file = out_dir / "timing_geant.txt"
+    optix_file = out_dir / "timing_optix.txt"
+    log_file = out_dir / "g4logs.txt"
 
-    with open(geant_file, "w") as gfile, open(optix_file, "w") as ofile, open(log_file, "w") as logfile:
-        for threads in range(50, 0, -1):
-            times = {}
-            sim_time_true = None
-            for flag in ['true', 'false']:
-                # Write run.mac with current flag
-                with open(run_mac_path, "w") as rm:
-                    rm.write(run_mac_template.format(threads=threads, flag=flag))
+    with tempfile.TemporaryDirectory(prefix="simphony-run-performance-") as tmpdir:
+        run_mac_path = Path(tmpdir) / "run.mac"
 
-                # Run with time in bash to capture real/user/sys
-                cmd = f"time GPUCerenkov -g {gdml_path} -m {run_mac_path}"
-                print(f"Running {threads} threads: {cmd}")
-                result = subprocess.run(
-                    ["bash", "-c", cmd],
-                    capture_output=True, text=True
-                )
-                stdout = result.stdout
-                stderr = result.stderr
-                # Save full output to log file
-                logfile.write(f"\n{'='*60}\n")
-                logfile.write(f"Threads: {threads}, StackPhotons: {flag}\n")
-                logfile.write(f"{'='*60}\n")
-                logfile.write(f"--- STDOUT ---\n{stdout}\n")
-                logfile.write(f"--- STDERR ---\n{stderr}\n")
-                logfile.flush()
+        with open(geant_file, "w") as gfile, open(optix_file, "w") as ofile, open(log_file, "w") as logfile:
+            for threads in range(50, 0, -1):
+                times = {}
+                sim_time_true = None
+                for flag in ['true', 'false']:
+                    run_mac_path.write_text(run_mac_template.format(threads=threads, flag=flag))
 
-                # Save simulation time for true run only
-                if flag == 'true':
-                    sim_time_true = parse_sim_time(stdout + stderr)
-                    if sim_time_true is not None:
-                        ofile.write(f"{threads} {sim_time_true}\n")
-                        ofile.flush()
+                    cmd = ["GPUCerenkov", "-g", str(gdml_path), "-m", str(run_mac_path)]
+                    print(f"Running {threads} threads: {' '.join(cmd)}")
+                    t0 = time.perf_counter()
+                    result = subprocess.run(cmd, capture_output=True, text=True)
+                    elapsed_sec = time.perf_counter() - t0
+                    stdout = result.stdout
+                    stderr = result.stderr
+                    # Save full output to log file
+                    logfile.write(f"\n{'='*60}\n")
+                    logfile.write(f"Threads: {threads}, StackPhotons: {flag}\n")
+                    logfile.write(f"{'='*60}\n")
+                    logfile.write(f"--- STDOUT ---\n{stdout}\n")
+                    logfile.write(f"--- STDERR ---\n{stderr}\n")
+                    logfile.flush()
 
-                # Extract real time
-                real_match = re.search(r"real\s+\d+m[\d.]+s", stderr)
-                if real_match:
-                    real_sec = parse_real_time(real_match.group())
-                    times[flag] = real_sec
+                    # Save simulation time for true run only
+                    if flag == 'true':
+                        sim_time_true = parse_sim_time(stdout + stderr)
+                        if sim_time_true is not None:
+                            ofile.write(f"{threads} {sim_time_true}\n")
+                            ofile.flush()
+
+                    times[flag] = elapsed_sec
+
+                # Write the difference to timing_geant.txt (true - false)
+                if 'true' in times and 'false' in times:
+                    diff = times['true'] - times['false']
+                    gfile.write(f"{threads} {diff}\n")
+                    gfile.flush()
                 else:
-                    print(f"[!] Could not find 'real' time for threads={threads} flag={flag}")
-
-            # Write the difference to timing_geant.txt (true - false)
-            if 'true' in times and 'false' in times:
-                diff = times['true'] - times['false']
-                gfile.write(f"{threads} {diff}\n")
-                gfile.flush()
-            else:
-                print(f"[!] Missing times for threads={threads}")
+                    print(f"[!] Missing times for threads={threads}")
 
     print("Done.")
 

--- a/tests/g4trap_validation.sh
+++ b/tests/g4trap_validation.sh
@@ -16,8 +16,8 @@
 #   ./tests/g4trap_validation.sh scintillation_trd        # scint+Cherenkov trd only
 #
 # Pre-requisites: GPUPhotonSource and GPURaytrace on PATH (any standard
-# install of simphony puts them in OPTICKS_PREFIX/bin which is added to
-# PATH in the Dockerfile and devcontainer).
+# install of simphony puts them in the chosen install prefix's `bin/`,
+# which is added to PATH in the Dockerfile and devcontainer).
 
 set -e
 

--- a/tests/test_GPUPhotonFileSource.sh
+++ b/tests/test_GPUPhotonFileSource.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export OPTICKS_MAX_SLOT=M1
 
 SEED=42
 PASS=true
 PHOTON_FILE=$(mktemp /tmp/test_photons_XXXXXX.txt)
 HITS_FILE=opticks_hits_output.txt
+GEOM_FILE="$SCRIPT_DIR/geom/opticks_raindrop.gdml"
+MAC_FILE="$SCRIPT_DIR/run.mac"
 
 cleanup() {
     rm -f "$PHOTON_FILE" "$HITS_FILE"
@@ -32,9 +35,9 @@ EOF
 
 echo "Running GPUPhotonFileSource with seed $SEED ..."
 OUTPUT=$(GPUPhotonFileSource \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
+    -g "$GEOM_FILE" \
     -p "$PHOTON_FILE" \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -m "$MAC_FILE" \
     -s "$SEED" 2>&1)
 
 LOADED=$(echo "$OUTPUT" | grep "Loaded" | awk '{print $2}')
@@ -100,9 +103,9 @@ EOF
 
 echo "Running GPUPhotonFileSource ..."
 OUTPUT=$(GPUPhotonFileSource \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
+    -g "$GEOM_FILE" \
     -p "$PHOTON_FILE" \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -m "$MAC_FILE" \
     -s "$SEED" 2>&1)
 
 LOADED=$(echo "$OUTPUT" | grep "Loaded" | awk '{print $2}')
@@ -123,8 +126,8 @@ echo ""
 echo "=== Test 3: Missing --photons argument ==="
 
 if GPUPhotonFileSource \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
-    -m "$OPTICKS_HOME/tests/run.mac" 2>&1; then
+    -g "$GEOM_FILE" \
+    -m "$MAC_FILE" 2>&1; then
     echo "FAILED: Should have exited with error for missing --photons"
     PASS=false
 else

--- a/tests/test_GPUPhotonSource_8x8SiPM.sh
+++ b/tests/test_GPUPhotonSource_8x8SiPM.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 export OPTICKS_MAX_BOUNCE=32
 
 SEED=42
 NSIGMA=3
 PASS=true
+GEOM_FILE="$SCRIPT_DIR/geom/8x8SiPM_w_CSI_optial_grease.gdml"
+MAC_FILE="$SCRIPT_DIR/run.mac"
 
 check_within_nsigma() {
     local label=$1
@@ -42,9 +45,9 @@ echo "Config: 1000 photons inside crystal at (-8.7, -8.7, 4.0)mm, 420nm, disc r=
 echo "Running GPUPhotonSource with seed $SEED ..."
 
 OUTPUT=$(GPUPhotonSource \
-    -g "$OPTICKS_HOME/tests/geom/8x8SiPM_w_CSI_optial_grease.gdml" \
+    -g "$GEOM_FILE" \
     -c 8x8SiPM_crystal \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -m "$MAC_FILE" \
     -s "$SEED" 2>&1)
 
 G4_HITS=$(echo "$OUTPUT" | grep "Geant4: NumHits:" | awk '{print $NF}')

--- a/tests/test_GPURaytrace.sh
+++ b/tests/test_GPURaytrace.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 SEED=42
 TOLERANCE=113
 PASS=true
+MAC_FILE="$SCRIPT_DIR/run.mac"
+GEOM_CERENKOV="$SCRIPT_DIR/geom/opticks_raindrop.gdml"
+GEOM_SCINT="$SCRIPT_DIR/geom/opticks_raindrop_with_scintillation.gdml"
+GEOM_REEMIT="$SCRIPT_DIR/geom/opticks_raindrop_reemit_no_scint.gdml"
 
 GEANT4_VERSION=$(geant4-version version)
 GEANT4_SERIES=$(geant4-version series)
@@ -68,8 +73,8 @@ set_expected_hits cerenkov
 
 echo "Running GPURaytrace with seed $SEED ..."
 OUTPUT=$(GPURaytrace \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop.gdml" \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -g "$GEOM_CERENKOV" \
+    -m "$MAC_FILE" \
     -s "$SEED" 2>&1)
 
 G4_HITS=$(echo "$OUTPUT" | grep "Geant4: NumHits:" | awk '{print $NF}')
@@ -88,8 +93,8 @@ set_expected_hits cerenkov_scintillation
 
 echo "Running GPURaytrace with seed $SEED ..."
 OUTPUT=$(GPURaytrace \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop_with_scintillation.gdml" \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -g "$GEOM_SCINT" \
+    -m "$MAC_FILE" \
     -s "$SEED" 2>&1)
 
 G4_HITS=$(echo "$OUTPUT" | grep "Geant4: NumHits:" | awk '{print $NF}')
@@ -107,8 +112,8 @@ echo "=== Test 3: Cerenkov + Re-emission, no Scintillation (opticks_raindrop_ree
 
 echo "Running GPURaytrace with seed $SEED ..."
 USER=fakeuser GEOM=fakegeom GPURaytrace \
-    -g "$OPTICKS_HOME/tests/geom/opticks_raindrop_reemit_no_scint.gdml" \
-    -m "$OPTICKS_HOME/tests/run.mac" \
+    -g "$GEOM_REEMIT" \
+    -m "$MAC_FILE" \
     -s "$SEED"
 
 # ---- Summary ----

--- a/tests/test_simg4ox.sh
+++ b/tests/test_simg4ox.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-simg4ox -g "$OPTICKS_HOME/tests/geom/raindrop.gdml" -m "$OPTICKS_HOME/tests/run.mac"
-python "$OPTICKS_HOME/tests/compare_ab.py"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+simg4ox -g "$SCRIPT_DIR/geom/raindrop.gdml" -m "$SCRIPT_DIR/run.mac"
+python3 "$SCRIPT_DIR/compare_ab.py"

--- a/tests/test_triangulated.sh
+++ b/tests/test_triangulated.sh
@@ -17,9 +17,10 @@
 # tolerance below absorbs cross-OptiX-version numerics while still failing hard
 # if the triangulated-GAS wiring breaks (zero / grossly wrong hits).
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-GDML="$OPTICKS_HOME/tests/geom/opticks_raindrop_sphere.gdml"
-MAC="$OPTICKS_HOME/tests/run.mac"
+GDML="$SCRIPT_DIR/geom/opticks_raindrop_sphere.gdml"
+MAC="$SCRIPT_DIR/run.mac"
 SEED=42
 TOL=0.02
 

--- a/tests/test_triangulated_multi.sh
+++ b/tests/test_triangulated_multi.sh
@@ -16,9 +16,10 @@
 # forceA,B. If naming A also triangulated B, forceA would equal forceA,B -- so
 # this ordering proves each named solid triangulates only itself.
 set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-GDML="$OPTICKS_HOME/tests/geom/opticks_two_spheres.gdml"
-MAC="$OPTICKS_HOME/tests/run.mac"
+GDML="$SCRIPT_DIR/geom/opticks_two_spheres.gdml"
+MAC="$SCRIPT_DIR/run.mac"
 SEED=42
 RES=U4Mesh__NumberOfRotationSteps_entityType_G4Orb=12
 hits(){ awk '/Opticks: NumHits:/ {print $NF}'; }


### PR DESCRIPTION
This PR reduces the top-level test and tooling dependence on legacy `OPTICKS_*` environment
variables.

The main goal is not a full repo-wide removal yet, but to stop requiring `OPTICKS_HOME`,
`OPTICKS_PREFIX`, and `OPTICKS_BUILD` for the test paths we run regularly and for the container
workflows around them.

The top-level tests continue to pass without `OPTICKS_*` because they now pass geometry and macro
paths explicitly, and the runtime already resolves config/PTX through compiled-in search paths
rather than `OPTICKS_HOME`/`OPTICKS_PREFIX`.

This PR focuses on the active test workflow and related tooling.

It does **not** remove all remaining legacy `OPTICKS_*` references across the repo. Older helper
scripts and standalone tests in areas like `sysrap/tests`, `qudarap/tests`, `u4/tests`, and
`CSG/tests` still contain those references and may need a follow-up sweep.
