### PR TITLE
ci: test release and develop PR images

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -54,39 +54,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: release
-            os: ubuntu24.04
+        target: [release, develop]
+        config: &build_configs
+          - os: ubuntu24.04
             cuda_version: 13.2.0
             optix_version: 9.1.0
             geant4_version: 11.4.1
             cmake_version: 4.3.1
-          - target: release
-            os: ubuntu24.04
+          - os: ubuntu24.04
             cuda_version: 13.0.2
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 4.2.1
-          - target: release
-            os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
-          - target: develop
-            os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - target: develop
-            os: ubuntu24.04
+          - os: ubuntu24.04
             cuda_version: 12.5.1
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 3.28.3
-          - target: develop
-            os: ubuntu22.04
+          - os: ubuntu22.04
             cuda_version: 12.1.1
             optix_version: 8.0.0
             geant4_version: 11.3.2
@@ -97,8 +82,8 @@ jobs:
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BASE_VARIANT=cuda${{ matrix.config.cuda_version }}-base-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
           echo BASE_CACHE_REF=${IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
@@ -125,17 +110,17 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           target: ${{ matrix.target }}
           build-args: |
-            OS=${{ matrix.os }}
-            CUDA_VERSION=${{ matrix.cuda_version }}
-            OPTIX_VERSION=${{ matrix.optix_version }}
-            GEANT4_VERSION=${{ matrix.geant4_version }}
-            CMAKE_VERSION=${{ matrix.cmake_version }}
+            OS=${{ matrix.config.os }}
+            CUDA_VERSION=${{ matrix.config.cuda_version }}
+            OPTIX_VERSION=${{ matrix.config.optix_version }}
+            GEANT4_VERSION=${{ matrix.config.geant4_version }}
+            CMAKE_VERSION=${{ matrix.config.cmake_version }}
           cache-from: |
             type=registry,ref=${{ env.BASE_CACHE_REF }}
             type=registry,ref=${{ env.CACHE_REF }}
-          push: ${{ matrix.target == 'develop' && github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
-  test-develop-image:
+  test-image:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     needs: build-image
     runs-on: [gpu]
@@ -145,30 +130,24 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: &develop_matrix
-        include:
-          - os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - os: ubuntu24.04
-            cuda_version: 12.5.1
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 3.28.3
-          - os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
+      matrix:
+        target: [release, develop]
+        config: *build_configs
+        exclude:
+          # The gpu runner driver does not support OptiX 9.1.0 yet
+          - config:
+              os: ubuntu24.04
+              cuda_version: 13.2.0
+              optix_version: 9.1.0
+              geant4_version: 11.4.1
+              cmake_version: 4.3.1
 
     steps:
       - name: Define environment variables
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-develop-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
 
@@ -179,7 +158,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull develop image
+      - name: Pull PR image
         run: |
           docker pull ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
@@ -206,21 +185,23 @@ jobs:
 
   cleanup-pr-images:
     if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: test-develop-image
+    needs: test-image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
-      matrix: *develop_matrix
+      matrix:
+        target: [release, develop]
+        config: *build_configs
 
     steps:
       - name: Define environment variables
         run: |
           PACKAGE_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-develop-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
 

--- a/qudarap/QEvt.cc
+++ b/qudarap/QEvt.cc
@@ -718,10 +718,16 @@ NP* QEvt::gatherPhotonLite() const
     return l ;
 }
 
-
-
-
-
+/**
+ * Gensteps originate on host and are uploaded to device. Gathering from the
+ * device returns the currently uploaded launch slice.
+ */
+NP* QEvt::gatherGenstepFromDevice() const
+{
+    NP* a = NP::Make<float>(evt->num_genstep, 6, 4);
+    QU::copy_device_to_host<quad6>((quad6*)a->bytes(), evt->genstep, evt->num_genstep);
+    return a;
+}
 
 #ifndef PRODUCTION
 
@@ -736,23 +742,6 @@ NP* QEvt::gatherSeed() const
 }
 
 NP* QEvt::gatherDomain() const { return sev ? sev->gatherDomain() : nullptr ; }
-
-
-/**
-QEvt::gatherGenstepFromDevice
----------------------------------
-
-Gensteps originate on host and are uploaded to device, so downloading
-them from device is not usually done. It is for debugging only.
-
-**/
-
-NP* QEvt::gatherGenstepFromDevice() const
-{
-    NP* a = NP::Make<float>( evt->num_genstep, 6, 4 );
-    QU::copy_device_to_host<quad6>( (quad6*)a->bytes(), evt->genstep, evt->num_genstep );
-    return a ;
-}
 
 
 void QEvt::gatherSimtrace(NP* t) const
@@ -1383,6 +1372,9 @@ NP* QEvt::gatherComponent_(unsigned cmp) const
         case SCOMP_HITLITEMERGED: a = gatherHitLiteMerged()     ; break ;
         case SCOMP_HITMERGED:     a = gatherHitMerged()         ; break ;
         case SCOMP_RECORD:        a = gatherRecord();             break;
+        case SCOMP_GENSTEP:
+            a = gatherGenstepFromDevice();
+            break;
 #ifndef PRODUCTION
         case SCOMP_DOMAIN:    a = gatherDomain()      ; break ;
         case SCOMP_REC:       a = gatherRec()      ; break ;
@@ -1392,9 +1384,6 @@ NP* QEvt::gatherComponent_(unsigned cmp) const
         case SCOMP_SIMTRACE:  a = gatherSimtrace() ; break ;
         case SCOMP_TAG:       a = gatherTag()      ; break ;
         case SCOMP_FLAT:      a = gatherFlat()     ; break ;
-        case SCOMP_GENSTEP:   a = gatherGenstepFromDevice() ; break ;
-#else
-        case SCOMP_GENSTEP:   a = getGenstep()     ; break ;
 #endif
     }
     return a ;

--- a/qudarap/QEvt.hh
+++ b/qudarap/QEvt.hh
@@ -174,11 +174,11 @@ public:
     NP*      gatherHitLiteMerged() const ;
     NP*      gatherHitMerged() const ;
     NP* gatherRecord() const; // full step records
+    NP* gatherGenstepFromDevice() const;
 
 #ifndef PRODUCTION
     NP*      gatherSeed() const ;
     NP*      gatherDomain() const ;
-    NP*      gatherGenstepFromDevice() const ;
     void     gatherSimtrace(     NP* t ) const ;
     NP*      gatherSimtrace() const ;
     void     gatherSeq(          NP* seq) const ;


### PR DESCRIPTION
Share a single build configuration matrix across release and develop targets so PR image jobs cover the same CUDA, OptiX, Geant4, and CMake combinations.

Push same-repository PR images for every target, then pull, test, and clean up both release and develop variants.
