### PR TITLE
ci: consolidate container image build matrices

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -56,15 +56,15 @@ jobs:
       matrix:
         target: [release, develop]
         config: &build_configs
-          - os: ubuntu24.04
-            cuda_version: 13.2.0
+          - os: ubuntu26.04
+            cuda_version: 13.3.0
             optix_version: 9.1.0
-            geant4_version: 11.4.1
-            cmake_version: 4.3.1
+            geant4_version: 11.4.2
+            cmake_version: 4.3.4
           - os: ubuntu24.04
-            cuda_version: 13.0.2
+            cuda_version: 13.0.3
             optix_version: 9.0.0
-            geant4_version: 11.4.1
+            geant4_version: 11.4.2
             cmake_version: 4.2.1
           - os: ubuntu24.04
             cuda_version: 12.5.1
@@ -134,13 +134,13 @@ jobs:
         target: [release, develop]
         config: *build_configs
         exclude:
-          # The gpu runner driver does not support OptiX 9.1.0 yet
+          # The gpu runner driver does not support the ubuntu26.04/CUDA 13.3.0 image yet.
           - config:
-              os: ubuntu24.04
-              cuda_version: 13.2.0
+              os: ubuntu26.04
+              cuda_version: 13.3.0
               optix_version: 9.1.0
-              geant4_version: 11.4.1
-              cmake_version: 4.3.1
+              geant4_version: 11.4.2
+              cmake_version: 4.3.4
 
     steps:
       - name: Define environment variables

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
-      - test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name || github.event_name }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -18,51 +21,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: release
-            os: ubuntu24.04
-            cuda_version: 13.2.0
+        target: [release, develop]
+        config:
+          - os: ubuntu26.04
+            cuda_version: 13.3.0
             optix_version: 9.1.0
-            geant4_version: 11.4.1
-            cmake_version: 4.3.1
-          - target: release
-            os: ubuntu24.04
-            cuda_version: 13.0.2
+            geant4_version: 11.4.2
+            cmake_version: 4.3.4
+            default_alias: false
+          - os: ubuntu24.04
+            cuda_version: 13.0.3
             optix_version: 9.0.0
-            geant4_version: 11.4.1
+            geant4_version: 11.4.2
             cmake_version: 4.2.1
-          - target: release
-            os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
-          - target: develop
-            os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - target: develop
-            os: ubuntu24.04
+            default_alias: true
+          - os: ubuntu24.04
             cuda_version: 12.5.1
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 3.28.3
-          - target: develop
-            os: ubuntu22.04
+            default_alias: false
+          - os: ubuntu22.04
             cuda_version: 12.1.1
             optix_version: 8.0.0
             geant4_version: 11.3.2
             cmake_version: 3.22.1
+            default_alias: false
 
     steps:
       - name: Define environment variables
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           CACHE_IMAGE_NAME=${IMAGE_NAME}-buildcache
-          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BASE_VARIANT=cuda${{ matrix.config.cuda_version }}-base-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${BUILD_VARIANT} >> $GITHUB_ENV
           echo BASE_CACHE_REF=${CACHE_IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
@@ -90,18 +82,18 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           target: ${{ matrix.target }}
           build-args: |
-            OS=${{ matrix.os }}
-            CUDA_VERSION=${{ matrix.cuda_version }}
-            OPTIX_VERSION=${{ matrix.optix_version }}
-            GEANT4_VERSION=${{ matrix.geant4_version }}
-            CMAKE_VERSION=${{ matrix.cmake_version }}
+            OS=${{ matrix.config.os }}
+            CUDA_VERSION=${{ matrix.config.cuda_version }}
+            OPTIX_VERSION=${{ matrix.config.optix_version }}
+            GEANT4_VERSION=${{ matrix.config.geant4_version }}
+            CMAKE_VERSION=${{ matrix.config.cmake_version }}
           cache-from: |
             type=registry,ref=${{ env.BASE_CACHE_REF }}
             type=registry,ref=${{ env.CACHE_REF }}
           cache-to: type=registry,ref=${{ env.CACHE_REF }},mode=max
 
-      - name: Add devel alias tag for default CUDA
-        if: ${{ github.ref_name == 'main' && matrix.target == 'develop' && matrix.os == 'ubuntu24.04' && matrix.cuda_version == '13.0.2' && matrix.optix_version == '9.0.0' && matrix.geant4_version == '11.4.1' && matrix.cmake_version == '4.2.1' }}
+      - name: Add alias tag for default configuration
+        if: ${{ github.ref_name == 'main' && matrix.target == 'develop' && matrix.config.default_alias }}
         run: |
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:develop ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - '[0-9]*'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   packages: write
@@ -16,13 +20,14 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          - target: release
-            os: ubuntu24.04
-            cuda_version: 13.0.2
+        target: [release]
+        config:
+          - os: ubuntu24.04
+            cuda_version: 13.0.3
             optix_version: 9.0.0
-            geant4_version: 11.4.1
+            geant4_version: 11.4.2
             cmake_version: 4.2.1
+            default_alias: true
 
     steps:
       - name: Define environment variables
@@ -30,8 +35,8 @@ jobs:
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
           CACHE_IMAGE_NAME=${IMAGE_NAME}-buildcache
           REF_SANITIZED=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
-          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BASE_VARIANT=cuda${{ matrix.config.cuda_version }}-base-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
           echo IMAGE_TAG_SHORT=${REF_SANITIZED} >> $GITHUB_ENV
@@ -58,19 +63,23 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_SHORT }}
-            ${{ env.IMAGE_NAME }}:latest
           target: ${{ matrix.target }}
           build-args: |
