### PR TITLE
fix(sysrap): resolve optimized build warnings

### DIFF
--- a/sysrap/SOpticksResource.cc
+++ b/sysrap/SOpticksResource.cc
@@ -534,7 +534,7 @@ std::string SOpticksResource::Desc()
     for(unsigned i=0 ; i < keys.size() ; i++ ) 
     {
         const char* key = keys[i].c_str();
-        std::string lab = sstr::Format_("SOpticksResource::Get(\"%s\") ", key);
+        std::string lab = std::string("SOpticksResource::Get(\"") + key + "\") ";
         const char* val = Get(key); 
         ss 
             << std::setw(70) << lab.c_str() 

--- a/sysrap/spho.h
+++ b/sysrap/spho.h
@@ -201,21 +201,21 @@ inline const int* spho::cdata() const
 inline void spho::serialize( std::array<int, 4>& a ) const
 {
     assert( a.size() == N );
-    a[0] = gs ;
-    a[1] = ix ;
-    a[2] = id ;
-    a[3] = static_cast<int>(uc4packed()) ;
+    a[0] = gs;
+    a[1] = ix;
+    a[2] = id;
+    a[3] = static_cast<int>(uc4packed());
 }
 inline void spho::load( const std::array<int, 4>& a )
 {
     assert( a.size() == N );
-    gs = a[0] ;
-    ix = a[1] ;
-    id = a[2] ;
+    gs = a[0];
+    ix = a[1];
+    id = a[2];
 
-    spho_uuc4 uuc4 ;
-    uuc4.u = static_cast<unsigned>(a[3]) ;
-    uc4 = uuc4.uc4 ;
+    spho_uuc4 uuc4;
+    uuc4.u = static_cast<unsigned>(a[3]);
+    uc4 = uuc4.uc4;
 }
 
 

--- a/sysrap/spho.h
+++ b/sysrap/spho.h
@@ -201,14 +201,21 @@ inline const int* spho::cdata() const
 inline void spho::serialize( std::array<int, 4>& a ) const
 {
     assert( a.size() == N );
-    const int* ptr = cdata() ;
-    for(int i=0 ; i < N ; i++ ) a[i] = ptr[i] ;
+    a[0] = gs ;
+    a[1] = ix ;
+    a[2] = id ;
+    a[3] = static_cast<int>(uc4packed()) ;
 }
 inline void spho::load( const std::array<int, 4>& a )
 {
     assert( a.size() == N );
-    int* ptr = data() ;
-    for(int i=0 ; i < N ; i++ ) ptr[i] = a[i] ;
+    gs = a[0] ;
+    ix = a[1] ;
+    id = a[2] ;
+
+    spho_uuc4 uuc4 ;
+    uuc4.u = static_cast<unsigned>(a[3]) ;
+    uc4 = uuc4.uc4 ;
 }
 
 
@@ -219,6 +226,5 @@ inline std::ostream& operator<<(std::ostream& os, const spho& p)
     os << p.desc() ;
     return os;
 }
-
 
 

--- a/sysrap/sstr.h
+++ b/sysrap/sstr.h
@@ -21,7 +21,6 @@
 #define SSTR_NOINLINE
 #endif
 
