### PR TITLE
build(cmake): raise minimum CMake version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.22)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/dd4hepplugins/CMakeLists.txt
+++ b/dd4hepplugins/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Detect standalone vs in-tree build
 if(NOT TARGET G4CX)
-    cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
     project(ddsimphony VERSION 0.1.0 LANGUAGES CXX)
     find_package(DD4hep REQUIRED COMPONENTS DDG4 DDCore)
     find_package(simphony REQUIRED)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ GPU.
 - CUDA 12.1+
 - NVIDIA OptiX 7+
 - Geant4 11.3+
-- CMake 3.18+
+- CMake 3.22+
 - Python 3.10+
 
 OptiX releases have specific [minimum NVIDIA driver

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 
 project(simphox LANGUAGES CXX)
 

--- a/examples/MC_Truth/CMakeLists.txt
+++ b/examples/MC_Truth/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 
 project(GPUMCTruth LANGUAGES CXX)
 

--- a/examples/async_gpu_launch/CMakeLists.txt
+++ b/examples/async_gpu_launch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 
 project(async_gpu_launch LANGUAGES CXX)
 

--- a/examples/async_gpu_std/CMakeLists.txt
+++ b/examples/async_gpu_std/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.22)
 
 project(async_gpu_std LANGUAGES CXX)
 

--- a/sysrap/SGLFW_tests/CMakeLists.txt
+++ b/sysrap/SGLFW_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
 set(name SGLFW_tests)
 project(${name} VERSION 0.1.0)
 include(OpticksBuildOptions)


### PR DESCRIPTION
Raise Simphony's declared minimum CMake version to 3.22 across the main project, standalone
examples, DD4hep plugin standalone mode, and the standalone SGLFW test target.

Ubuntu 22.04 is the intended minimum supported platform baseline for Simphony, and its system
package baseline includes CMake 3.22.1.

The project now relies on CMake features such as `PROJECT_IS_TOP_LEVEL`, which are supported by
CMake 3.22. Raising the declared minimum keeps the build requirements aligned with the supported
platform policy and avoids older CMake versions silently misconfiguring testing defaults.