-            OS=${{ matrix.os }}
-            CUDA_VERSION=${{ matrix.cuda_version }}
-            OPTIX_VERSION=${{ matrix.optix_version }}
-            GEANT4_VERSION=${{ matrix.geant4_version }}
-            CMAKE_VERSION=${{ matrix.cmake_version }}
+            OS=${{ matrix.config.os }}
+            CUDA_VERSION=${{ matrix.config.cuda_version }}
+            OPTIX_VERSION=${{ matrix.config.optix_version }}
+            GEANT4_VERSION=${{ matrix.config.geant4_version }}
+            CMAKE_VERSION=${{ matrix.config.cmake_version }}
           cache-from: |
             type=registry,ref=${{ env.BASE_CACHE_REF }}
             type=registry,ref=${{ env.CACHE_REF }}
           cache-to: type=registry,ref=${{ env.CACHE_REF }},mode=max
+
+      - name: Add alias tag for default configuration
+        if: ${{ matrix.target == 'release' && matrix.config.default_alias }}
+        run: |
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:latest ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG_SHORT }} ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
   cleanup:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 # syntax=docker/dockerfile:latest
 
 ARG OS=ubuntu24.04
-ARG CUDA_VERSION=13.0.2
+ARG CUDA_VERSION=13.0.3
 ARG OPTIX_VERSION=9.0.0
-ARG GEANT4_VERSION=11.4.1
+ARG GEANT4_VERSION=11.4.2
 ARG CMAKE_VERSION=4.2.1
+ARG PYTHON_VERSION=3.13
 ARG SPACK_BUILDCACHE_MIRROR=oci://ghcr.io/bnlnpps/simphony-spack-buildcache
 ARG SPACK_TARGET=x86_64_v2
 
@@ -13,6 +14,7 @@ FROM nvidia/cuda:${CUDA_VERSION}-devel-${OS} AS base
 ARG OPTIX_VERSION
 ARG GEANT4_VERSION
 ARG CMAKE_VERSION
+ARG PYTHON_VERSION
 ARG CMAKE_BUILD_JOBS
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -52,6 +54,9 @@ RUN mkdir -p /opt/optix && curl -sL https://github.com/NVIDIA/optix-dev/archive/
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
+ENV UV_PYTHON=${PYTHON_VERSION}
+ENV UV_MANAGED_PYTHON=1
+
 SHELL ["/bin/bash", "-l", "-c"]
 
 # Set up non-interactive shells by sourcing all of the scripts in /etc/profile.d/
@@ -82,7 +87,7 @@ WORKDIR $SIMPHONY_HOME
 # Install Python dependencies
 COPY pyproject.toml uv.lock $SIMPHONY_HOME/
 COPY optiphy $SIMPHONY_HOME/optiphy
-RUN uv sync
+RUN uv sync --python "${PYTHON_VERSION}" --managed-python
 
 
 FROM base AS release

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ while `release.yaml` publishes the `latest` alias on tagged releases. Tag entrie
 
 | Target | OS | CUDA | OptiX | Geant4 | Alias | Tag |
 |---|---|---:|---:|---:|---|---|
