### PR TITLE
ci: consolidate PR image build matrix

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -54,39 +54,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: release
-            os: ubuntu24.04
+        target: [release, develop]
+        config: &build_configs
+          - os: ubuntu24.04
             cuda_version: 13.2.0
             optix_version: 9.1.0
             geant4_version: 11.4.1
             cmake_version: 4.3.1
-          - target: release
-            os: ubuntu24.04
+          - os: ubuntu24.04
             cuda_version: 13.0.2
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 4.2.1
-          - target: release
-            os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
-          - target: develop
-            os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - target: develop
-            os: ubuntu24.04
+          - os: ubuntu24.04
             cuda_version: 12.5.1
             optix_version: 9.0.0
             geant4_version: 11.4.1
             cmake_version: 3.28.3
-          - target: develop
-            os: ubuntu22.04
+          - os: ubuntu22.04
             cuda_version: 12.1.1
             optix_version: 8.0.0
             geant4_version: 11.3.2
@@ -97,8 +82,8 @@ jobs:
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BASE_VARIANT=cuda${{ matrix.cuda_version }}-base-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-${{ matrix.target }}-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BASE_VARIANT=cuda${{ matrix.config.cuda_version }}-base-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
           echo BASE_CACHE_REF=${IMAGE_NAME}:${BASE_VARIANT} >> $GITHUB_ENV
@@ -125,17 +110,17 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           target: ${{ matrix.target }}
           build-args: |
-            OS=${{ matrix.os }}
-            CUDA_VERSION=${{ matrix.cuda_version }}
-            OPTIX_VERSION=${{ matrix.optix_version }}
-            GEANT4_VERSION=${{ matrix.geant4_version }}
-            CMAKE_VERSION=${{ matrix.cmake_version }}
+            OS=${{ matrix.config.os }}
+            CUDA_VERSION=${{ matrix.config.cuda_version }}
+            OPTIX_VERSION=${{ matrix.config.optix_version }}
+            GEANT4_VERSION=${{ matrix.config.geant4_version }}
+            CMAKE_VERSION=${{ matrix.config.cmake_version }}
           cache-from: |
             type=registry,ref=${{ env.BASE_CACHE_REF }}
             type=registry,ref=${{ env.CACHE_REF }}
-          push: ${{ matrix.target == 'develop' && github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
-  test-develop-image:
+  test-image:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     needs: build-image
     runs-on: [gpu]
@@ -145,30 +130,24 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: &develop_matrix
-        include:
-          - os: ubuntu24.04
-            cuda_version: 13.0.2
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 4.2.1
-          - os: ubuntu24.04
-            cuda_version: 12.5.1
-            optix_version: 9.0.0
-            geant4_version: 11.4.1
-            cmake_version: 3.28.3
-          - os: ubuntu22.04
-            cuda_version: 12.1.1
-            optix_version: 8.0.0
-            geant4_version: 11.3.2
-            cmake_version: 3.22.1
+      matrix:
+        target: [release, develop]
+        config: *build_configs
+        exclude:
+          # The gpu runner driver does not support OptiX 9.1.0 yet
+          - config:
+              os: ubuntu24.04
+              cuda_version: 13.2.0
+              optix_version: 9.1.0
+              geant4_version: 11.4.1
+              cmake_version: 4.3.1
 
     steps:
       - name: Define environment variables
         run: |
           IMAGE_NAME=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-develop-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo IMAGE_NAME=${IMAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
 
@@ -179,7 +158,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull develop image
+      - name: Pull PR image
         run: |
           docker pull ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
@@ -206,21 +185,23 @@ jobs:
 
   cleanup-pr-images:
     if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
-    needs: test-develop-image
+    needs: test-image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
-      matrix: *develop_matrix
+      matrix:
+        target: [release, develop]
+        config: *build_configs
 
     steps:
       - name: Define environment variables
         run: |
           PACKAGE_NAME=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')-buildcache
           REF_SANITIZED=PR-${{ github.event.pull_request.number }}
-          BUILD_VARIANT=cuda${{ matrix.cuda_version }}-develop-${{ matrix.os }}-optix${{ matrix.optix_version }}-geant4${{ matrix.geant4_version }}-cmake${{ matrix.cmake_version }}
+          BUILD_VARIANT=cuda${{ matrix.config.cuda_version }}-${{ matrix.target }}-${{ matrix.config.os }}-optix${{ matrix.config.optix_version }}-geant4${{ matrix.config.geant4_version }}-cmake${{ matrix.config.cmake_version }}
           echo PACKAGE_NAME=${PACKAGE_NAME} >> $GITHUB_ENV
           echo IMAGE_TAG=${REF_SANITIZED}-${BUILD_VARIANT} >> $GITHUB_ENV
 

--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -184,7 +184,7 @@ jobs:
 
 
   cleanup-pr-images:
-    if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Share one supported image configuration matrix across release and develop PR
image builds so CUDA, OptiX, Geant4, CMake, and OS combinations stay aligned.

Add the missing CUDA 12.5.1 release configuration and CUDA 13.2.0 develop
configuration. Reuse the shared matrix for PR image testing and cleanup so
build, test, and cleanup jobs operate on the same image variants.
