### PR TITLE
ci: publish reusable base image cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,17 +1,6 @@
 {
   "name": "simphony",
-  "build": {
-    "dockerfile": "../Dockerfile",
-    "context": "..",
-    "target": "base",
-    // Uncomment to rebuild the devcontainer with custom build args, e.g. a different CUDA version.
-    //"args": {
-    //  "CUDA_VERSION": "12.5.1"
-    //},
-    "cacheFrom": [
-      "ghcr.io/bnlnpps/simphony:base"
-    ]
-  },
+  "image": "ghcr.io/bnlnpps/simphony:base",
   "features": {
     "./features/llvm": {
       "version": "23"

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -97,9 +97,11 @@ jobs:
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
+          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
           BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
+          echo BASE_CACHE_REF=${IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
           echo CACHE_REF=${IMAGE_NAME}:${BUILD_VARIANT} >> $GITHUB_ENV
 
       - name: Checkout code
@@ -128,7 +130,9 @@ jobs:
             OPTIX_VERSION=${{ matrix.optix_version }}
             GEANT4_VERSION=${{ matrix.geant4_version }}
             CMAKE_VERSION=${{ matrix.cmake_version }}
-          cache-from: type=registry,ref=${{ env.CACHE_REF }}
+          cache-from: |
+            type=registry,ref=${{ env.BASE_CACHE_REF }}
+            type=registry,ref=${{ env.CACHE_REF }}
           push: ${{ matrix.target == 'develop' && github.event.pull_request.head.repo.full_name == github.repository }}
 
   test-develop-image:

--- a/.github/workflows/build-push-base.yaml
+++ b/.github/workflows/build-push-base.yaml
@@ -1,10 +1,22 @@
-name: Build Push Image
+name: Build Push Base Image
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'
   push:
     branches:
       - main
-      - test
+    paths:
+      - Dockerfile
+      - pyproject.toml
+      - uv.lock
+      - optiphy/**
+      - .github/workflows/build-push-base.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name || github.event_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,60 +24,47 @@ permissions:
 
 jobs:
 
-  build-push:
+  build-push-base:
+    if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: release
-            os: ubuntu24.04
+          - os: ubuntu24.04
             cuda_version: 13.2.0
             optix_version: 9.1.0
             geant4_version: 11.4.1
             cmake_version: 4.3.1
-          - target: release
-            os: ubuntu24.04
+            default_alias: false
+          - os: ubuntu24.04
             cuda_version: 13.0.2
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 4.2.1
-          - target: release
-            os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
-          - target: develop
-            os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - target: develop
-            os: ubuntu24.04
+            default_alias: true
+          - os: ubuntu24.04
             cuda_version: 12.5.1
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 3.28.3
-          - target: develop
-            os: ubuntu22.04
+            default_alias: false
+          - os: ubuntu22.04
             cuda_version: 12.1.1
             optix_version: 8.0.0
             geant4_version: 11.3.2
             cmake_version: 3.22.1
+            default_alias: false
 
     steps:
       - name: Define environment variables
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           CACHE_IMAGE_NAME=${IMAGE_NAME}-buildcache
-          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${BUILD_VARIANT} >> $GITHUB_ENV
-          echo BASE_CACHE_REF=${CACHE_IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
           echo CACHE_REF=${CACHE_IMAGE_NAME}:${BUILD_VARIANT} >> $GITHUB_ENV
 
       - name: Checkout code
@@ -81,33 +80,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push to registries
+      - name: Build and push base image
         uses: docker/build-push-action@v6
         with:
           context: .
+          pull: true
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-          target: ${{ matrix.target }}
+          target: base
           build-args: |
             OS=${{ matrix.os }}
             CUDA_VERSION=${{ matrix.cuda_version }}
             OPTIX_VERSION=${{ matrix.optix_version }}
             GEANT4_VERSION=${{ matrix.geant4_version }}
             CMAKE_VERSION=${{ matrix.cmake_version }}
-          cache-from: |
-            type=registry,ref=${{ env.BASE_CACHE_REF }}
-            type=registry,ref=${{ env.CACHE_REF }}
+          cache-from: type=registry,ref=${{ env.CACHE_REF }}
           cache-to: type=registry,ref=${{ env.CACHE_REF }},mode=max
+          no-cache-filters: ${{ github.event_name != 'push' && 'base' || '' }}
 
-      - name: Add devel alias tag for default CUDA
-        if: ${{ github.ref_name == 'main' && matrix.target == 'develop' && matrix.os == 'ubuntu24.04' && matrix.cuda_version == '13.0.2' && matrix.optix_version == '9.0.0' && matrix.geant4_version == '11.4.1' && matrix.cmake_version == '4.2.1' }}
+      - name: Add base alias tag for default CUDA
+        if: ${{ github.ref_name == 'main' && matrix.default_alias }}
         run: |
-          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:develop ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:base ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
   cleanup:
     runs-on: ubuntu-latest
-    needs: build-push
+    needs: build-push-base
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,10 +30,12 @@ jobs:
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           CACHE_IMAGE_NAME=${IMAGE_NAME}-buildcache
           REF_SANITIZED=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
           BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
           echo IMAGE_TAG_SHORT=${REF_SANITIZED} >> $GITHUB_ENV
+          echo BASE_CACHE_REF=${CACHE_IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
           echo CACHE_REF=${CACHE_IMAGE_NAME}:${BUILD_VARIANT} >> $GITHUB_ENV
 
       - name: Checkout code
@@ -65,7 +67,9 @@ jobs:
             OPTIX_VERSION=${{ matrix.optix_version }}
             GEANT4_VERSION=${{ matrix.geant4_version }}
             CMAKE_VERSION=${{ matrix.cmake_version }}
-          cache-from: type=registry,ref=${{ env.CACHE_REF }}
+          cache-from: |
+            type=registry,ref=${{ env.BASE_CACHE_REF }}
+            type=registry,ref=${{ env.CACHE_REF }}
           cache-to: type=registry,ref=${{ env.CACHE_REF }},mode=max
 
   cleanup:

--- a/README.md
+++ b/README.md
@@ -51,11 +51,17 @@ and development-environment details.
 
 ## Supported Images
 
-The `build-push.yaml` workflow publishes the versioned container tags below to GHCR on pushes to `main`, while `release.yaml` publishes the `latest` alias on tagged releases. Tag entries link to the
+The `build-push-base.yaml` workflow publishes reusable `base` images for development environments and Docker build
+cache warmup. The `build-push.yaml` workflow publishes the versioned container tags below to GHCR on pushes to `main`,
+while `release.yaml` publishes the `latest` alias on tagged releases. Tag entries link to the
 [Simphony package page](https://github.com/BNLNPPS/simphony/pkgs/container/simphony).
 
 | Target | OS | CUDA | OptiX | Geant4 | Alias | Tag |
 |---|---|---:|---:|---:|---|---|
+| `base` | `ubuntu24.04` | `13.2.0` | `9.1.0` | `11.4.1` | | [cuda13.2.0-base-ubuntu24.04-optix9.1.0-geant411.4.1-cmake4.3.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `base` | `ubuntu24.04` | `13.0.2` | `9.0.0` | `11.4.1` | `base` | [cuda13.0.2-base-ubuntu24.04-optix9.0.0-geant411.4.1-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `base` | `ubuntu24.04` | `12.5.1` | `9.0.0` | `11.4.1` | | [cuda12.5.1-base-ubuntu24.04-optix9.0.0-geant411.4.1-cmake3.28.3](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `base` | `ubuntu22.04` | `12.1.1` | `8.0.0` | `11.3.2` | | [cuda12.1.1-base-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `release` | `ubuntu24.04` | `13.2.0` | `9.1.0` | `11.4.1` | | [cuda13.2.0-release-ubuntu24.04-optix9.1.0-geant411.4.1-cmake4.3.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `release` | `ubuntu24.04` | `13.0.2` | `9.0.0` | `11.4.1` | `latest` | [cuda13.0.2-release-ubuntu24.04-optix9.0.0-geant411.4.1-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `release` | `ubuntu22.04` | `12.1.1` | `8.0.0` | `11.3.2` | | [cuda12.1.1-release-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |


### PR DESCRIPTION
This PR makes the Docker `base` stage a first-class CI artifact and uses it to speed up both CI
image builds and devcontainer startup.

The new base-image workflow publishes versioned `base` images to GHCR, exports BuildKit registry
caches for those base variants, and maintains the default `ghcr.io/bnlnpps/simphony:base` alias used
by the devcontainer.

- Add `build-push-base.yaml` to build and publish the Dockerfile `base` target for supported CUDA/Ubuntu/OptiX/Geant4/CMake combinations.
- Export base-stage BuildKit caches to `ghcr.io/bnlnpps/simphony-buildcache:<base-variant>` with `mode=max`.
- Refresh base images on:
  - manual workflow dispatch
  - weekly schedule
  - pushes to `main` that touch base-relevant inputs
- Add `pull: true` for base builds so scheduled/manual refreshes pick up updated upstream CUDA parent images.
- Add a `base` alias for the default environment:
  - CUDA 13.0.2
  - Ubuntu 24.04
  - OptiX 9.0.0
  - Geant4 11.4.1
  - CMake 4.2.1
- Update PR, push, and release image workflows to import both:
  - `BASE_CACHE_REF` for shared base-stage layers
  - `CACHE_REF` for target-specific `develop`/`release` layers
- Switch the default devcontainer to pull `ghcr.io/bnlnpps/simphony:base` directly for faster startup.
- Document the new published base image variants in the README.

The Dockerfile `base` stage is the expensive, slow-moving part of the image build. It installs
system dependencies and builds large dependencies such as CLHEP, Geant4, OptiX headers, CMake, and
Python dependencies.

Publishing this stage separately gives CI and developers a stable reusable foundation while keeping
`develop` and `release` image builds focused on source changes. This also makes the devcontainer
contract explicit: `ghcr.io/bnlnpps/simphony:base` is now produced by CI rather than being an
implied or stale tag.

The root devcontainer is optimized for the fast default path by pulling the published base image.
