### PR TITLE
fix(docker): add XKB headers and drop OpenSSL dev package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt update \
  && apt install -y libssl-dev \
     nlohmann-json3-dev \
     libglfw3-dev libglu1-mesa-dev libxmu-dev libglew-dev libglm-dev \
+    libxkbcommon-dev \
     qt6-base-dev libxerces-c-dev libexpat1-dev \
  && apt clean \
  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ RUN apt update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN apt update \
- && apt install -y libssl-dev \
-    nlohmann-json3-dev \
+ && apt install -y nlohmann-json3-dev \
     libglfw3-dev libglu1-mesa-dev libxmu-dev libglew-dev libglm-dev \
     libxkbcommon-dev \
     qt6-base-dev libxerces-c-dev libexpat1-dev \


### PR DESCRIPTION
- Add `libxkbcommon-dev` to the base image dependencies so Qt/Geant4 CMake configuration can find XKB headers and libraries.
- Remove `libssl-dev`, since the image no longer needs OpenSSL headers for MD5 support.

Fixes #369