-| `base` | `ubuntu24.04` | `13.2.0` | `9.1.0` | `11.4.1` | | [cuda13.2.0-base-ubuntu24.04-optix9.1.0-geant411.4.1-cmake4.3.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
-| `base` | `ubuntu24.04` | `13.0.2` | `9.0.0` | `11.4.1` | `base` | [cuda13.0.2-base-ubuntu24.04-optix9.0.0-geant411.4.1-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `base` | `ubuntu26.04` | `13.3.0` | `9.1.0` | `11.4.2` | | [cuda13.3.0-base-ubuntu26.04-optix9.1.0-geant411.4.2-cmake4.3.4](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `base` | `ubuntu24.04` | `13.0.3` | `9.0.0` | `11.4.2` | `base` | [cuda13.0.3-base-ubuntu24.04-optix9.0.0-geant411.4.2-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `base` | `ubuntu24.04` | `12.5.1` | `9.0.0` | `11.4.1` | | [cuda12.5.1-base-ubuntu24.04-optix9.0.0-geant411.4.1-cmake3.28.3](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `base` | `ubuntu22.04` | `12.1.1` | `8.0.0` | `11.3.2` | | [cuda12.1.1-base-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
-| `release` | `ubuntu24.04` | `13.2.0` | `9.1.0` | `11.4.1` | | [cuda13.2.0-release-ubuntu24.04-optix9.1.0-geant411.4.1-cmake4.3.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
-| `release` | `ubuntu24.04` | `13.0.2` | `9.0.0` | `11.4.1` | `latest` | [cuda13.0.2-release-ubuntu24.04-optix9.0.0-geant411.4.1-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `release` | `ubuntu26.04` | `13.3.0` | `9.1.0` | `11.4.2` | | [cuda13.3.0-release-ubuntu26.04-optix9.1.0-geant411.4.2-cmake4.3.4](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `release` | `ubuntu24.04` | `13.0.3` | `9.0.0` | `11.4.2` | `latest` | [cuda13.0.3-release-ubuntu24.04-optix9.0.0-geant411.4.2-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `release` | `ubuntu22.04` | `12.1.1` | `8.0.0` | `11.3.2` | | [cuda12.1.1-release-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
-| `develop` | `ubuntu24.04` | `13.0.2` | `9.0.0` | `11.4.1` | `develop` | [cuda13.0.2-develop-ubuntu24.04-optix9.0.0-geant411.4.1-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
+| `develop` | `ubuntu24.04` | `13.0.3` | `9.0.0` | `11.4.2` | `develop` | [cuda13.0.3-develop-ubuntu24.04-optix9.0.0-geant411.4.2-cmake4.2.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `develop` | `ubuntu24.04` | `12.5.1` | `9.0.0` | `11.4.1` | | [cuda12.5.1-develop-ubuntu24.04-optix9.0.0-geant411.4.1-cmake3.28.3](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 | `develop` | `ubuntu22.04` | `12.1.1` | `8.0.0` | `11.3.2` | | [cuda12.1.1-develop-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1](https://github.com/BNLNPPS/simphony/pkgs/container/simphony) |
 


### PR DESCRIPTION
This PR consolidates the container build matrices so release and develop images are generated from the same configuration list, instead of maintaining separate duplicated matrix entries. It also refreshes the default CUDA/Geant4 image versions and keeps the README image table aligned with the workflow tags.

## Changes

- Consolidates `build-push.yaml` around a shared `target: [release, develop]` and `config` matrix.
- Adds matrix-level `default_alias` metadata so alias tagging no longer depends on hard-coded version checks.
- Updates default container versions:
  - CUDA `13.0.2` -> `13.0.3`
  - Geant4 `11.4.1` -> `11.4.2`
  - Adds Ubuntu `26.04` / CUDA `13.3.0` / OptiX `9.1.0` / CMake `4.3.4`
- Updates PR build coverage to test both `release` and `develop` targets across the refreshed matrix.
- Keeps the Ubuntu 26.04 / CUDA 13.3.0 GPU test excluded until runner support is available.
- Adds workflow concurrency controls for push and release builds.
- Updates release tagging so `latest` and the short release tag are created as aliases for the default release configuration.
- Updates the Dockerfile defaults and makes `uv` use managed Python `3.13`.
- Refreshes the README container image table to match the new image tags and aliases.