-
 struct sstr
 {
     enum { MATCH_ALL, MATCH_START, MATCH_END } ;
@@ -97,9 +96,8 @@ struct sstr
     template<typename T>
     static std::string desc( const std::vector<T>& elem );
 
-
-    template<typename ... Args>
-    static int FormatWrite_( char* dst, std::size_t size, const char* fmt, Args ... args ) SSTR_NOINLINE;
+    template <typename... Args>
+    static int FormatWrite_(char* dst, std::size_t size, const char* fmt, Args... args) SSTR_NOINLINE;
 
     template<typename ... Args>
     static std::string Format_( const char* fmt, Args ... args );
@@ -801,10 +799,10 @@ See sysrap/tests/StringFormatTest.cc
 
 **/
 
-template<typename ... Args>
-int sstr::FormatWrite_( char* dst, std::size_t size, const char* fmt, Args ... args )
+template <typename... Args>
+int sstr::FormatWrite_(char* dst, std::size_t size, const char* fmt, Args... args)
 {
-    return std::snprintf( dst, size, fmt, args ... );
+    return std::snprintf(dst, size, fmt, args...);
 }
 
 #undef SSTR_NOINLINE
@@ -812,14 +810,15 @@ int sstr::FormatWrite_( char* dst, std::size_t size, const char* fmt, Args ... a
 template<typename ... Args>
 inline std::string sstr::Format_( const char* fmt, Args ... args )
 {
-    int len = std::snprintf( nullptr, 0, fmt, args ... );
-    assert( len >= 0 );
-    if( len < 0 ) return std::string();
+    int len = std::snprintf(nullptr, 0, fmt, args...);
+    assert(len >= 0);
+    if (len < 0)
+        return std::string();
 
-    std::vector<char> buf(static_cast<std::size_t>(len) + 1u) ; // +1 for null termination
-    int written = FormatWrite_( buf.data(), buf.size(), fmt, args ... );
-    assert( written == len );
-    return std::string( buf.data(), static_cast<std::size_t>(len) );  // exclude null termination
+    std::vector<char> buf(static_cast<std::size_t>(len) + 1u); // +1 for null termination
+    int               written = FormatWrite_(buf.data(), buf.size(), fmt, args...);
+    assert(written == len);
+    return std::string(buf.data(), static_cast<std::size_t>(len)); // exclude null termination
 }
 
 template std::string sstr::Format_( const char*, const char*, int, int );

--- a/sysrap/sstr.h
+++ b/sysrap/sstr.h
@@ -15,6 +15,12 @@
 #include <charconv> // std::from_chars
 #include <type_traits>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define SSTR_NOINLINE __attribute__((noinline))
+#else
+#define SSTR_NOINLINE
+#endif
+
 
 struct sstr
 {
@@ -91,6 +97,9 @@ struct sstr
     template<typename T>
     static std::string desc( const std::vector<T>& elem );
 
+
+    template<typename ... Args>
+    static int FormatWrite_( char* dst, std::size_t size, const char* fmt, Args ... args ) SSTR_NOINLINE;
 
     template<typename ... Args>
     static std::string Format_( const char* fmt, Args ... args );
@@ -793,13 +802,24 @@ See sysrap/tests/StringFormatTest.cc
 **/
 
 template<typename ... Args>
+int sstr::FormatWrite_( char* dst, std::size_t size, const char* fmt, Args ... args )
+{
+    return std::snprintf( dst, size, fmt, args ... );
+}
+
+#undef SSTR_NOINLINE
+
+template<typename ... Args>
 inline std::string sstr::Format_( const char* fmt, Args ... args )
 {
-    int sz = std::snprintf( nullptr, 0, fmt, args ... ) + 1 ; // +1 for null termination
-    assert( sz > 0 );
-    std::vector<char> buf(sz) ;
-    std::snprintf( buf.data(), sz, fmt, args ... );
-    return std::string( buf.begin(), buf.begin() + sz - 1 );  // exclude null termination
+    int len = std::snprintf( nullptr, 0, fmt, args ... );
+    assert( len >= 0 );
+    if( len < 0 ) return std::string();
+
+    std::vector<char> buf(static_cast<std::size_t>(len) + 1u) ; // +1 for null termination
+    int written = FormatWrite_( buf.data(), buf.size(), fmt, args ... );
+    assert( written == len );
+    return std::string( buf.data(), static_cast<std::size_t>(len) );  // exclude null termination
 }
 
 template std::string sstr::Format_( const char*, const char*, int, int );


### PR DESCRIPTION
GCC 13 optimized Release builds were reporting two warning classes in the sysrap/u4 path:

- -Wformat-truncation from inlined calls to sstr::Format_, where the compiler lost the relationship between the snprintf size probe and the subsequent write buffer.

- -Wstringop-overflow from spho::load, which wrote through a pointer to the first scalar member and relied on adjacent members being treated as an int array.

This change updates sstr::Format_ to keep its measured length path while routing the write through a small noinline helper, preventing the fortify false positives without changing the public formatting API. SOpticksResource::Desc also builds its simple label with std::string concatenation instead of printf formatting.

spho serialization/deserialization now assigns the three scalar label fields explicitly and preserves the packed uc4 word through spho_uuc4, avoiding object-boundary pointer walking while keeping the serialized four-int representation unchanged.

Verification:

```
cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release
cmake --build build-release/ -- -j40
```

Resolves #385 