### PR TITLE
refactor(sysrap): use vendored OptiX Toolkit vector math

### DIFF
--- a/CSGOptiX/CMakeLists.txt
+++ b/CSGOptiX/CMakeLists.txt
@@ -31,6 +31,7 @@ set_target_properties(${OPTIX_PTX_TARGET} PROPERTIES CUDA_PTX_COMPILATION ON)
 target_include_directories(${OPTIX_PTX_TARGET} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/CSG>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/sysrap>
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/third_party/optix-toolkit>
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/qudarap>)
 target_compile_definitions(${OPTIX_PTX_TARGET}
     PUBLIC

--- a/sysrap/CMakeLists.txt
+++ b/sysrap/CMakeLists.txt
@@ -497,10 +497,12 @@ target_include_directories( ${name} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../third_party>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../third_party/optix-toolkit>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/sysrap>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/third_party>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/third_party/optix-toolkit>
 )
 
 
@@ -551,6 +553,18 @@ target_compile_definitions( ${name}
 )
 
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/sysrap/)
+install(
+    FILES
+        ../third_party/optix-toolkit/README.md
+        ../third_party/optix-toolkit/LICENSE.txt
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/third_party/optix-toolkit
+)
+install(
+    FILES
+        ../third_party/optix-toolkit/OptiXToolkit/ShaderUtil/vec_math.h
+        ../third_party/optix-toolkit/OptiXToolkit/ShaderUtil/Preprocessor.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/third_party/optix-toolkit/OptiXToolkit/ShaderUtil
+)
 
 install(TARGETS ${name}
         EXPORT ${PROJECT_NAME}Targets

--- a/sysrap/scuda.h
+++ b/sysrap/scuda.h
@@ -45,13 +45,19 @@
 #define M_SQRT2f 1.4142135623730951f
 #endif
 
-// Preserve the previous scuda.h contract: callers use vec_math helpers without
-// an otk:: qualifier.
+// Preserve the previous scuda.h contract by default: callers can use vec_math
+// helpers without an otk:: qualifier. New code can define
+// SCUDA_NO_GLOBAL_OTK_USING before including this header to avoid importing the
+// full OptiX Toolkit namespace into global scope.
+#ifndef SCUDA_NO_GLOBAL_OTK_USING
 using namespace otk;
+#endif
 
-#if CUDART_VERSION < 13000
+#if CUDART_VERSION < 13000 || defined(SCUDA_NO_GLOBAL_OTK_USING)
 // CUDA 12 needs these legacy scuda overloads because the upstream compatibility
 // guard hides the adjacent OptiX Toolkit definitions with CUDA 13-only types.
+// The opt-out mode also keeps this narrow legacy surface available without
+// importing every otk symbol.
 SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float3& v)
 {
     return ::make_float2(v.x, v.y);
@@ -70,7 +76,7 @@ SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float4& v)
 
 SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_cost(const float3& v)
 {
-    return v.z / sqrtf(dot(v, v));
+    return v.z / sqrtf(otk::dot(v, v));
 }
 
 SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_fphi(const float3& v)
@@ -166,7 +172,7 @@ inline float3 scuda::efloat3(const char* ekey, const char* fallback, char delim)
 {
     std::vector<float> fv;
     evec(fv, ekey, fallback, delim);
-    return make_float3(
+    return ::make_float3(
         fv.size() > 0 ? fv[0] : 0.f,
         fv.size() > 1 ? fv[1] : 0.f,
         fv.size() > 2 ? fv[2] : 0.f);
@@ -176,7 +182,7 @@ inline float4 scuda::efloat4(const char* ekey, const char* fallback, char delim)
 {
     std::vector<float> fv;
     evec(fv, ekey, fallback, delim);
-    return make_float4(
+    return ::make_float4(
         fv.size() > 0 ? fv[0] : 0.f,
         fv.size() > 1 ? fv[1] : 0.f,
         fv.size() > 2 ? fv[2] : 0.f,
@@ -186,7 +192,7 @@ inline float4 scuda::efloat4(const char* ekey, const char* fallback, char delim)
 inline float3 scuda::efloat3n(const char* ekey, const char* fallback, char delim)
 {
     float3 v = efloat3(ekey, fallback, delim);
-    return normalize(v);
+    return otk::normalize(v);
 }
 
 inline std::string scuda::serialize(const float2& v)
@@ -212,11 +218,11 @@ inline std::string scuda::serialize(const float4& v)
 
 inline float4 scuda::center_extent_(const float* mn, const float* mx)
 {
-    float3 center = make_float3((mn[0] + mx[0]) / 2.f, (mn[1] + mx[1]) / 2.f, (mn[2] + mx[2]) / 2.f);
-    float3 mx_rel = make_float3(mx[0], mx[1], mx[2]) - center;
-    float3 mn_rel = center - make_float3(mn[0], mn[1], mn[2]);
-    float  extent = fmaxf(fmaxf(mx_rel), fmaxf(mn_rel));
-    return make_float4(center, extent);
+    float3 center = ::make_float3((mn[0] + mx[0]) / 2.f, (mn[1] + mx[1]) / 2.f, (mn[2] + mx[2]) / 2.f);
+    float3 mx_rel = ::make_float3(mx[0], mx[1], mx[2]) - center;
+    float3 mn_rel = center - ::make_float3(mn[0], mn[1], mn[2]);
+    float  extent = fmaxf(otk::fmaxf(mx_rel), otk::fmaxf(mn_rel));
+    return otk::make_float4(center, extent);
 }
 
 inline float4 scuda::center_extent(const float3& mn, const float3& mx)

--- a/sysrap/scuda.h
+++ b/sysrap/scuda.h
@@ -49,6 +49,25 @@
 // an otk:: qualifier.
 using namespace otk;
 
+#if CUDART_VERSION < 13000
+// CUDA 12 needs these legacy scuda overloads because the upstream compatibility
+// guard hides the adjacent OptiX Toolkit definitions with CUDA 13-only types.
+SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float3& v)
+{
+    return ::make_float2(v.x, v.y);
+}
+
+SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float4& v)
+{
+    return ::make_float2(v.x, v.y);
+}
+
+SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float4& v)
+{
+    return ::make_float3(v.x, v.y, v.z);
+}
+#endif
+
 SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_cost(const float3& v)
 {
     return v.z / sqrtf(dot(v, v));

--- a/sysrap/scuda.h
+++ b/sysrap/scuda.h
@@ -1,51 +1,23 @@
 //
-// Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+// Compatibility facade for Simphony code that historically included scuda.h.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in the
-//    documentation and/or other materials provided with the distribution.
-//  * Neither the name of NVIDIA CORPORATION nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
+// NVIDIA's CUDA vector math helpers are provided by the vendored official
+// OptiX Toolkit vec_math.h. This header keeps only project-local helpers and
+// legacy names that are not provided by that upstream header.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
-// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
-// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//
-
 
 #pragma once
+
+#include <cuda_runtime_api.h>
+#include <OptiXToolkit/ShaderUtil/vec_math.h>
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
 #    define SUTIL_HOSTDEVICE __host__ __device__
 #    define SUTIL_INLINE __forceinline__
-#    define CONST_STATIC_INIT( ... )
 #else
 #    define SUTIL_HOSTDEVICE
 #    define SUTIL_INLINE inline
-#    define CONST_STATIC_INIT( ... ) = __VA_ARGS__
 #endif
-
-
-#include <vector_functions.h>
-#include <vector_types.h>
-
-
-#include <cmath>
-#include <cstdlib>
 
 #if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
 #    define LONGLONG4 longlong4_32a
@@ -54,7 +26,6 @@
 #    define MAKE_LONGLONG4 make_longlong4_32a
 #    define MAKE_ULONGLONG4 make_ulonglong4_32a
 #else
-#    include <cuda_runtime_api.h>
 #    if (CUDART_VERSION >= 13000)
 #        define LONGLONG4 longlong4_32a
 #        define ULONGLONG4 ulonglong4_32a
@@ -70,2733 +41,101 @@
 #    endif
 #endif
 
-
-
-/* scalar functions used in vector functions */
-#ifndef M_PIf
-#define M_PIf       3.14159265358979323846f
-#endif
-#ifndef M_1_PIf
-#define M_1_PIf     0.318309886183790671538f
-#endif
-
 #ifndef M_SQRT2f
 #define M_SQRT2f  1.4142135623730951f
 #endif
 
+// Preserve the previous scuda.h contract: callers use vec_math helpers without
+// an otk:: qualifier.
+using namespace otk;
 
-#if !defined(__CUDACC__)
-
-SUTIL_INLINE SUTIL_HOSTDEVICE int max(int a, int b)
-{
-    return a > b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE int min(int a, int b)
-{
-    return a < b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE long long max(long long a, long long b)
-{
-    return a > b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE long long min(long long a, long long b)
-{
-    return a < b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int max(unsigned int a, unsigned int b)
-{
-    return a > b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int min(unsigned int a, unsigned int b)
-{
-    return a < b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long max(unsigned long long a, unsigned long long b)
-{
-    return a > b ? a : b;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long min(unsigned long long a, unsigned long long b)
-{
-    return a < b ? a : b;
-}
-
-
-
-
-
-/**
-lerp
-----
-
-For C++20 compilation have adopted the suggestion from Nicola Mori, although
-I did not succeed to reproduce the issue.
-
-notes/issues/cpp20_nicolamori_scuda_curand_math_lerp_conflict.rst
-
-**/
-
-#if __cplusplus <= 201703L
-SUTIL_INLINE SUTIL_HOSTDEVICE float lerp(const float a, const float b, const float t)
-{
-  return a + t*(b-a);
-}
-#else
-using std::lerp;
-#endif
-
-
-
-/** bilerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float bilerp(const float x00, const float x10, const float x01, const float x11,
-                                         const float u, const float v)
-{
-  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
-}
-
-template <typename IntegerType>
-SUTIL_INLINE SUTIL_HOSTDEVICE IntegerType roundUp(IntegerType x, IntegerType y)
-{
-    return ( ( x + y - 1 ) / y ) * y;
-}
-
-#endif
-
-/** clamp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float clamp(const float f, const float a, const float b)
-{
-  return fmaxf(a, fminf(f, b));
-}
-
-
-/* float2 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float s)
-{
-  return make_float2(s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const int2& a)
-{
-  return make_float2(float(a.x), float(a.y));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const uint2& a)
-{
-  return make_float2(float(a.x), float(a.y));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator-(const float2& a)
-{
-  return make_float2(-a.x, -a.y);
-}
-
-/** min
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 fminf(const float2& a, const float2& b)
-{
-  return make_float2(fminf(a.x,b.x), fminf(a.y,b.y));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fminf(const float2& a)
-{
-  return fminf(a.x, a.y);
-}
-/** @} */
-
-/** max
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 fmaxf(const float2& a, const float2& b)
-{
-  return make_float2(fmaxf(a.x,b.x), fmaxf(a.y,b.y));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fmaxf(const float2& a)
-{
-  return fmaxf(a.x, a.y);
-}
-/** @} */
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator+(const float2& a, const float2& b)
-{
-  return make_float2(a.x + b.x, a.y + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator+(const float2& a, const float b)
-{
-  return make_float2(a.x + b, a.y + b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator+(const float a, const float2& b)
-{
-  return make_float2(a + b.x, a + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(float2& a, const float2& b)
-{
-  a.x += b.x; a.y += b.y;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator-(const float2& a, const float2& b)
-{
-  return make_float2(a.x - b.x, a.y - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator-(const float2& a, const float b)
-{
-  return make_float2(a.x - b, a.y - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator-(const float a, const float2& b)
-{
-  return make_float2(a - b.x, a - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(float2& a, const float2& b)
-{
-  a.x -= b.x; a.y -= b.y;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator*(const float2& a, const float2& b)
-{
-  return make_float2(a.x * b.x, a.y * b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator*(const float2& a, const float s)
-{
-  return make_float2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator*(const float s, const float2& a)
-{
-  return make_float2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float2& a, const float2& s)
-{
-  a.x *= s.x; a.y *= s.y;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float2& a, const float s)
-{
-  a.x *= s; a.y *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator/(const float2& a, const float2& b)
-{
-  return make_float2(a.x / b.x, a.y / b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator/(const float2& a, const float s)
-{
-  float inv = 1.0f / s;
-  return a * inv;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 operator/(const float s, const float2& a)
-{
-  return make_float2( s/a.x, s/a.y );
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(float2& a, const float s)
-{
-  float inv = 1.0f / s;
-  a *= inv;
-}
-/** @} */
-
-/** lerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 lerp(const float2& a, const float2& b, const float t)
-{
-  return a + t*(b-a);
-}
-
-/** bilerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 bilerp(const float2& x00, const float2& x10, const float2& x01, const float2& x11,
-                                          const float u, const float v)
-{
-  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
-}
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 clamp(const float2& v, const float a, const float b)
-{
-  return make_float2(clamp(v.x, a, b), clamp(v.y, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 clamp(const float2& v, const float2& a, const float2& b)
-{
-  return make_float2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
-}
-/** @} */
-
-/** dot product */
-SUTIL_INLINE SUTIL_HOSTDEVICE float dot(const float2& a, const float2& b)
-{
-  return a.x * b.x + a.y * b.y;
-}
-
-/** length */
-SUTIL_INLINE SUTIL_HOSTDEVICE float length(const float2& v)
-{
-  return sqrtf(dot(v, v));
-}
-
-/** normalize */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 normalize(const float2& v)
-{
-  float invLen = 1.0f / sqrtf(dot(v, v));
-  return v * invLen;
-}
-
-/** floor */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 floor(const float2& v)
-{
-  return make_float2(::floorf(v.x), ::floorf(v.y));
-}
-
-/** reflect */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 reflect(const float2& i, const float2& n)
-{
-  return i - 2.0f * n * dot(n,i);
-}
-
-/** Faceforward
-* Returns N if dot(i, nref) > 0; else -N;
-* Typical usage is N = faceforward(N, -ray.dir, N);
-* Note that this is opposite of what faceforward does in Cg and GLSL */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 faceforward(const float2& n, const float2& i, const float2& nref)
-{
-  return n * copysignf( 1.0f, dot(i, nref) );
-}
-
-/** exp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 expf(const float2& v)
-{
-  return make_float2(::expf(v.x), ::expf(v.y));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE float getByIndex(const float2& v, int i)
-{
-  return ((float*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(float2& v, int i, float x)
-{
-  ((float*)(&v))[i] = x;
-}
-
-
-/* float3 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float s)
-{
-  return make_float3(s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float2& a)
-{
-  return make_float3(a.x, a.y, 0.0f);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const int3& a)
-{
-  return make_float3(float(a.x), float(a.y), float(a.z));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const uint3& a)
-{
-  return make_float3(float(a.x), float(a.y), float(a.z));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator-(const float3& a)
-{
-  return make_float3(-a.x, -a.y, -a.z);
-}
-
-/** min
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 fminf(const float3& a, const float3& b)
-{
-  return make_float3(fminf(a.x,b.x), fminf(a.y,b.y), fminf(a.z,b.z));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fminf(const float3& a)
-{
-  return fminf(fminf(a.x, a.y), a.z);
-}
-/** @} */
-
-/** max
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 fmaxf(const float3& a, const float3& b)
-{
-  return make_float3(fmaxf(a.x,b.x), fmaxf(a.y,b.y), fmaxf(a.z,b.z));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fmaxf(const float3& a)
-{
-  return fmaxf(fmaxf(a.x, a.y), a.z);
-}
-/** @} */
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator+(const float3& a, const float3& b)
-{
-  return make_float3(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator+(const float3& a, const float b)
-{
-  return make_float3(a.x + b, a.y + b, a.z + b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator+(const float a, const float3& b)
-{
-  return make_float3(a + b.x, a + b.y, a + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(float3& a, const float3& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator-(const float3& a, const float3& b)
-{
-  return make_float3(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator-(const float3& a, const float b)
-{
-  return make_float3(a.x - b, a.y - b, a.z - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator-(const float a, const float3& b)
-{
-  return make_float3(a - b.x, a - b.y, a - b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(float3& a, const float3& b)
+SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_cost(const float3& v)
 {
-  a.x -= b.x; a.y -= b.y; a.z -= b.z;
+    return v.z / sqrtf(dot(v, v));
 }
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator*(const float3& a, const float3& b)
-{
-  return make_float3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator*(const float3& a, const float s)
-{
-  return make_float3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator*(const float s, const float3& a)
-{
-  return make_float3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float3& a, const float3& s)
-{
-  a.x *= s.x; a.y *= s.y; a.z *= s.z;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float3& a, const float s)
-{
-  a.x *= s; a.y *= s; a.z *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator/(const float3& a, const float3& b)
-{
-  return make_float3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator/(const float3& a, const float s)
-{
-  float inv = 1.0f / s;
-  return a * inv;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 operator/(const float s, const float3& a)
-{
-  return make_float3( s/a.x, s/a.y, s/a.z );
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(float3& a, const float s)
-{
-  float inv = 1.0f / s;
-  a *= inv;
-}
-/** @} */
-
-/** lerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 lerp(const float3& a, const float3& b, const float t)
-{
-  return a + t*(b-a);
-}
-
-/** bilerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 bilerp(const float3& x00, const float3& x10, const float3& x01, const float3& x11,
-                                          const float u, const float v)
-{
-  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
-}
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 clamp(const float3& v, const float a, const float b)
-{
-  return make_float3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 clamp(const float3& v, const float3& a, const float3& b)
-{
-  return make_float3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
-}
-/** @} */
-
-/** dot product */
-SUTIL_INLINE SUTIL_HOSTDEVICE float dot(const float3& a, const float3& b)
-{
-  return a.x * b.x + a.y * b.y + a.z * b.z;
-}
-
-/** cross product */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 cross(const float3& a, const float3& b)
-{
-  return make_float3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
-}
-
-/** length */
-SUTIL_INLINE SUTIL_HOSTDEVICE float length(const float3& v)
-{
-  return sqrtf(dot(v, v));
-}
-
-/** normalize */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 normalize(const float3& v)
-{
-  float invLen = 1.0f / sqrtf(dot(v, v));
-  return v * invLen;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_cost(const float3& v)  // formerly normalize_z,  CLHEP ThreeVector calls this cosTheta
-{
-  return v.z / sqrtf(dot(v, v));
-}
-
-
-/**
-normalize_fphi
---------------
-
-atan2f range is -pi to pi, so add pi, giving range 0 to 2pi
-which is then normalized to give fphi in range 0:1
-
-Note discontinuity of phi close to [-1,0,0] flipping between pi and -pi,
-
-    In [4]: np.arctan2(+0.00000001, -1)
-    Out[4]: np.float64(3.141592643589793)
-
-    In [5]: np.arctan2(-0.00000001, -1)
-    Out[5]: np.float64(-3.141592643589793)
-
-Which corresponds to fphi flipping between 0 and 1::
-
-    In [6]: (np.arctan2(-0.00000001, -1) + np.pi)/(2*np.pi)
-    Out[6]: np.float64(1.591549421246358e-09)
-
-    In [7]: (np.arctan2(+0.00000001, -1) + np.pi)/(2*np.pi)
-    Out[7]: np.float64(0.9999999984084506)
-
-No such issue at [1,0,0] where fphi close to 0.5::
-
-    In [8]: (np.arctan2(+0.00000001, 1) + np.pi)/(2*np.pi)
-    Out[8]: np.float64(0.5000000015915494)
-
-    In [9]: (np.arctan2(-0.00000001, 1) + np.pi)/(2*np.pi)
-    Out[9]: np.float64(0.49999999840845055)
-
-
-**/
-
 
 SUTIL_INLINE SUTIL_HOSTDEVICE float normalize_fphi(const float3& v)
 {
-  return (atan2f(v.y, v.x) + M_PIf) / (2.0f * M_PIf);
+    return (atan2f(v.y, v.x) + M_PIf) / (2.0f * M_PIf);
 }
 
-SUTIL_INLINE SUTIL_HOSTDEVICE float phi_from_fphi( float fphi )
+SUTIL_INLINE SUTIL_HOSTDEVICE float phi_from_fphi(float fphi)
 {
-   // recover phi angle in range -pi to pi from fphi in range 0:1
-   return ( fphi * 2.0f - 1.f ) * M_PIf ;
+    return (fphi * 2.0f - 1.f) * M_PIf;
 }
 
+#if !defined(__CUDACC__) && !defined(__CUDABE__)
 
-
-/** floor */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 floor(const float3& v)
-{
-  return make_float3(::floorf(v.x), ::floorf(v.y), ::floorf(v.z));
-}
-
-/** reflect */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 reflect(const float3& i, const float3& n)
-{
-  return i - 2.0f * n * dot(n,i);
-}
-
-/** Faceforward
-* Returns N if dot(i, nref) > 0; else -N;
-* Typical usage is N = faceforward(N, -ray.dir, N);
-* Note that this is opposite of what faceforward does in Cg and GLSL */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 faceforward(const float3& n, const float3& i, const float3& nref)
-{
-  return n * copysignf( 1.0f, dot(i, nref) );
-}
-
-/** exp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 expf(const float3& v)
-{
-  return make_float3(::expf(v.x), ::expf(v.y), ::expf(v.z));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE float getByIndex(const float3& v, int i)
-{
-  return ((float*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(float3& v, int i, float x)
-{
-  ((float*)(&v))[i] = x;
-}
-
-/* float4 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float s)
-{
-  return make_float4(s, s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float3& a)
-{
-  return make_float4(a.x, a.y, a.z, 0.0f);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const int4& a)
-{
-  return make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const uint4& a)
-{
-  return make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator-(const float4& a)
-{
-  return make_float4(-a.x, -a.y, -a.z, -a.w);
-}
-
-/** min
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 fminf(const float4& a, const float4& b)
-{
-  return make_float4(fminf(a.x,b.x), fminf(a.y,b.y), fminf(a.z,b.z), fminf(a.w,b.w));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fminf(const float4& a)
-{
-  return fminf(fminf(a.x, a.y), fminf(a.z, a.w));
-}
-/** @} */
-
-/** max
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 fmaxf(const float4& a, const float4& b)
-{
-  return make_float4(fmaxf(a.x,b.x), fmaxf(a.y,b.y), fmaxf(a.z,b.z), fmaxf(a.w,b.w));
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float fmaxf(const float4& a)
-{
-  return fmaxf(fmaxf(a.x, a.y), fmaxf(a.z, a.w));
-}
-/** @} */
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator+(const float4& a, const float4& b)
-{
-  return make_float4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator+(const float4& a, const float b)
-{
-  return make_float4(a.x + b, a.y + b, a.z + b,  a.w + b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator+(const float a, const float4& b)
-{
-  return make_float4(a + b.x, a + b.y, a + b.z,  a + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(float4& a, const float4& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z; a.w += b.w;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator-(const float4& a, const float4& b)
-{
-  return make_float4(a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator-(const float4& a, const float b)
-{
-  return make_float4(a.x - b, a.y - b, a.z - b,  a.w - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator-(const float a, const float4& b)
-{
-  return make_float4(a - b.x, a - b.y, a - b.z,  a - b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(float4& a, const float4& b)
-{
-  a.x -= b.x; a.y -= b.y; a.z -= b.z; a.w -= b.w;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator*(const float4& a, const float4& s)
-{
-  return make_float4(a.x * s.x, a.y * s.y, a.z * s.z, a.w * s.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator*(const float4& a, const float s)
-{
-  return make_float4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator*(const float s, const float4& a)
-{
-  return make_float4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float4& a, const float4& s)
-{
-  a.x *= s.x; a.y *= s.y; a.z *= s.z; a.w *= s.w;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(float4& a, const float s)
-{
-  a.x *= s; a.y *= s; a.z *= s; a.w *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator/(const float4& a, const float4& b)
-{
-  return make_float4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator/(const float4& a, const float s)
-{
-  float inv = 1.0f / s;
-  return a * inv;
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 operator/(const float s, const float4& a)
-{
-  return make_float4( s/a.x, s/a.y, s/a.z, s/a.w );
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(float4& a, const float s)
-{
-  float inv = 1.0f / s;
-  a *= inv;
-}
-/** @} */
-
-/** lerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 lerp(const float4& a, const float4& b, const float t)
-{
-  return a + t*(b-a);
-}
-
-/** bilerp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 bilerp(const float4& x00, const float4& x10, const float4& x01, const float4& x11,
-                                          const float u, const float v)
-{
-  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
-}
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 clamp(const float4& v, const float a, const float b)
-{
-  return make_float4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 clamp(const float4& v, const float4& a, const float4& b)
-{
-  return make_float4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
-}
-/** @} */
-
-/** dot product */
-SUTIL_INLINE SUTIL_HOSTDEVICE float dot(const float4& a, const float4& b)
-{
-  return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
-}
-
-/** length */
-SUTIL_INLINE SUTIL_HOSTDEVICE float length(const float4& r)
-{
-  return sqrtf(dot(r, r));
-}
-
-/** normalize */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 normalize(const float4& v)
-{
-  float invLen = 1.0f / sqrtf(dot(v, v));
-  return v * invLen;
-}
-
-/** floor */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 floor(const float4& v)
-{
-  return make_float4(::floorf(v.x), ::floorf(v.y), ::floorf(v.z), ::floorf(v.w));
-}
-
-/** reflect */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 reflect(const float4& i, const float4& n)
-{
-  return i - 2.0f * n * dot(n,i);
-}
-
-/**
-* Faceforward
-* Returns N if dot(i, nref) > 0; else -N;
-* Typical usage is N = faceforward(N, -ray.dir, N);
-* Note that this is opposite of what faceforward does in Cg and GLSL
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 faceforward(const float4& n, const float4& i, const float4& nref)
-{
-  return n * copysignf( 1.0f, dot(i, nref) );
-}
-
-/** exp */
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 expf(const float4& v)
-{
-  return make_float4(::expf(v.x), ::expf(v.y), ::expf(v.z), ::expf(v.w));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE float getByIndex(const float4& v, int i)
-{
-  return ((float*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(float4& v, int i, float x)
-{
-  ((float*)(&v))[i] = x;
-}
-
-
-/* int functions */
-/******************************************************************************/
-
-/** clamp */
-SUTIL_INLINE SUTIL_HOSTDEVICE int clamp(const int f, const int a, const int b)
-{
-  return max(a, min(f, b));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE int getByIndex(const int1& v, int i)
-{
-  return ((int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(int1& v, int i, int x)
-{
-  ((int*)(&v))[i] = x;
-}
-
-
-/* int2 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 make_int2(const int s)
-{
-  return make_int2(s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 make_int2(const float2& a)
-{
-  return make_int2(int(a.x), int(a.y));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator-(const int2& a)
-{
-  return make_int2(-a.x, -a.y);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 min(const int2& a, const int2& b)
-{
-  return make_int2(min(a.x,b.x), min(a.y,b.y));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 max(const int2& a, const int2& b)
-{
-  return make_int2(max(a.x,b.x), max(a.y,b.y));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator+(const int2& a, const int2& b)
-{
-  return make_int2(a.x + b.x, a.y + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(int2& a, const int2& b)
-{
-  a.x += b.x; a.y += b.y;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator-(const int2& a, const int2& b)
-{
-  return make_int2(a.x - b.x, a.y - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator-(const int2& a, const int b)
-{
-  return make_int2(a.x - b, a.y - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(int2& a, const int2& b)
-{
-  a.x -= b.x; a.y -= b.y;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator*(const int2& a, const int2& b)
-{
-  return make_int2(a.x * b.x, a.y * b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator*(const int2& a, const int s)
-{
-  return make_int2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 operator*(const int s, const int2& a)
-{
-  return make_int2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(int2& a, const int s)
-{
-  a.x *= s; a.y *= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 clamp(const int2& v, const int a, const int b)
-{
-  return make_int2(clamp(v.x, a, b), clamp(v.y, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 clamp(const int2& v, const int2& a, const int2& b)
-{
-  return make_int2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const int2& a, const int2& b)
-{
-  return a.x == b.x && a.y == b.y;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const int2& a, const int2& b)
-{
-  return a.x != b.x || a.y != b.y;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE int getByIndex(const int2& v, int i)
-{
-  return ((int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(int2& v, int i, int x)
-{
-  ((int*)(&v))[i] = x;
-}
-
-
-/* int3 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 make_int3(const int s)
-{
-  return make_int3(s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 make_int3(const float3& a)
-{
-  return make_int3(int(a.x), int(a.y), int(a.z));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator-(const int3& a)
-{
-  return make_int3(-a.x, -a.y, -a.z);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 min(const int3& a, const int3& b)
-{
-  return make_int3(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 max(const int3& a, const int3& b)
-{
-  return make_int3(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator+(const int3& a, const int3& b)
-{
-  return make_int3(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(int3& a, const int3& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator-(const int3& a, const int3& b)
-{
-  return make_int3(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(int3& a, const int3& b)
-{
-  a.x -= b.x; a.y -= b.y; a.z -= b.z;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator*(const int3& a, const int3& b)
-{
-  return make_int3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator*(const int3& a, const int s)
-{
-  return make_int3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator*(const int s, const int3& a)
-{
-  return make_int3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(int3& a, const int s)
-{
-  a.x *= s; a.y *= s; a.z *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator/(const int3& a, const int3& b)
-{
-  return make_int3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator/(const int3& a, const int s)
-{
-  return make_int3(a.x / s, a.y / s, a.z / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 operator/(const int s, const int3& a)
-{
-  return make_int3(s /a.x, s / a.y, s / a.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(int3& a, const int s)
-{
-  a.x /= s; a.y /= s; a.z /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 clamp(const int3& v, const int a, const int b)
-{
-  return make_int3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 clamp(const int3& v, const int3& a, const int3& b)
-{
-  return make_int3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const int3& a, const int3& b)
-{
-  return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const int3& a, const int3& b)
-{
-  return a.x != b.x || a.y != b.y || a.z != b.z;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE int getByIndex(const int3& v, int i)
-{
-  return ((int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(int3& v, int i, int x)
-{
-  ((int*)(&v))[i] = x;
-}
-
-
-/* int4 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int s)
-{
-  return make_int4(s, s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const float4& a)
-{
-  return make_int4((int)a.x, (int)a.y, (int)a.z, (int)a.w);
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator-(const int4& a)
-{
-  return make_int4(-a.x, -a.y, -a.z, -a.w);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 min(const int4& a, const int4& b)
-{
-  return make_int4(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z), min(a.w,b.w));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 max(const int4& a, const int4& b)
-{
-  return make_int4(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z), max(a.w,b.w));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator+(const int4& a, const int4& b)
-{
-  return make_int4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(int4& a, const int4& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z; a.w += b.w;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator-(const int4& a, const int4& b)
-{
-  return make_int4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(int4& a, const int4& b)
-{
-  a.x -= b.x; a.y -= b.y; a.z -= b.z; a.w -= b.w;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator*(const int4& a, const int4& b)
-{
-  return make_int4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator*(const int4& a, const int s)
-{
-  return make_int4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator*(const int s, const int4& a)
-{
-  return make_int4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(int4& a, const int s)
-{
-  a.x *= s; a.y *= s; a.z *= s; a.w *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator/(const int4& a, const int4& b)
-{
-  return make_int4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator/(const int4& a, const int s)
-{
-  return make_int4(a.x / s, a.y / s, a.z / s, a.w / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 operator/(const int s, const int4& a)
-{
-  return make_int4(s / a.x, s / a.y, s / a.z, s / a.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(int4& a, const int s)
-{
-  a.x /= s; a.y /= s; a.z /= s; a.w /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 clamp(const int4& v, const int a, const int b)
-{
-  return make_int4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 clamp(const int4& v, const int4& a, const int4& b)
-{
-  return make_int4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const int4& a, const int4& b)
-{
-  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const int4& a, const int4& b)
-{
-  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE int getByIndex(const int4& v, int i)
-{
-  return ((int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(int4& v, int i, int x)
-{
-  ((int*)(&v))[i] = x;
-}
-
-
-/* uint functions */
-/******************************************************************************/
-
-/** clamp */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int clamp(const unsigned int f, const unsigned int a, const unsigned int b)
-{
-  return max(a, min(f, b));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int getByIndex(const uint1& v, unsigned int i)
-{
-  return ((unsigned int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(uint1& v, int i, unsigned int x)
-{
-  ((unsigned int*)(&v))[i] = x;
-}
-
-
-/* uint2 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 make_uint2(const unsigned int s)
-{
-  return make_uint2(s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 make_uint2(const float2& a)
-{
-  return make_uint2((unsigned int)a.x, (unsigned int)a.y);
-}
-/** @} */
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 min(const uint2& a, const uint2& b)
-{
-  return make_uint2(min(a.x,b.x), min(a.y,b.y));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 max(const uint2& a, const uint2& b)
-{
-  return make_uint2(max(a.x,b.x), max(a.y,b.y));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator+(const uint2& a, const uint2& b)
-{
-  return make_uint2(a.x + b.x, a.y + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(uint2& a, const uint2& b)
-{
-  a.x += b.x; a.y += b.y;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator-(const uint2& a, const uint2& b)
-{
-  return make_uint2(a.x - b.x, a.y - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator-(const uint2& a, const unsigned int b)
-{
-  return make_uint2(a.x - b, a.y - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(uint2& a, const uint2& b)
-{
-  a.x -= b.x; a.y -= b.y;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator*(const uint2& a, const uint2& b)
-{
-  return make_uint2(a.x * b.x, a.y * b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator*(const uint2& a, const unsigned int s)
-{
-  return make_uint2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 operator*(const unsigned int s, const uint2& a)
-{
-  return make_uint2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(uint2& a, const unsigned int s)
-{
-  a.x *= s; a.y *= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 clamp(const uint2& v, const unsigned int a, const unsigned int b)
-{
-  return make_uint2(clamp(v.x, a, b), clamp(v.y, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 clamp(const uint2& v, const uint2& a, const uint2& b)
-{
-  return make_uint2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const uint2& a, const uint2& b)
-{
-  return a.x == b.x && a.y == b.y;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const uint2& a, const uint2& b)
-{
-  return a.x != b.x || a.y != b.y;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int getByIndex(const uint2& v, unsigned int i)
-{
-  return ((unsigned int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(uint2& v, int i, unsigned int x)
-{
-  ((unsigned int*)(&v))[i] = x;
-}
-
-
-/* uint3 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 make_uint3(const unsigned int s)
-{
-  return make_uint3(s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 make_uint3(const float3& a)
-{
-  return make_uint3((unsigned int)a.x, (unsigned int)a.y, (unsigned int)a.z);
-}
-/** @} */
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 min(const uint3& a, const uint3& b)
-{
-  return make_uint3(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 max(const uint3& a, const uint3& b)
-{
-  return make_uint3(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator+(const uint3& a, const uint3& b)
-{
-  return make_uint3(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(uint3& a, const uint3& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator-(const uint3& a, const uint3& b)
-{
-  return make_uint3(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(uint3& a, const uint3& b)
-{
-  a.x -= b.x; a.y -= b.y; a.z -= b.z;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator*(const uint3& a, const uint3& b)
-{
-  return make_uint3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator*(const uint3& a, const unsigned int s)
-{
-  return make_uint3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator*(const unsigned int s, const uint3& a)
-{
-  return make_uint3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(uint3& a, const unsigned int s)
-{
-  a.x *= s; a.y *= s; a.z *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator/(const uint3& a, const uint3& b)
-{
-  return make_uint3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator/(const uint3& a, const unsigned int s)
-{
-  return make_uint3(a.x / s, a.y / s, a.z / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 operator/(const unsigned int s, const uint3& a)
-{
-  return make_uint3(s / a.x, s / a.y, s / a.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(uint3& a, const unsigned int s)
-{
-  a.x /= s; a.y /= s; a.z /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 clamp(const uint3& v, const unsigned int a, const unsigned int b)
-{
-  return make_uint3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 clamp(const uint3& v, const uint3& a, const uint3& b)
-{
-  return make_uint3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const uint3& a, const uint3& b)
-{
-  return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const uint3& a, const uint3& b)
-{
-  return a.x != b.x || a.y != b.y || a.z != b.z;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int getByIndex(const uint3& v, unsigned int i)
-{
-  return ((unsigned int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(uint3& v, int i, unsigned int x)
-{
-  ((unsigned int*)(&v))[i] = x;
-}
-
-
-/* uint4 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const unsigned int s)
-{
-  return make_uint4(s, s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const float4& a)
-{
-  return make_uint4((unsigned int)a.x, (unsigned int)a.y, (unsigned int)a.z, (unsigned int)a.w);
-}
-/** @} */
-
-/** min
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 min(const uint4& a, const uint4& b)
-{
-  return make_uint4(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z), min(a.w,b.w));
-}
-/** @} */
-
-/** max
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 max(const uint4& a, const uint4& b)
-{
-  return make_uint4(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z), max(a.w,b.w));
-}
-/** @} */
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator+(const uint4& a, const uint4& b)
-{
-  return make_uint4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(uint4& a, const uint4& b)
-{
-  a.x += b.x; a.y += b.y; a.z += b.z; a.w += b.w;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator-(const uint4& a, const uint4& b)
-{
-  return make_uint4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(uint4& a, const uint4& b)
-{
-  a.x -= b.x; a.y -= b.y; a.z -= b.z; a.w -= b.w;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator*(const uint4& a, const uint4& b)
-{
-  return make_uint4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator*(const uint4& a, const unsigned int s)
-{
-  return make_uint4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator*(const unsigned int s, const uint4& a)
-{
-  return make_uint4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(uint4& a, const unsigned int s)
-{
-  a.x *= s; a.y *= s; a.z *= s; a.w *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator/(const uint4& a, const uint4& b)
-{
-  return make_uint4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator/(const uint4& a, const unsigned int s)
-{
-  return make_uint4(a.x / s, a.y / s, a.z / s, a.w / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 operator/(const unsigned int s, const uint4& a)
-{
-  return make_uint4(s / a.x, s / a.y, s / a.z, s / a.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(uint4& a, const unsigned int s)
-{
-  a.x /= s; a.y /= s; a.z /= s; a.w /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 clamp(const uint4& v, const unsigned int a, const unsigned int b)
-{
-  return make_uint4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 clamp(const uint4& v, const uint4& a, const uint4& b)
-{
-  return make_uint4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const uint4& a, const uint4& b)
-{
-  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const uint4& a, const uint4& b)
-{
-  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned int getByIndex(const uint4& v, unsigned int i)
-{
-  return ((unsigned int*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(uint4& v, int i, unsigned int x)
-{
-  ((unsigned int*)(&v))[i] = x;
-}
-
-/* long long functions */
-/******************************************************************************/
-
-/** clamp */
-SUTIL_INLINE SUTIL_HOSTDEVICE long long clamp(const long long f, const long long a, const long long b)
-{
-    return max(a, min(f, b));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE long long getByIndex(const longlong1& v, int i)
-{
-    return ((long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(longlong1& v, int i, long long x)
-{
-    ((long long*)(&v))[i] = x;
-}
-
-
-/* longlong2 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 make_longlong2(const long long s)
-{
-    return make_longlong2(s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 make_longlong2(const float2& a)
-{
-    return make_longlong2(int(a.x), int(a.y));
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator-(const longlong2& a)
-{
-    return make_longlong2(-a.x, -a.y);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 min(const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(min(a.x, b.x), min(a.y, b.y));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 max(const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(max(a.x, b.x), max(a.y, b.y));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator+(const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(a.x + b.x, a.y + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(longlong2& a, const longlong2& b)
-{
-    a.x += b.x; a.y += b.y;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator-(const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(a.x - b.x, a.y - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator-(const longlong2& a, const long long b)
-{
-    return make_longlong2(a.x - b, a.y - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(longlong2& a, const longlong2& b)
-{
-    a.x -= b.x; a.y -= b.y;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator*(const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(a.x * b.x, a.y * b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator*(const longlong2& a, const long long s)
-{
-    return make_longlong2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 operator*(const long long s, const longlong2& a)
-{
-    return make_longlong2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(longlong2& a, const long long s)
-{
-    a.x *= s; a.y *= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 clamp(const longlong2& v, const long long a, const long long b)
-{
-    return make_longlong2(clamp(v.x, a, b), clamp(v.y, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 clamp(const longlong2& v, const longlong2& a, const longlong2& b)
-{
-    return make_longlong2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const longlong2& a, const longlong2& b)
-{
-    return a.x == b.x && a.y == b.y;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const longlong2& a, const longlong2& b)
-{
-    return a.x != b.x || a.y != b.y;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE long long getByIndex(const longlong2& v, int i)
-{
-    return ((long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(longlong2& v, int i, long long x)
-{
-    ((long long*)(&v))[i] = x;
-}
-
-
-/* longlong3 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 make_longlong3(const long long s)
-{
-    return make_longlong3(s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 make_longlong3(const float3& a)
-{
-    return make_longlong3( (long long)a.x, (long long)a.y, (long long)a.z);
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator-(const longlong3& a)
-{
-    return make_longlong3(-a.x, -a.y, -a.z);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 min(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 max(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator+(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(longlong3& a, const longlong3& b)
-{
-    a.x += b.x; a.y += b.y; a.z += b.z;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator-(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(longlong3& a, const longlong3& b)
-{
-    a.x -= b.x; a.y -= b.y; a.z -= b.z;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator*(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator*(const longlong3& a, const long long s)
-{
-    return make_longlong3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator*(const long long s, const longlong3& a)
-{
-    return make_longlong3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(longlong3& a, const long long s)
-{
-    a.x *= s; a.y *= s; a.z *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator/(const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator/(const longlong3& a, const long long s)
-{
-    return make_longlong3(a.x / s, a.y / s, a.z / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 operator/(const long long s, const longlong3& a)
-{
-    return make_longlong3(s /a.x, s / a.y, s / a.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(longlong3& a, const long long s)
-{
-    a.x /= s; a.y /= s; a.z /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 clamp(const longlong3& v, const long long a, const long long b)
-{
-    return make_longlong3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 clamp(const longlong3& v, const longlong3& a, const longlong3& b)
-{
-    return make_longlong3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const longlong3& a, const longlong3& b)
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const longlong3& a, const longlong3& b)
-{
-    return a.x != b.x || a.y != b.y || a.z != b.z;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE long long getByIndex(const longlong3& v, int i)
-{
-    return ((long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(longlong3& v, int i, int x)
-{
-    ((long long*)(&v))[i] = x;
-}
-
-
-/* LONGLONG4 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const long long s)
-{
-    return MAKE_LONGLONG4(s, s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const float4& a)
-{
-    return MAKE_LONGLONG4((long long)a.x, (long long)a.y, (long long)a.z, (long long)a.w);
-}
-/** @} */
-
-/** negate */
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator-(const LONGLONG4& a)
-{
-    return MAKE_LONGLONG4(-a.x, -a.y, -a.z, -a.w);
-}
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 min(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 max(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator+(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(LONGLONG4& a, const LONGLONG4& b)
-{
-    a.x += b.x; a.y += b.y; a.z += b.z; a.w += b.w;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator-(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(LONGLONG4& a, const LONGLONG4& b)
-{
-    a.x -= b.x; a.y -= b.y; a.z -= b.z; a.w -= b.w;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator*(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator*(const LONGLONG4& a, const long long s)
-{
-    return MAKE_LONGLONG4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator*(const long long s, const LONGLONG4& a)
-{
-    return MAKE_LONGLONG4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(LONGLONG4& a, const long long s)
-{
-    a.x *= s; a.y *= s; a.z *= s; a.w *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator/(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator/(const LONGLONG4& a, const long long s)
-{
-    return MAKE_LONGLONG4(a.x / s, a.y / s, a.z / s, a.w / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 operator/(const long long s, const LONGLONG4& a)
-{
-    return MAKE_LONGLONG4(s / a.x, s / a.y, s / a.z, s / a.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(LONGLONG4& a, const long long s)
-{
-    a.x /= s; a.y /= s; a.z /= s; a.w /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 clamp(const LONGLONG4& v, const long long a, const long long b)
-{
-    return MAKE_LONGLONG4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 clamp(const LONGLONG4& v, const LONGLONG4& a, const LONGLONG4& b)
-{
-    return MAKE_LONGLONG4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const LONGLONG4& a, const LONGLONG4& b)
-{
-    return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE long long getByIndex(const LONGLONG4& v, int i)
-{
-    return ((long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(LONGLONG4& v, int i, long long x)
-{
-    ((long long*)(&v))[i] = x;
-}
-
-/* ulonglong functions */
-/******************************************************************************/
-
-/** clamp */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long clamp(const unsigned long long f, const unsigned long long a, const unsigned long long b)
-{
-    return max(a, min(f, b));
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long getByIndex(const ulonglong1& v, unsigned int i)
-{
-    return ((unsigned long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(ulonglong1& v, int i, unsigned long long x)
-{
-    ((unsigned long long*)(&v))[i] = x;
-}
-
-
-/* ulonglong2 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 make_ulonglong2(const unsigned long long s)
-{
-    return make_ulonglong2(s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 make_ulonglong2(const float2& a)
-{
-    return make_ulonglong2((unsigned long long)a.x, (unsigned long long)a.y);
-}
-/** @} */
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 min(const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(min(a.x, b.x), min(a.y, b.y));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 max(const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(max(a.x, b.x), max(a.y, b.y));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator+(const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(a.x + b.x, a.y + b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(ulonglong2& a, const ulonglong2& b)
-{
-    a.x += b.x; a.y += b.y;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator-(const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(a.x - b.x, a.y - b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator-(const ulonglong2& a, const unsigned long long b)
-{
-    return make_ulonglong2(a.x - b, a.y - b);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(ulonglong2& a, const ulonglong2& b)
-{
-    a.x -= b.x; a.y -= b.y;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator*(const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(a.x * b.x, a.y * b.y);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator*(const ulonglong2& a, const unsigned long long s)
-{
-    return make_ulonglong2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 operator*(const unsigned long long s, const ulonglong2& a)
-{
-    return make_ulonglong2(a.x * s, a.y * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(ulonglong2& a, const unsigned long long s)
-{
-    a.x *= s; a.y *= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 clamp(const ulonglong2& v, const unsigned long long a, const unsigned long long b)
-{
-    return make_ulonglong2(clamp(v.x, a, b), clamp(v.y, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 clamp(const ulonglong2& v, const ulonglong2& a, const ulonglong2& b)
-{
-    return make_ulonglong2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const ulonglong2& a, const ulonglong2& b)
-{
-    return a.x == b.x && a.y == b.y;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const ulonglong2& a, const ulonglong2& b)
-{
-    return a.x != b.x || a.y != b.y;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long getByIndex(const ulonglong2& v, unsigned int i)
-{
-    return ((unsigned long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory */
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(ulonglong2& v, int i, unsigned long long x)
-{
-    ((unsigned long long*)(&v))[i] = x;
-}
-
-
-/* ulonglong3 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 make_ulonglong3(const unsigned long long s)
-{
-    return make_ulonglong3(s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 make_ulonglong3(const float3& a)
-{
-    return make_ulonglong3((unsigned long long)a.x, (unsigned long long)a.y, (unsigned long long)a.z);
-}
-/** @} */
-
-/** min */
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 min(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
-}
-
-/** max */
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 max(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
-}
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator+(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(a.x + b.x, a.y + b.y, a.z + b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(ulonglong3& a, const ulonglong3& b)
-{
-    a.x += b.x; a.y += b.y; a.z += b.z;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator-(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(a.x - b.x, a.y - b.y, a.z - b.z);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(ulonglong3& a, const ulonglong3& b)
-{
-    a.x -= b.x; a.y -= b.y; a.z -= b.z;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator*(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(a.x * b.x, a.y * b.y, a.z * b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator*(const ulonglong3& a, const unsigned long long s)
-{
-    return make_ulonglong3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator*(const unsigned long long s, const ulonglong3& a)
-{
-    return make_ulonglong3(a.x * s, a.y * s, a.z * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(ulonglong3& a, const unsigned long long s)
-{
-    a.x *= s; a.y *= s; a.z *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator/(const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(a.x / b.x, a.y / b.y, a.z / b.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator/(const ulonglong3& a, const unsigned long long s)
-{
-    return make_ulonglong3(a.x / s, a.y / s, a.z / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 operator/(const unsigned long long s, const ulonglong3& a)
-{
-    return make_ulonglong3(s / a.x, s / a.y, s / a.z);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(ulonglong3& a, const unsigned long long s)
-{
-    a.x /= s; a.y /= s; a.z /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 clamp(const ulonglong3& v, const unsigned long long a, const unsigned long long b)
-{
-    return make_ulonglong3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 clamp(const ulonglong3& v, const ulonglong3& a, const ulonglong3& b)
-{
-    return make_ulonglong3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const ulonglong3& a, const ulonglong3& b)
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const ulonglong3& a, const ulonglong3& b)
-{
-    return a.x != b.x || a.y != b.y || a.z != b.z;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long getByIndex(const ulonglong3& v, unsigned int i)
-{
-    return ((unsigned long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(ulonglong3& v, int i, unsigned long long x)
-{
-    ((unsigned long long*)(&v))[i] = x;
-}
-
-
-/* ULONGLONG4 functions */
-/******************************************************************************/
-
-/** additional constructors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const unsigned long long s)
-{
-    return MAKE_ULONGLONG4(s, s, s, s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const float4& a)
-{
-    return MAKE_ULONGLONG4((unsigned long long)a.x, (unsigned long long)a.y, (unsigned long long)a.z, (unsigned long long)a.w);
-}
-/** @} */
-
-/** min
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 min(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
-}
-/** @} */
-
-/** max
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 max(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
-}
-/** @} */
-
-/** add
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator+(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator+=(ULONGLONG4& a, const ULONGLONG4& b)
-{
-    a.x += b.x; a.y += b.y; a.z += b.z; a.w += b.w;
-}
-/** @} */
-
-/** subtract
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator-(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator-=(ULONGLONG4& a, const ULONGLONG4& b)
-{
-    a.x -= b.x; a.y -= b.y; a.z -= b.z; a.w -= b.w;
-}
-/** @} */
-
-/** multiply
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator*(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator*(const ULONGLONG4& a, const unsigned long long s)
-{
-    return MAKE_ULONGLONG4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator*(const unsigned long long s, const ULONGLONG4& a)
-{
-    return MAKE_ULONGLONG4(a.x * s, a.y * s, a.z * s, a.w * s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator*=(ULONGLONG4& a, const unsigned long long s)
-{
-    a.x *= s; a.y *= s; a.z *= s; a.w *= s;
-}
-/** @} */
-
-/** divide
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator/(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator/(const ULONGLONG4& a, const unsigned long long s)
-{
-    return MAKE_ULONGLONG4(a.x / s, a.y / s, a.z / s, a.w / s);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 operator/(const unsigned long long s, const ULONGLONG4& a)
-{
-    return MAKE_ULONGLONG4(s / a.x, s / a.y, s / a.z, s / a.w);
-}
-SUTIL_INLINE SUTIL_HOSTDEVICE void operator/=(ULONGLONG4& a, const unsigned long long s)
-{
-    a.x /= s; a.y /= s; a.z /= s; a.w /= s;
-}
-/** @} */
-
-/** clamp
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 clamp(const ULONGLONG4& v, const unsigned long long a, const unsigned long long b)
-{
-    return MAKE_ULONGLONG4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 clamp(const ULONGLONG4& v, const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return MAKE_ULONGLONG4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
-}
-/** @} */
-
-/** equality
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator==(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
-}
-
-SUTIL_INLINE SUTIL_HOSTDEVICE bool operator!=(const ULONGLONG4& a, const ULONGLONG4& b)
-{
-    return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
-}
-/** @} */
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE unsigned long long getByIndex(const ULONGLONG4& v, unsigned int i)
-{
-    return ((unsigned long long*)(&v))[i];
-}
-
-/** If used on the device, this could place the the 'v' in local memory
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE void setByIndex(ULONGLONG4& v, int i, unsigned long long x)
-{
-    ((unsigned long long*)(&v))[i] = x;
-}
-
-
-/******************************************************************************/
-
-/** Narrowing functions
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 make_int2(const int3& v0) { return make_int2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int2 make_int2(const int4& v0) { return make_int2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 make_int3(const int4& v0) { return make_int3( v0.x, v0.y, v0.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 make_uint2(const uint3& v0) { return make_uint2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint2 make_uint2(const uint4& v0) { return make_uint2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 make_uint3(const uint4& v0) { return make_uint3( v0.x, v0.y, v0.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 make_longlong2(const longlong3& v0) { return make_longlong2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong2 make_longlong2(const LONGLONG4& v0) { return make_longlong2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 make_longlong3(const LONGLONG4& v0) { return make_longlong3( v0.x, v0.y, v0.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 make_ulonglong2(const ulonglong3& v0) { return make_ulonglong2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong2 make_ulonglong2(const ULONGLONG4& v0) { return make_ulonglong2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 make_ulonglong3(const ULONGLONG4& v0) { return make_ulonglong3( v0.x, v0.y, v0.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float3& v0) { return make_float2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float2 make_float2(const float4& v0) { return make_float2( v0.x, v0.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float4& v0) { return make_float3( v0.x, v0.y, v0.z ); }
-/** @} */
-
-/** Assemble functions from smaller vectors
-* @{
-*/
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 make_int3(const int v0, const int2& v1) { return make_int3( v0, v1.x, v1.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int3 make_int3(const int2& v0, const int v1) { return make_int3( v0.x, v0.y, v1 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int v0, const int v1, const int2& v2) { return make_int4( v0, v1, v2.x, v2.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int v0, const int2& v1, const int v2) { return make_int4( v0, v1.x, v1.y, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int2& v0, const int v1, const int v2) { return make_int4( v0.x, v0.y, v1, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int v0, const int3& v1) { return make_int4( v0, v1.x, v1.y, v1.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int3& v0, const int v1) { return make_int4( v0.x, v0.y, v0.z, v1 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE int4 make_int4(const int2& v0, const int2& v1) { return make_int4( v0.x, v0.y, v1.x, v1.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 make_uint3(const unsigned int v0, const uint2& v1) { return make_uint3( v0, v1.x, v1.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint3 make_uint3(const uint2& v0, const unsigned int v1) { return make_uint3( v0.x, v0.y, v1 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const unsigned int v1, const uint2& v2) { return make_uint4( v0, v1, v2.x, v2.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const uint2& v1, const unsigned int v2) { return make_uint4( v0, v1.x, v1.y, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const uint2& v0, const unsigned int v1, const unsigned int v2) { return make_uint4( v0.x, v0.y, v1, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const uint3& v1) { return make_uint4( v0, v1.x, v1.y, v1.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const uint3& v0, const unsigned int v1) { return make_uint4( v0.x, v0.y, v0.z, v1 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE uint4 make_uint4(const uint2& v0, const uint2& v1) { return make_uint4( v0.x, v0.y, v1.x, v1.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 make_longlong3(const long long v0, const longlong2& v1) { return make_longlong3(v0, v1.x, v1.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE longlong3 make_longlong3(const longlong2& v0, const long long v1) { return make_longlong3(v0.x, v0.y, v1); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const long long v0, const long long v1, const longlong2& v2) { return MAKE_LONGLONG4(v0, v1, v2.x, v2.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const long long v0, const longlong2& v1, const long long v2) { return MAKE_LONGLONG4(v0, v1.x, v1.y, v2); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const longlong2& v0, const long long v1, const long long v2) { return MAKE_LONGLONG4(v0.x, v0.y, v1, v2); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const long long v0, const longlong3& v1) { return MAKE_LONGLONG4(v0, v1.x, v1.y, v1.z); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const longlong3& v0, const long long v1) { return MAKE_LONGLONG4(v0.x, v0.y, v0.z, v1); }
-SUTIL_INLINE SUTIL_HOSTDEVICE LONGLONG4 MAKE_LONGLONG4(const longlong2& v0, const longlong2& v1) { return MAKE_LONGLONG4(v0.x, v0.y, v1.x, v1.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 make_ulonglong3(const unsigned long long v0, const ulonglong2& v1) { return make_ulonglong3(v0, v1.x, v1.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ulonglong3 make_ulonglong3(const ulonglong2& v0, const unsigned long long v1) { return make_ulonglong3(v0.x, v0.y, v1); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const unsigned long long v0, const unsigned long long v1, const ulonglong2& v2) { return MAKE_ULONGLONG4(v0, v1, v2.x, v2.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const unsigned long long v0, const ulonglong2& v1, const unsigned long long v2) { return MAKE_ULONGLONG4(v0, v1.x, v1.y, v2); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const ulonglong2& v0, const unsigned long long v1, const unsigned long long v2) { return MAKE_ULONGLONG4(v0.x, v0.y, v1, v2); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const unsigned long long v0, const ulonglong3& v1) { return MAKE_ULONGLONG4(v0, v1.x, v1.y, v1.z); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const ulonglong3& v0, const unsigned long long v1) { return MAKE_ULONGLONG4(v0.x, v0.y, v0.z, v1); }
-SUTIL_INLINE SUTIL_HOSTDEVICE ULONGLONG4 MAKE_ULONGLONG4(const ulonglong2& v0, const ulonglong2& v1) { return MAKE_ULONGLONG4(v0.x, v0.y, v1.x, v1.y); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float2& v0, const float v1) { return make_float3(v0.x, v0.y, v1); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float3 make_float3(const float v0, const float2& v1) { return make_float3( v0, v1.x, v1.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float v0, const float v1, const float2& v2) { return make_float4( v0, v1, v2.x, v2.y ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float v0, const float2& v1, const float v2) { return make_float4( v0, v1.x, v1.y, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float2& v0, const float v1, const float v2) { return make_float4( v0.x, v0.y, v1, v2 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float v0, const float3& v1) { return make_float4( v0, v1.x, v1.y, v1.z ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float3& v0, const float v1) { return make_float4( v0.x, v0.y, v0.z, v1 ); }
-SUTIL_INLINE SUTIL_HOSTDEVICE float4 make_float4(const float2& v0, const float2& v1) { return make_float4( v0.x, v0.y, v1.x, v1.y ); }
-/** @} */
-
-
-
-
-#if defined(__CUDACC__) || defined(__CUDABE__)
-#else
-
-#include <iostream>
+#include <cstdlib>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
+#include <string>
 #include <vector>
-
 
 struct scuda
 {
-    template<typename T>    // parse string into value
-    static T  sval(const char* str );
+    template<typename T>
+    static T sval(const char* str);
 
-    template<typename T>    // parse envvar into value
-    static T  eval(const char* ekey, T fallback );
+    template<typename T>
+    static T eval(const char* ekey, T fallback);
 
-    template<typename T>    // parse string into vector
-    static void   svec( std::vector<T>& v, const char* str, char delim=',' );
+    template<typename T>
+    static void svec(std::vector<T>& v, const char* str, char delim=',');
 
-    template<typename T>    // parse envvar into vector
-    static void   evec( std::vector<T>& v, const char* ekey, const char* fallback, char delim=',' );
+    template<typename T>
+    static void evec(std::vector<T>& v, const char* ekey, const char* fallback, char delim=',');
 
-    static float  efloat( const char* ekey, float fallback=0.f );
-    static float3 efloat3(const char* ekey, const char* fallback="0,0,0",   char delim=',' );
-    static float4 efloat4(const char* ekey, const char* fallback="0,0,0,0", char delim=',' );
-    static float3 efloat3n(const char* ekey, const char* fallback="0,0,0",   char delim=',' );
+    static float efloat(const char* ekey, float fallback=0.f);
+    static float3 efloat3(const char* ekey, const char* fallback="0,0,0", char delim=',');
+    static float4 efloat4(const char* ekey, const char* fallback="0,0,0,0", char delim=',');
+    static float3 efloat3n(const char* ekey, const char* fallback="0,0,0", char delim=',');
 
-    static std::string serialize( const float2& v );  // eg for metadata vector into string
-    static std::string serialize( const float3& v );
-    static std::string serialize( const float4& v );
+    static std::string serialize(const float2& v);
+    static std::string serialize(const float3& v);
+    static std::string serialize(const float4& v);
 
-    static float4 center_extent_( const float* mn, const float* mx );
-    static float4 center_extent( const float3& mn, const float3& mx );
-    static float4 center_extent( const float4& mn, const float4& mx );
-
+    static float4 center_extent_(const float* mn, const float* mx);
+    static float4 center_extent(const float3& mn, const float3& mx);
+    static float4 center_extent(const float4& mn, const float4& mx);
 };
 
 template<typename T>
-inline T scuda::sval( const char* str )
+inline T scuda::sval(const char* str)
 {
-    std::string s(str) ;
+    std::string s(str);
     std::istringstream iss(s);
-    T t ;
-    iss >> t ;
-    return t ;
+    T t;
+    iss >> t;
+    return t;
 }
 
 template<typename T>
-inline T scuda::eval( const char* ekey, T fallback )
+inline T scuda::eval(const char* ekey, T fallback)
 {
-    const char* str = getenv(ekey) ;
-    return str ? sval<T>(str) : fallback ;
+    const char* str = getenv(ekey);
+    return str ? sval<T>(str) : fallback;
 }
 
 template<typename T>
-inline void scuda::svec(std::vector<T>& v , const char* str, char delim )
+inline void scuda::svec(std::vector<T>& v, const char* str, char delim)
 {
     std::stringstream ss;
-    ss.str(str)  ;
+    ss.str(str);
     std::string s;
     while (std::getline(ss, s, delim))
     {
         T t = sval<T>(s.c_str());
-        v.push_back(t) ;
+        v.push_back(t);
     }
 }
 
 template<typename T>
-inline void scuda::evec(std::vector<T>& v , const char* ekey, const char* fallback, char delim )
+inline void scuda::evec(std::vector<T>& v, const char* ekey, const char* fallback, char delim)
 {
-    const char* str = getenv(ekey) ;
-    svec(v, str ? str : fallback, delim );
+    const char* str = getenv(ekey);
+    svec(v, str ? str : fallback, delim);
 }
 
 inline float scuda::efloat(const char* ekey, float fallback)
@@ -2804,139 +143,101 @@ inline float scuda::efloat(const char* ekey, float fallback)
     return eval<float>(ekey, fallback);
 }
 
-inline float3 scuda::efloat3(const char* ekey, const char* fallback, char delim )
+inline float3 scuda::efloat3(const char* ekey, const char* fallback, char delim)
 {
-   std::vector<float> fv ;
-   evec(fv, ekey, fallback, delim );
-   return make_float3(
-              fv.size() > 0 ? fv[0] : 0.f ,
-              fv.size() > 1 ? fv[1] : 0.f ,
-              fv.size() > 2 ? fv[2] : 0.f
-             );
+    std::vector<float> fv;
+    evec(fv, ekey, fallback, delim);
+    return make_float3(
+        fv.size() > 0 ? fv[0] : 0.f,
+        fv.size() > 1 ? fv[1] : 0.f,
+        fv.size() > 2 ? fv[2] : 0.f);
 }
 
-inline float4 scuda::efloat4(const char* ekey, const char* fallback, char delim )
+inline float4 scuda::efloat4(const char* ekey, const char* fallback, char delim)
 {
-   std::vector<float> fv ;
-   evec(fv, ekey, fallback, delim );
-   return make_float4(
-              fv.size() > 0 ? fv[0] : 0.f ,
-              fv.size() > 1 ? fv[1] : 0.f ,
-              fv.size() > 2 ? fv[2] : 0.f ,
-              fv.size() > 3 ? fv[3] : 0.f
-             );
+    std::vector<float> fv;
+    evec(fv, ekey, fallback, delim);
+    return make_float4(
+        fv.size() > 0 ? fv[0] : 0.f,
+        fv.size() > 1 ? fv[1] : 0.f,
+        fv.size() > 2 ? fv[2] : 0.f,
+        fv.size() > 3 ? fv[3] : 0.f);
 }
 
-inline float3 scuda::efloat3n(const char* ekey, const char* fallback, char delim )
+inline float3 scuda::efloat3n(const char* ekey, const char* fallback, char delim)
 {
-   float3 v = efloat3(ekey, fallback, delim);
-   return normalize(v);
+    float3 v = efloat3(ekey, fallback, delim);
+    return normalize(v);
 }
 
-
-
-inline std::string scuda::serialize(const float2& v )
+inline std::string scuda::serialize(const float2& v)
 {
-    std::stringstream ss ;
-    ss << v.x
-       << ","
-       << v.y
-       ;
-    std::string str = ss.str();
-    return str ;
+    std::stringstream ss;
+    ss << v.x << "," << v.y;
+    return ss.str();
 }
 
-inline std::string scuda::serialize(const float3& v )
+inline std::string scuda::serialize(const float3& v)
 {
-    std::stringstream ss ;
-    ss << v.x
-       << ","
-       << v.y
-       << ","
-       << v.z
-       ;
-    std::string str = ss.str();
-    return str ;
-}
-inline std::string scuda::serialize(const float4& v )
-{
-    std::stringstream ss ;
-    ss << v.x
-       << ","
-       << v.y
-       << ","
-       << v.z
-       << ","
-       << v.w
-       ;
-    std::string str = ss.str();
-    return str ;
+    std::stringstream ss;
+    ss << v.x << "," << v.y << "," << v.z;
+    return ss.str();
 }
 
-
-/**
-scuda::center_extent
-----------------------
-
-The aim of center_extent "ce" is to define a box
-that contains all the points of a point cloud
-here defined by the mn and mx coordinate points.
-
-**/
-inline float4 scuda::center_extent_( const float* mn, const float* mx )
+inline std::string scuda::serialize(const float4& v)
 {
-    float3 center = make_float3( (mn[0]+mx[0])/2.f, (mn[1]+mx[1])/2.f, (mn[2]+mx[2])/2.f ) ;
-    float3 mx_rel = make_float3( mx[0],mx[1],mx[2] ) - center ;
-    float3 mn_rel = center - make_float3( mn[0],mn[1],mn[2] ) ;
-    float extent = fmaxf( fmaxf(mx_rel), fmaxf(mn_rel) ) ;
-    return make_float4( center, extent );
+    std::stringstream ss;
+    ss << v.x << "," << v.y << "," << v.z << "," << v.w;
+    return ss.str();
 }
-inline float4 scuda::center_extent( const float3& mn, const float3& mx )
+
+inline float4 scuda::center_extent_(const float* mn, const float* mx)
 {
-    return center_extent_(&mn.x, &mx.x);
+    float3 center = make_float3((mn[0]+mx[0])/2.f, (mn[1]+mx[1])/2.f, (mn[2]+mx[2])/2.f);
+    float3 mx_rel = make_float3(mx[0], mx[1], mx[2]) - center;
+    float3 mn_rel = center - make_float3(mn[0], mn[1], mn[2]);
+    float extent = fmaxf(fmaxf(mx_rel), fmaxf(mn_rel));
+    return make_float4(center, extent);
 }
-inline float4 scuda::center_extent( const float4& mn, const float4& mx )
+
+inline float4 scuda::center_extent(const float3& mn, const float3& mx)
 {
     return center_extent_(&mn.x, &mx.x);
 }
 
+inline float4 scuda::center_extent(const float4& mn, const float4& mx)
+{
+    return center_extent_(&mn.x, &mx.x);
+}
 
 inline std::ostream& operator<<(std::ostream& os, const float2& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << std::fixed << std::setprecision(3) << v.x
        << ","
        << std::setw(w) << std::fixed << std::setprecision(3) << v.y
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
-
-
-
 inline std::ostream& operator<<(std::ostream& os, const float3& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << std::fixed << std::setprecision(3) << v.x
        << ","
        << std::setw(w) << std::fixed << std::setprecision(3) << v.y
        << ","
        << std::setw(w) << std::fixed << std::setprecision(3) << v.z
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const float4& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << std::fixed << std::setprecision(3) << v.x
        << ","
        << std::setw(w) << std::fixed << std::setprecision(3) << v.y
@@ -2944,52 +245,34 @@ inline std::ostream& operator<<(std::ostream& os, const float4& v)
        << std::setw(w) << std::fixed << std::setprecision(3) << v.z
        << ","
        << std::setw(w) << std::fixed << std::setprecision(3) << v.w
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
-
-
-
-
-
-
-
-
 inline std::ostream& operator<<(std::ostream& os, const int2& v)
 {
-    int w = 6 ;
-    os
-       << "("
-       << std::setw(w) << v.x
-       << ","
-       << std::setw(w) << v.y
-       << ") "
-       ;
+    int w = 6;
+    os << "(" << std::setw(w) << v.x << "," << std::setw(w) << v.y << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const int3& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << v.x
        << ","
        << std::setw(w) << v.y
        << ","
        << std::setw(w) << v.z
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const int4& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << v.x
        << ","
        << std::setw(w) << v.y
@@ -2997,16 +280,14 @@ inline std::ostream& operator<<(std::ostream& os, const int4& v)
        << std::setw(w) << v.z
        << ","
        << std::setw(w) << v.w
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const short4& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << v.x
        << ","
        << std::setw(w) << v.y
@@ -3014,71 +295,57 @@ inline std::ostream& operator<<(std::ostream& os, const short4& v)
        << std::setw(w) << v.z
        << ","
        << std::setw(w) << v.w
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const uchar4& v)
 {
-    int w = 4 ;
-    os
-       << "("
-       << std::setw(w) << int(v.x)     // avoid trying to output char
+    int w = 4;
+    os << "("
+       << std::setw(w) << int(v.x)
        << ","
        << std::setw(w) << int(v.y)
        << ","
        << std::setw(w) << int(v.z)
        << ","
        << std::setw(w) << int(v.w)
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, const char4& v)
 {
-    int w = 4 ;
-    os
-       << "("
-       << std::setw(w) << int(v.x)     // avoid trying to output char
+    int w = 4;
+    os << "("
+       << std::setw(w) << int(v.x)
        << ","
        << std::setw(w) << int(v.y)
        << ","
        << std::setw(w) << int(v.z)
        << ","
        << std::setw(w) << int(v.w)
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
-
-
-
 inline std::ostream& operator<<(std::ostream& os, const uint3& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << v.x
        << ","
        << std::setw(w) << v.y
        << ","
        << std::setw(w) << v.z
-       << ") "
-       ;
+       << ") ";
     return os;
 }
 
-
-
-
 inline std::ostream& operator<<(std::ostream& os, const uint4& v)
 {
-    int w = 6 ;
-    os
-       << "("
+    int w = 6;
+    os << "("
        << std::setw(w) << v.x
        << ","
        << std::setw(w) << v.y
@@ -3086,11 +353,8 @@ inline std::ostream& operator<<(std::ostream& os, const uint4& v)
        << std::setw(w) << v.z
        << ","
        << std::setw(w) << v.w
-       << ") "
-       ;
+       << ") ";
     return os;
 }
-
-
 
 #endif

--- a/sysrap/scuda.h
+++ b/sysrap/scuda.h
@@ -8,41 +8,41 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
 #include <OptiXToolkit/ShaderUtil/vec_math.h>
+#include <cuda_runtime_api.h>
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
-#    define SUTIL_HOSTDEVICE __host__ __device__
-#    define SUTIL_INLINE __forceinline__
+#define SUTIL_HOSTDEVICE __host__ __device__
+#define SUTIL_INLINE __forceinline__
 #else
-#    define SUTIL_HOSTDEVICE
-#    define SUTIL_INLINE inline
+#define SUTIL_HOSTDEVICE
+#define SUTIL_INLINE inline
 #endif
 
 #if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
-#    define LONGLONG4 longlong4_32a
-#    define ULONGLONG4 ulonglong4_32a
-#    define DOUBLE4 double4_32a
-#    define MAKE_LONGLONG4 make_longlong4_32a
-#    define MAKE_ULONGLONG4 make_ulonglong4_32a
+#define LONGLONG4 longlong4_32a
+#define ULONGLONG4 ulonglong4_32a
+#define DOUBLE4 double4_32a
+#define MAKE_LONGLONG4 make_longlong4_32a
+#define MAKE_ULONGLONG4 make_ulonglong4_32a
 #else
-#    if (CUDART_VERSION >= 13000)
-#        define LONGLONG4 longlong4_32a
-#        define ULONGLONG4 ulonglong4_32a
-#        define DOUBLE4 double4_32a
-#        define MAKE_LONGLONG4 make_longlong4_32a
-#        define MAKE_ULONGLONG4 make_ulonglong4_32a
-#    else
-#        define LONGLONG4 longlong4
-#        define ULONGLONG4 ulonglong4
-#        define DOUBLE4 double4
-#        define MAKE_LONGLONG4 make_longlong4
-#        define MAKE_ULONGLONG4 make_ulonglong4
-#    endif
+#if (CUDART_VERSION >= 13000)
+#define LONGLONG4 longlong4_32a
+#define ULONGLONG4 ulonglong4_32a
+#define DOUBLE4 double4_32a
+#define MAKE_LONGLONG4 make_longlong4_32a
+#define MAKE_ULONGLONG4 make_ulonglong4_32a
+#else
+#define LONGLONG4 longlong4
+#define ULONGLONG4 ulonglong4
+#define DOUBLE4 double4
+#define MAKE_LONGLONG4 make_longlong4
+#define MAKE_ULONGLONG4 make_ulonglong4
+#endif
 #endif
 
 #ifndef M_SQRT2f
-#define M_SQRT2f  1.4142135623730951f
+#define M_SQRT2f 1.4142135623730951f
 #endif
 
 // Preserve the previous scuda.h contract: callers use vec_math helpers without
@@ -94,22 +94,22 @@ SUTIL_INLINE SUTIL_HOSTDEVICE float phi_from_fphi(float fphi)
 
 struct scuda
 {
-    template<typename T>
+    template <typename T>
     static T sval(const char* str);
 
-    template<typename T>
+    template <typename T>
     static T eval(const char* ekey, T fallback);
 
-    template<typename T>
-    static void svec(std::vector<T>& v, const char* str, char delim=',');
+    template <typename T>
+    static void svec(std::vector<T>& v, const char* str, char delim = ',');
 
-    template<typename T>
-    static void evec(std::vector<T>& v, const char* ekey, const char* fallback, char delim=',');
+    template <typename T>
+    static void evec(std::vector<T>& v, const char* ekey, const char* fallback, char delim = ',');
 
-    static float efloat(const char* ekey, float fallback=0.f);
-    static float3 efloat3(const char* ekey, const char* fallback="0,0,0", char delim=',');
-    static float4 efloat4(const char* ekey, const char* fallback="0,0,0,0", char delim=',');
-    static float3 efloat3n(const char* ekey, const char* fallback="0,0,0", char delim=',');
+    static float efloat(const char* ekey, float fallback = 0.f);
+    static float3 efloat3(const char* ekey, const char* fallback = "0,0,0", char delim = ',');
+    static float4 efloat4(const char* ekey, const char* fallback = "0,0,0,0", char delim = ',');
+    static float3 efloat3n(const char* ekey, const char* fallback = "0,0,0", char delim = ',');
 
     static std::string serialize(const float2& v);
     static std::string serialize(const float3& v);
@@ -120,24 +120,24 @@ struct scuda
     static float4 center_extent(const float4& mn, const float4& mx);
 };
 
-template<typename T>
+template <typename T>
 inline T scuda::sval(const char* str)
 {
-    std::string s(str);
+    std::string        s(str);
     std::istringstream iss(s);
-    T t;
+    T                  t;
     iss >> t;
     return t;
 }
 
-template<typename T>
+template <typename T>
 inline T scuda::eval(const char* ekey, T fallback)
 {
     const char* str = getenv(ekey);
     return str ? sval<T>(str) : fallback;
 }
 
-template<typename T>
+template <typename T>
 inline void scuda::svec(std::vector<T>& v, const char* str, char delim)
 {
     std::stringstream ss;
@@ -150,7 +150,7 @@ inline void scuda::svec(std::vector<T>& v, const char* str, char delim)
     }
 }
 
-template<typename T>
+template <typename T>
 inline void scuda::evec(std::vector<T>& v, const char* ekey, const char* fallback, char delim)
 {
     const char* str = getenv(ekey);
@@ -212,10 +212,10 @@ inline std::string scuda::serialize(const float4& v)
 
 inline float4 scuda::center_extent_(const float* mn, const float* mx)
 {
-    float3 center = make_float3((mn[0]+mx[0])/2.f, (mn[1]+mx[1])/2.f, (mn[2]+mx[2])/2.f);
+    float3 center = make_float3((mn[0] + mx[0]) / 2.f, (mn[1] + mx[1]) / 2.f, (mn[2] + mx[2]) / 2.f);
     float3 mx_rel = make_float3(mx[0], mx[1], mx[2]) - center;
     float3 mn_rel = center - make_float3(mn[0], mn[1], mn[2]);
-    float extent = fmaxf(fmaxf(mx_rel), fmaxf(mn_rel));
+    float  extent = fmaxf(fmaxf(mx_rel), fmaxf(mn_rel));
     return make_float4(center, extent);
 }
 

--- a/third_party/optix-toolkit/LICENSE.txt
+++ b/third_party/optix-toolkit/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of NVIDIA CORPORATION nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/Preprocessor.h
+++ b/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/Preprocessor.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#if defined(__CUDACC__) || defined(__CUDABE__)
+#    define OTK_DEVICE __device__
+#    define OTK_HOSTDEVICE __host__ __device__
+#    define OTK_INLINE __forceinline__
+#    define CONST_STATIC_INIT( ... )
+#else
+#    define OTK_DEVICE
+#    define OTK_HOSTDEVICE
+#    define OTK_INLINE inline
+#    define CONST_STATIC_INIT( ... ) = __VA_ARGS__
+#endif
+
+
+

--- a/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/vec_math.h
+++ b/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/vec_math.h
@@ -1224,6 +1224,7 @@ namespace otk {
 
 } // namespace otk
 
+#if CUDART_VERSION >= 13000
 /* double4_16a operators */
 /******************************************************************************/
 
@@ -1361,6 +1362,7 @@ namespace otk {
 /******************************************************************************/
 
 } // namespace otk
+#endif // CUDART_VERSION >= 13000
 
 namespace otk {
 
@@ -3582,6 +3584,7 @@ namespace otk {
 
 } // namespace otk
 
+#if CUDART_VERSION >= 13000
 /* long4_16a operators */
 /******************************************************************************/
 
@@ -3851,6 +3854,7 @@ namespace otk {
 /******************************************************************************/
 
 } // namespace otk
+#endif // CUDART_VERSION >= 13000
 
 /* ulong2 operators */
 /******************************************************************************/
@@ -4515,6 +4519,7 @@ OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong3& v, int i, int x)
 
 } // namespace otk
 
+#if CUDART_VERSION >= 13000
 /* longlong4_16a operators */
 /******************************************************************************/
 
@@ -4707,6 +4712,7 @@ OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong4_16a& v, int i, long long x)
 }
 
 } // namespace otk
+#endif // CUDART_VERSION >= 13000
 
 /* ulonglong operators */
 /******************************************************************************/
@@ -5104,6 +5110,7 @@ OTK_INLINE OTK_HOSTDEVICE void setByIndex(ulonglong3& v, int i, unsigned long lo
 
 } // namespace otk
 
+#if CUDART_VERSION >= 13000
 /* ulonglong4_16a operators */
 /******************************************************************************/
 
@@ -5342,6 +5349,11 @@ OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong2& v
 OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long v0, const ulonglong3& v1) { return make_ulonglong4_16a(v0, v1.x, v1.y, v1.z); }
 OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong3& v0, const unsigned long long v1) { return make_ulonglong4_16a(v0.x, v0.y, v0.z, v1); }
 OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong2& v0, const ulonglong2& v1) { return make_ulonglong4_16a(v0.x, v0.y, v1.x, v1.y); }
+
+} // namespace otk
+#endif // CUDART_VERSION >= 13000
+
+namespace otk {
 OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float2& v0, const float v1) { return ::make_float3(v0.x, v0.y, v1); }
 OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float v0, const float2& v1) { return ::make_float3( v0, v1.x, v1.y ); }
 OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float v0, const float v1, const float2& v2) { return ::make_float4( v0, v1, v2.x, v2.y ); }

--- a/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/vec_math.h
+++ b/third_party/optix-toolkit/OptiXToolkit/ShaderUtil/vec_math.h
@@ -1,0 +1,5355 @@
+// SPDX-FileCopyrightText: Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+#pragma once
+
+#include <OptiXToolkit/ShaderUtil/Preprocessor.h>
+
+#include <vector_functions.h>
+#include <vector_types.h>
+
+#if !defined(__CUDACC_RTC__)
+#include <cmath>
+#include <cstdlib>
+#endif
+
+/* scalar functions used in vector functions */
+#ifndef M_PIf
+#define M_PIf       3.14159265358979323846f
+#endif
+#ifndef M_PI_2f
+#define M_PI_2f     1.57079632679489661923f
+#endif
+#ifndef M_1_PIf
+#define M_1_PIf     0.318309886183790671538f
+#endif
+
+// Operators are defined in the global namespace so that
+// argument-dependent lookup will find them.
+//
+// Functions are declared in namespace otk.
+
+namespace otk {
+
+#if defined( __CUDACC__ )
+using ::max;
+using ::min;
+#else
+#undef max
+#undef min
+
+OTK_INLINE OTK_HOSTDEVICE int max(int a, int b)
+{
+    return a > b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE int min(int a, int b)
+{
+    return a < b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE long long max(long long a, long long b)
+{
+    return a > b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE long long min(long long a, long long b)
+{
+    return a < b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE unsigned int max(unsigned int a, unsigned int b)
+{
+    return a > b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE unsigned int min(unsigned int a, unsigned int b)
+{
+    return a < b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE unsigned long long max(unsigned long long a, unsigned long long b)
+{
+    return a > b ? a : b;
+}
+
+OTK_INLINE OTK_HOSTDEVICE unsigned long long min(unsigned long long a, unsigned long long b)
+{
+    return a < b ? a : b;
+}
+
+
+/** lerp */
+OTK_INLINE OTK_HOSTDEVICE float lerp(const float a, const float b, const float t)
+{
+  return a + t*(b-a);
+}
+
+/** bilerp */
+OTK_INLINE OTK_HOSTDEVICE float bilerp(const float x00, const float x10, const float x01, const float x11,
+                                         const float u, const float v)
+{
+  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
+}
+
+template <typename IntegerType>
+OTK_INLINE OTK_HOSTDEVICE IntegerType roundUp(IntegerType x, IntegerType y)
+{
+    return ( ( x + y - 1 ) / y ) * y;
+}
+
+#endif
+
+/** clamp */
+OTK_INLINE OTK_HOSTDEVICE float clamp( const float f, const float a, const float b )
+{
+    return ::fmaxf( a, fminf( f, b ) );
+}
+
+} // namespace otk
+
+/* float2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE float2 operator-(const float2& a)
+{
+  return ::make_float2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float2 operator+(const float2& a, const float2& b)
+{
+  return ::make_float2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator+(const float2& a, const float b)
+{
+  return ::make_float2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator+(const float a, const float2& b)
+{
+  return ::make_float2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator+=(float2& a, const float2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator+=(float2& a, const float b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float2 operator-(const float2& a, const float2& b)
+{
+  return ::make_float2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator-(const float2& a, const float b)
+{
+  return ::make_float2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator-(const float a, const float2& b)
+{
+  return ::make_float2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator-=(float2& a, const float2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator-=(float2& a, const float b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float2 operator*(const float2& a, const float2& b)
+{
+  return ::make_float2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator*(const float2& a, const float s)
+{
+  return ::make_float2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator*(const float s, const float2& a)
+{
+  return ::make_float2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator*=(float2& a, const float2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator*=(float2& a, const float s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float2 operator/(const float2& a, const float2& b)
+{
+  return ::make_float2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator/(const float2& a, const float s)
+{
+  float inv = 1.0f / s;
+  return a * inv;
+}
+OTK_INLINE OTK_HOSTDEVICE float2 operator/(const float s, const float2& a)
+{
+  return ::make_float2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator/=(float2& a, const float2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float2& operator/=(float2& a, const float s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const float2& a, const float2& b )
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const float2& a, const float2& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* float2 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+using ::make_float2;
+
+
+OTK_INLINE OTK_HOSTDEVICE float2 make_float2(const float s)
+{
+  return ::make_float2(s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE float2 make_float2(const int2& a)
+{
+  return ::make_float2(float(a.x), float(a.y));
+}
+OTK_INLINE OTK_HOSTDEVICE float2 make_float2(const uint2& a)
+{
+  return ::make_float2(float(a.x), float(a.y));
+}
+/** @} */
+
+/** min
+* @{
+*/
+using ::fminf;
+
+OTK_INLINE OTK_HOSTDEVICE float2 fminf(const float2& a, const float2& b)
+{
+  return ::make_float2(::fminf(a.x,b.x), ::fminf(a.y,b.y));
+}
+OTK_INLINE OTK_HOSTDEVICE float fminf(const float2& a)
+{
+  return ::fminf(a.x, a.y);
+}
+/** @} */
+
+/** max
+* @{
+*/
+using ::fmaxf;
+
+OTK_INLINE OTK_HOSTDEVICE float2 fmaxf(const float2& a, const float2& b)
+{
+  return ::make_float2(::fmaxf(a.x,b.x), ::fmaxf(a.y,b.y));
+}
+OTK_INLINE OTK_HOSTDEVICE float fmaxf(const float2& a)
+{
+  return ::fmaxf(a.x, a.y);
+}
+/** @} */
+
+/** lerp */
+OTK_INLINE OTK_HOSTDEVICE float2 lerp(const float2& a, const float2& b, const float t)
+{
+  return a + t*(b-a);
+}
+
+/** bilerp */
+OTK_INLINE OTK_HOSTDEVICE float2 bilerp(const float2& x00, const float2& x10, const float2& x01, const float2& x11,
+                                          const float u, const float v)
+{
+  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float2 clamp(const float2& v, const float a, const float b)
+{
+  return ::make_float2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE float2 clamp(const float2& v, const float2& a, const float2& b)
+{
+  return ::make_float2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+/** @} */
+
+/** dot product */
+OTK_INLINE OTK_HOSTDEVICE float dot(const float2& a, const float2& b)
+{
+  return a.x * b.x + a.y * b.y;
+}
+
+/** length */
+OTK_INLINE OTK_HOSTDEVICE float length(const float2& v)
+{
+  return sqrtf(dot(v, v));
+}
+
+/** normalize */
+OTK_INLINE OTK_HOSTDEVICE float2 normalize(const float2& v)
+{
+  float invLen = 1.0f / sqrtf(dot(v, v));
+  return v * invLen;
+}
+
+/** floor
+* @{
+*/
+using ::floor;
+
+OTK_INLINE OTK_HOSTDEVICE float2 floor(const float2& v)
+{
+  return ::make_float2(::floorf(v.x), ::floorf(v.y));
+}
+
+/** @} */
+
+/** reflect */
+OTK_INLINE OTK_HOSTDEVICE float2 reflect(const float2& i, const float2& n)
+{
+  return i - 2.0f * n * dot(n,i);
+}
+
+/** Faceforward
+* Returns N if dot(i, nref) > 0; else -N;
+* Typical usage is N = faceforward(N, -ray.dir, N);
+* Note that this is opposite of what faceforward does in Cg and GLSL */
+OTK_INLINE OTK_HOSTDEVICE float2 faceforward(const float2& n, const float2& i, const float2& nref)
+{
+  return n * copysignf( 1.0f, dot(i, nref) );
+}
+
+/** exp
+* @{
+*/
+using ::expf;
+
+OTK_INLINE OTK_HOSTDEVICE float2 expf(const float2& v)
+{
+  return ::make_float2(::expf(v.x), ::expf(v.y));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE float getByIndex(const float2& v, int i)
+{
+  return ((float*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(float2& v, int i, float x)
+{
+  ((float*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* float3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE float3 operator-( const float3& a )
+{
+  return ::make_float3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 operator+( const float3& a, const float3& b )
+{
+  return ::make_float3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator+( const float3& a, const float b )
+{
+  return ::make_float3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator+( const float a, const float3& b )
+{
+  return ::make_float3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator+=( float3& a, const float3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator+=( float3& a, const float b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 operator-( const float3& a, const float3& b )
+{
+  return ::make_float3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator-( const float3& a, const float b )
+{
+  return ::make_float3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator-( const float a, const float3& b )
+{
+  return ::make_float3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator-=( float3& a, const float3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator-=( float3& a, const float b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 operator*(const float3& a, const float3& b)
+{
+  return ::make_float3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator*(const float3& a, const float s)
+{
+  return ::make_float3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator*(const float s, const float3& a)
+{
+  return ::make_float3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator*=(float3& a, const float3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator*=(float3& a, const float s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 operator/(const float3& a, const float3& b)
+{
+  return ::make_float3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator/(const float3& a, const float s)
+{
+  return ::make_float3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 operator/(const float s, const float3& a)
+{
+  return ::make_float3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator/=(float3& a, const float3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float3& operator/=(float3& a, const float s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const float3& a, const float3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const float3& a, const float3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* float3 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+using ::make_float3;
+
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float s)
+{
+  return ::make_float3(s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float2& a)
+{
+  return ::make_float3(a.x, a.y, 0.0f);
+}
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const int3& a)
+{
+  return ::make_float3(float(a.x), float(a.y), float(a.z));
+}
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const uint3& a)
+{
+  return ::make_float3(float(a.x), float(a.y), float(a.z));
+}
+/** @} */
+
+/** min
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 fminf(const float3& a, const float3& b)
+{
+  return ::make_float3(::fminf(a.x,b.x), ::fminf(a.y,b.y), ::fminf(a.z,b.z));
+}
+OTK_INLINE OTK_HOSTDEVICE float fminf(const float3& a)
+{
+  return ::fminf(::fminf(a.x, a.y), a.z);
+}
+/** @} */
+
+/** max
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 fmaxf(const float3& a, const float3& b)
+{
+  return ::make_float3(::fmaxf(a.x,b.x), ::fmaxf(a.y,b.y), ::fmaxf(a.z,b.z));
+}
+OTK_INLINE OTK_HOSTDEVICE float fmaxf(const float3& a)
+{
+  return ::fmaxf(::fmaxf(a.x, a.y), a.z);
+}
+/** @} */
+
+/** lerp */
+OTK_INLINE OTK_HOSTDEVICE float3 lerp(const float3& a, const float3& b, const float t)
+{
+  return a + t*(b-a);
+}
+
+/** bilerp */
+OTK_INLINE OTK_HOSTDEVICE float3 bilerp(const float3& x00, const float3& x10, const float3& x01, const float3& x11,
+                                          const float u, const float v)
+{
+  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float3 clamp(const float3& v, const float a, const float b)
+{
+  return ::make_float3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE float3 clamp(const float3& v, const float3& a, const float3& b)
+{
+  return ::make_float3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+/** @} */
+
+/** dot product */
+OTK_INLINE OTK_HOSTDEVICE float dot(const float3& a, const float3& b)
+{
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+/** cross product */
+OTK_INLINE OTK_HOSTDEVICE float3 cross(const float3& a, const float3& b)
+{
+  return ::make_float3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x);
+}
+
+/** length */
+OTK_INLINE OTK_HOSTDEVICE float length(const float3& v)
+{
+  return sqrtf(dot(v, v));
+}
+
+/** normalize */
+OTK_INLINE OTK_HOSTDEVICE float3 normalize(const float3& v)
+{
+  float invLen = 1.0f / sqrtf(dot(v, v));
+  return v * invLen;
+}
+
+/** floor */
+OTK_INLINE OTK_HOSTDEVICE float3 floor(const float3& v)
+{
+  return ::make_float3(::floorf(v.x), ::floorf(v.y), ::floorf(v.z));
+}
+
+/** reflect */
+OTK_INLINE OTK_HOSTDEVICE float3 reflect(const float3& i, const float3& n)
+{
+  return i - 2.0f * n * dot(n,i);
+}
+
+/** Faceforward
+* Returns N if dot(i, nref) > 0; else -N;
+* Typical usage is N = faceforward(N, -ray.dir, N);
+* Note that this is opposite of what faceforward does in Cg and GLSL */
+OTK_INLINE OTK_HOSTDEVICE float3 faceforward(const float3& n, const float3& i, const float3& nref)
+{
+  return n * copysignf( 1.0f, dot(i, nref) );
+}
+
+/** exp */
+OTK_INLINE OTK_HOSTDEVICE float3 expf(const float3& v)
+{
+  return ::make_float3(::expf(v.x), ::expf(v.y), ::expf(v.z));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE float getByIndex(const float3& v, int i)
+{
+  return ((float*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(float3& v, int i, float x)
+{
+  ((float*)(&v))[i] = x;
+}
+
+}  // namespace otk
+
+/* float4 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE float4 operator-(const float4& a)
+{
+  return ::make_float4(-a.x, -a.y, -a.z, -a.w);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 operator+(const float4& a, const float4& b)
+{
+  return ::make_float4(a.x + b.x, a.y + b.y, a.z + b.z,  a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator+(const float4& a, const float b)
+{
+  return ::make_float4(a.x + b, a.y + b, a.z + b,  a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator+(const float a, const float4& b)
+{
+  return ::make_float4(a + b.x, a + b.y, a + b.z,  a + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator+=(float4& a, const float4& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator+=(float4& a, const float b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 operator-(const float4& a, const float4& b)
+{
+  return ::make_float4(a.x - b.x, a.y - b.y, a.z - b.z,  a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator-(const float4& a, const float b)
+{
+  return ::make_float4(a.x - b, a.y - b, a.z - b,  a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator-(const float a, const float4& b)
+{
+  return ::make_float4(a - b.x, a - b.y, a - b.z,  a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator-=(float4& a, const float4& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator-=(float4& a, const float b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 operator*(const float4& a, const float4& s)
+{
+  return ::make_float4(a.x * s.x, a.y * s.y, a.z * s.z, a.w * s.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator*(const float4& a, const float s)
+{
+  return ::make_float4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator*(const float s, const float4& a)
+{
+  return ::make_float4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator*=(float4& a, const float4& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator*=(float4& a, const float s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 operator/(const float4& a, const float4& b)
+{
+  return ::make_float4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator/(const float4& a, const float s)
+{
+  float inv = 1.0f / s;
+  return a * inv;
+}
+OTK_INLINE OTK_HOSTDEVICE float4 operator/(const float s, const float4& a)
+{
+  return ::make_float4( s/a.x, s/a.y, s/a.z, s/a.w );
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator/=(float4& a, const float4& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE float4& operator/=(float4& a, const float s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const float4& a, const float4& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const float4& a, const float4& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* float4 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+using ::make_float4;
+
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float s)
+{
+  return ::make_float4(s, s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float3& a)
+{
+  return ::make_float4(a.x, a.y, a.z, 0.0f);
+}
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const int4& a)
+{
+  return ::make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
+}
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const uint4& a)
+{
+  return ::make_float4(float(a.x), float(a.y), float(a.z), float(a.w));
+}
+/** @} */
+
+/** min
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 fminf(const float4& a, const float4& b)
+{
+  return ::make_float4(::fminf(a.x,b.x), ::fminf(a.y,b.y), ::fminf(a.z,b.z), ::fminf(a.w,b.w));
+}
+OTK_INLINE OTK_HOSTDEVICE float fminf(const float4& a)
+{
+  return ::fminf(::fminf(a.x, a.y), ::fminf(a.z, a.w));
+}
+/** @} */
+
+/** max
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 fmaxf(const float4& a, const float4& b)
+{
+  return ::make_float4(::fmaxf(a.x,b.x), ::fmaxf(a.y,b.y), ::fmaxf(a.z,b.z), ::fmaxf(a.w,b.w));
+}
+OTK_INLINE OTK_HOSTDEVICE float fmaxf(const float4& a)
+{
+  return ::fmaxf(::fmaxf(a.x, a.y), ::fmaxf(a.z, a.w));
+}
+/** @} */
+
+/** lerp */
+OTK_INLINE OTK_HOSTDEVICE float4 lerp(const float4& a, const float4& b, const float t)
+{
+  return a + t*(b-a);
+}
+
+/** bilerp */
+OTK_INLINE OTK_HOSTDEVICE float4 bilerp(const float4& x00, const float4& x10, const float4& x01, const float4& x11,
+                                          const float u, const float v)
+{
+  return lerp( lerp( x00, x10, u ), lerp( x01, x11, u ), v );
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 clamp(const float4& v, const float a, const float b)
+{
+  return ::make_float4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE float4 clamp(const float4& v, const float4& a, const float4& b)
+{
+  return ::make_float4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+/** @} */
+
+/** dot product */
+OTK_INLINE OTK_HOSTDEVICE float dot(const float4& a, const float4& b)
+{
+  return a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w;
+}
+
+/** length */
+OTK_INLINE OTK_HOSTDEVICE float length(const float4& r)
+{
+  return sqrtf(dot(r, r));
+}
+
+/** normalize */
+OTK_INLINE OTK_HOSTDEVICE float4 normalize(const float4& v)
+{
+  float invLen = 1.0f / sqrtf(dot(v, v));
+  return v * invLen;
+}
+
+/** floor */
+OTK_INLINE OTK_HOSTDEVICE float4 floor(const float4& v)
+{
+  return ::make_float4(::floorf(v.x), ::floorf(v.y), ::floorf(v.z), ::floorf(v.w));
+}
+
+/** reflect */
+OTK_INLINE OTK_HOSTDEVICE float4 reflect(const float4& i, const float4& n)
+{
+  return i - 2.0f * n * dot(n,i);
+}
+
+/**
+* Faceforward
+* Returns N if dot(i, nref) > 0; else -N;
+* Typical usage is N = faceforward(N, -ray.dir, N);
+* Note that this is opposite of what faceforward does in Cg and GLSL
+*/
+OTK_INLINE OTK_HOSTDEVICE float4 faceforward(const float4& n, const float4& i, const float4& nref)
+{
+  return n * copysignf( 1.0f, dot(i, nref) );
+}
+
+/** exp */
+OTK_INLINE OTK_HOSTDEVICE float4 expf(const float4& v)
+{
+  return ::make_float4(::expf(v.x), ::expf(v.y), ::expf(v.z), ::expf(v.w));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE float getByIndex(const float4& v, int i)
+{
+  return ((float*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(float4& v, int i, float x)
+{
+  ((float*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* double2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE double2 operator-(const double2& a)
+{
+  return ::make_double2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double2 operator+(const double2& a, const double2& b)
+{
+  return ::make_double2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator+(const double2& a, const double b)
+{
+  return ::make_double2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator+(const double a, const double2& b)
+{
+  return ::make_double2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator+=(double2& a, const double2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator+=(double2& a, const double b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double2 operator-(const double2& a, const double2& b)
+{
+  return ::make_double2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator-(const double2& a, const double b)
+{
+  return ::make_double2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator-(const double a, const double2& b)
+{
+  return ::make_double2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator-=(double2& a, const double2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator-=(double2& a, const double b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double2 operator*(const double2& a, const double2& b)
+{
+  return ::make_double2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator*(const double2& a, const double s)
+{
+  return ::make_double2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator*(const double s, const double2& a)
+{
+  return ::make_double2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator*=(double2& a, const double2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator*=(double2& a, const double s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double2 operator/(const double2& a, const double2& b)
+{
+  return ::make_double2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator/(const double2& a, const double s)
+{
+  double inv = 1.0 / s;
+  return a * inv;
+}
+OTK_INLINE OTK_HOSTDEVICE double2 operator/(const double s, const double2& a)
+{
+  return ::make_double2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator/=(double2& a, const double2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double2& operator/=(double2& a, const double s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const double2& a, const double2& b )
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const double2& a, const double2& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* double2 functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* double3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE double3 operator-( const double3& a )
+{
+  return ::make_double3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double3 operator+( const double3& a, const double3& b )
+{
+  return ::make_double3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator+( const double3& a, const double b )
+{
+  return ::make_double3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator+( const double a, const double3& b )
+{
+  return ::make_double3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator+=( double3& a, const double3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator+=( double3& a, const double b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double3 operator-( const double3& a, const double3& b )
+{
+  return ::make_double3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator-( const double3& a, const double b )
+{
+  return ::make_double3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator-( const double a, const double3& b )
+{
+  return ::make_double3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator-=( double3& a, const double3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator-=( double3& a, const double b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double3 operator*(const double3& a, const double3& b)
+{
+  return ::make_double3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator*(const double3& a, const double s)
+{
+  return ::make_double3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator*(const double s, const double3& a)
+{
+  return ::make_double3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator*=(double3& a, const double3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator*=(double3& a, const double s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double3 operator/(const double3& a, const double3& b)
+{
+  return ::make_double3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator/(const double3& a, const double s)
+{
+  return ::make_double3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE double3 operator/(const double s, const double3& a)
+{
+  return ::make_double3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator/=(double3& a, const double3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double3& operator/=(double3& a, const double s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const double3& a, const double3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const double3& a, const double3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* double3 functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* double4_16a operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator-( const double4_16a& a )
+{
+  return make_double4_16a( -a.x, -a.y, -a.z, -a.w );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator+( const double4_16a& a, const double4_16a& b )
+{
+  return make_double4_16a( a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator+( const double4_16a& a, const double b )
+{
+  return make_double4_16a( a.x + b, a.y + b, a.z + b, a.w + b );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator+( const double a, const double4_16a& b )
+{
+  return make_double4_16a( a + b.x, a + b.y, a + b.z, a + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator+=( double4_16a& a, const double4_16a& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator+=( double4_16a& a, const double b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator-( const double4_16a& a, const double4_16a& b )
+{
+  return make_double4_16a( a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator-( const double4_16a& a, const double b )
+{
+  return make_double4_16a( a.x - b, a.y - b, a.z - b, a.w - b );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator-( const double a, const double4_16a& b )
+{
+  return make_double4_16a( a - b.x, a - b.y, a - b.z, a - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator-=( double4_16a& a, const double4_16a& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator-=( double4_16a& a, const double b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator*(const double4_16a& a, const double4_16a& b)
+{
+  return make_double4_16a(a.x * b.x, a.y * b.y, a.z * b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator*(const double4_16a& a, const double s)
+{
+  return make_double4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator*(const double s, const double4_16a& a)
+{
+  return make_double4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator*=(double4_16a& a, const double4_16a& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator*=(double4_16a& a, const double s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator/(const double4_16a& a, const double4_16a& b)
+{
+  return make_double4_16a(a.x / b.x, a.y / b.y, a.z / b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator/(const double4_16a& a, const double s)
+{
+  return make_double4_16a(a.x / s, a.y / s, a.z / s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a operator/(const double s, const double4_16a& a)
+{
+  return make_double4_16a(s /a.x, s / a.y, s / a.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator/=(double4_16a& a, const double4_16a& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE double4_16a& operator/=(double4_16a& a, const double s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const double4_16a& a, const double4_16a& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const double4_16a& a, const double4_16a& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* double4_16a functions */
+/******************************************************************************/
+
+} // namespace otk
+
+namespace otk {
+
+/* int functions */
+/******************************************************************************/
+
+/** clamp */
+OTK_INLINE OTK_HOSTDEVICE int clamp(const int f, const int a, const int b)
+{
+  return max(a, min(f, b));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE int getByIndex(const int1& v, int i)
+{
+  return ((int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(int1& v, int i, int x)
+{
+  ((int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* short2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE short2 operator-(const short2& a)
+{
+  return ::make_short2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short2 operator+(const short2& a, const short2& b)
+{
+  return ::make_short2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator+(const short2& a, const short b)
+{
+  return ::make_short2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator+(const short a, const short2& b)
+{
+  return ::make_short2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator+=(short2& a, const short2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator+=(short2& a, const short b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short2 operator-(const short2& a, const short2& b)
+{
+  return ::make_short2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator-(const short2& a, const short b)
+{
+  return ::make_short2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator-(const short a, const short2& b)
+{
+  return ::make_short2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator-=(short2& a, const short2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator-=(short2& a, const short b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short2 operator*(const short2& a, const short2& b)
+{
+  return ::make_short2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator*(const short2& a, const short s)
+{
+  return ::make_short2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator*(const short s, const short2& a)
+{
+  return ::make_short2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator*=(short2& a, const short2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator*=(short2& a, const short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short2 operator/(const short2& a, const short2& b)
+{
+  return ::make_short2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator/(const short2& a, const short s)
+{
+  return ::make_short2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE short2 operator/(const short s, const short2& a)
+{
+  return ::make_short2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator/=(short2& a, const short2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short2& operator/=(short2& a, const short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const short2& a, const short2& b)
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const short2& a, const short2& b)
+{
+  return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+/* short3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE short3 operator-( const short3& a )
+{
+  return ::make_short3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short3 operator+( const short3& a, const short3& b )
+{
+  return ::make_short3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator+( const short3& a, const short b )
+{
+  return ::make_short3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator+( const short a, const short3& b )
+{
+  return ::make_short3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator+=( short3& a, const short3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator+=( short3& a, const short b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short3 operator-( const short3& a, const short3& b )
+{
+  return ::make_short3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator-( const short3& a, const short b )
+{
+  return ::make_short3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator-( const short a, const short3& b )
+{
+  return ::make_short3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator-=( short3& a, const short3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator-=( short3& a, const short b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short3 operator*(const short3& a, const short3& b)
+{
+  return ::make_short3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator*(const short3& a, const short s)
+{
+  return ::make_short3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator*(const short s, const short3& a)
+{
+  return ::make_short3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator*=(short3& a, const short3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator*=(short3& a, const short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short3 operator/(const short3& a, const short3& b)
+{
+  return ::make_short3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator/(const short3& a, const short s)
+{
+  return ::make_short3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE short3 operator/(const short s, const short3& a)
+{
+  return ::make_short3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator/=(short3& a, const short3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short3& operator/=(short3& a, const short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const short3& a, const short3& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const short3& a, const short3& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z;
+}
+/** @} */
+
+/* short4 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE short4 operator-(const short4& a)
+{
+  return ::make_short4(-a.x, -a.y, -a.z, -a.w);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short4 operator+(const short4& a, const short4& b)
+{
+  return ::make_short4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator+(const short4& a, const short b)
+{
+  return ::make_short4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator+(const short a, const short4& b)
+{
+  return b + a;
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator+=(short4& a, const short4& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator+=(short4& a, const short b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short4 operator-(const short4& a, const short4& b)
+{
+  return ::make_short4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator-(const short a, const short4& b)
+{
+  return ::make_short4(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator-(const short4& a, const short b)
+{
+  return ::make_short4(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator-=(short4& a, const short4& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator-=(short4& a, const short b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short4 operator*(const short4& a, const short4& b)
+{
+  return ::make_short4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator*(const short4& a, const short s)
+{
+  return ::make_short4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator*(const short s, const short4& a)
+{
+  return ::make_short4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator*=(short4& a, const short4& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator*=(short4& a, const short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE short4 operator/(const short4& a, const short4& b)
+{
+  return ::make_short4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator/(const short4& a, const short s)
+{
+  return ::make_short4(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE short4 operator/(const short s, const short4& a)
+{
+  return ::make_short4(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator/=(short4& a, const short4& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE short4& operator/=(short4& a, const short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const short4& a, const short4& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const short4& a, const short4& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+/* ushort2 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator+(const ushort2& a, const ushort2& b)
+{
+  return ::make_ushort2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator+(const ushort2& a, const short b)
+{
+  return ::make_ushort2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator+(const short a, const ushort2& b)
+{
+  return ::make_ushort2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator+=(ushort2& a, const ushort2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator+=(ushort2& a, const short b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator-(const ushort2& a, const ushort2& b)
+{
+  return ::make_ushort2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator-(const ushort2& a, const short b)
+{
+  return ::make_ushort2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator-(const short a, const ushort2& b)
+{
+  return ::make_ushort2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator-=(ushort2& a, const ushort2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator-=(ushort2& a, const short b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator*(const ushort2& a, const ushort2& b)
+{
+  return ::make_ushort2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator*(const ushort2& a, const short s)
+{
+  return ::make_ushort2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator*(const short s, const ushort2& a)
+{
+  return ::make_ushort2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator*=(ushort2& a, const ushort2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator*=(ushort2& a, const short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator/(const ushort2& a, const ushort2& b)
+{
+  return ::make_ushort2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator/(const ushort2& a, const short s)
+{
+  return ::make_ushort2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2 operator/(const short s, const ushort2& a)
+{
+  return ::make_ushort2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator/=(ushort2& a, const ushort2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort2& operator/=(ushort2& a, const short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const ushort2& a, const ushort2& b)
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const ushort2& a, const ushort2& b)
+{
+  return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+/* ushort3 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator+( const ushort3& a, const ushort3& b )
+{
+  return ::make_ushort3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator+( const ushort3& a, const unsigned short b )
+{
+  return ::make_ushort3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator+( const unsigned short a, const ushort3& b )
+{
+  return ::make_ushort3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator+=( ushort3& a, const ushort3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator+=( ushort3& a, const unsigned short b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator-( const ushort3& a, const ushort3& b )
+{
+  return ::make_ushort3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator-( const ushort3& a, const unsigned short b )
+{
+  return ::make_ushort3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator-( const unsigned short a, const ushort3& b )
+{
+  return ::make_ushort3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator-=( ushort3& a, const ushort3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator-=( ushort3& a, const unsigned short b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator*(const ushort3& a, const ushort3& b)
+{
+  return ::make_ushort3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator*(const ushort3& a, const unsigned short s)
+{
+  return ::make_ushort3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator*(const unsigned short s, const ushort3& a)
+{
+  return ::make_ushort3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator*=(ushort3& a, const ushort3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator*=(ushort3& a, const unsigned short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator/(const ushort3& a, const ushort3& b)
+{
+  return ::make_ushort3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator/(const ushort3& a, const unsigned short s)
+{
+  return ::make_ushort3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3 operator/(const unsigned short s, const ushort3& a)
+{
+  return ::make_ushort3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator/=(ushort3& a, const ushort3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort3& operator/=(ushort3& a, const unsigned short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const ushort3& a, const ushort3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const ushort3& a, const ushort3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+/* ushort4 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator+(const ushort4& a, const ushort4& b)
+{
+  return ::make_ushort4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator+(const ushort4& a, const unsigned short b)
+{
+  return ::make_ushort4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator+(const unsigned short a, const ushort4& b)
+{
+  return b + a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator+=(ushort4& a, const ushort4& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator+=(ushort4& a, const unsigned short b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator-(const ushort4& a, const ushort4& b)
+{
+  return ::make_ushort4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator-(const ushort4& a, const unsigned short b)
+{
+  return ::make_ushort4(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator-(const unsigned short a, const ushort4& b)
+{
+  return ::make_ushort4(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator-=(ushort4& a, const ushort4& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator-=(ushort4& a, const unsigned short b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator*(const ushort4& a, const ushort4& b)
+{
+  return ::make_ushort4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator*(const ushort4& a, const unsigned short s)
+{
+  return ::make_ushort4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator*(const unsigned short s, const ushort4& a)
+{
+  return ::make_ushort4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator*=(ushort4& a, const ushort4& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator*=(ushort4& a, const unsigned short s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator/(const ushort4& a, const ushort4& b)
+{
+  return ::make_ushort4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator/(const ushort4& a, const unsigned short s)
+{
+  return ::make_ushort4(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4 operator/(const unsigned short s, const ushort4& a)
+{
+  return ::make_ushort4(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator/=(ushort4& a, const ushort4& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ushort4& operator/=(ushort4& a, const unsigned short s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const ushort4& a, const ushort4& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const ushort4& a, const ushort4& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+/* int2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE int2 operator-(const int2& a)
+{
+  return ::make_int2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 operator+(const int2& a, const int2& b)
+{
+  return ::make_int2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator+(const int2& a, const int b)
+{
+  return ::make_int2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator+(const int a, const int2& b)
+{
+  return ::make_int2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator+=(int2& a, const int2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator+=(int2& a, const int b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 operator-(const int2& a, const int2& b)
+{
+  return ::make_int2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator-(const int2& a, const int b)
+{
+  return ::make_int2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator-(const int a, const int2& b)
+{
+  return ::make_int2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator-=(int2& a, const int2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator-=(int2& a, const int b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 operator*(const int2& a, const int2& b)
+{
+  return ::make_int2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator*(const int2& a, const int s)
+{
+  return ::make_int2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator*(const int s, const int2& a)
+{
+  return ::make_int2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator*=(int2& a, const int2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator*=(int2& a, const int s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 operator/(const int2& a, const int2& b)
+{
+  return ::make_int2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator/(const int2& a, const int s)
+{
+  return ::make_int2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 operator/(const int s, const int2& a)
+{
+  return ::make_int2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator/=(int2& a, const int2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int2& operator/=(int2& a, const int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const int2& a, const int2& b)
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const int2& a, const int2& b)
+{
+  return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+namespace otk {
+
+/* int2 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+using ::make_int2;
+
+OTK_INLINE OTK_HOSTDEVICE int2 make_int2(const int s)
+{
+  return ::make_int2(s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE int2 make_int2(const float2& a)
+{
+  return ::make_int2(int(a.x), int(a.y));
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE int2 min(const int2& a, const int2& b)
+{
+  return ::make_int2(min(a.x,b.x), min(a.y,b.y));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE int2 max(const int2& a, const int2& b)
+{
+  return ::make_int2(max(a.x,b.x), max(a.y,b.y));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 clamp(const int2& v, const int a, const int b)
+{
+  return ::make_int2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE int2 clamp(const int2& v, const int2& a, const int2& b)
+{
+  return ::make_int2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE int getByIndex(const int2& v, int i)
+{
+  return ((int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(int2& v, int i, int x)
+{
+  ((int*)(&v))[i] = x;
+}
+
+}  // namespace otk
+
+/* int3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE int3 operator-( const int3& a )
+{
+  return ::make_int3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 operator+( const int3& a, const int3& b )
+{
+  return ::make_int3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator+( const int3& a, const int b )
+{
+  return ::make_int3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator+( const int a, const int3& b )
+{
+  return ::make_int3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator+=( int3& a, const int3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator+=( int3& a, const int b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 operator-( const int3& a, const int3& b )
+{
+  return ::make_int3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator-( const int3& a, const int b )
+{
+  return ::make_int3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator-( const int a, const int3& b )
+{
+  return ::make_int3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator-=( int3& a, const int3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator-=( int3& a, const int b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 operator*(const int3& a, const int3& b)
+{
+  return ::make_int3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator*(const int3& a, const int s)
+{
+  return ::make_int3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator*(const int s, const int3& a)
+{
+  return ::make_int3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator*=(int3& a, const int3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator*=(int3& a, const int s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 operator/(const int3& a, const int3& b)
+{
+  return ::make_int3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator/(const int3& a, const int s)
+{
+  return ::make_int3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE int3 operator/(const int s, const int3& a)
+{
+  return ::make_int3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator/=(int3& a, const int3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int3& operator/=(int3& a, const int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const int3& a, const int3& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const int3& a, const int3& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z;
+}
+/** @} */
+
+namespace otk {
+
+/* int3 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+using ::make_int3;
+OTK_INLINE OTK_HOSTDEVICE int3 make_int3(const int s)
+{
+  return ::make_int3(s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE int3 make_int3(const float3& a)
+{
+  return ::make_int3(int(a.x), int(a.y), int(a.z));
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE int3 min(const int3& a, const int3& b)
+{
+  return ::make_int3(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE int3 max(const int3& a, const int3& b)
+{
+  return ::make_int3(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 clamp(const int3& v, const int a, const int b)
+{
+  return ::make_int3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE int3 clamp(const int3& v, const int3& a, const int3& b)
+{
+  return ::make_int3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE int getByIndex(const int3& v, int i)
+{
+  return ((int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(int3& v, int i, int x)
+{
+  ((int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* int4 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE int4 operator-(const int4& a)
+{
+  return ::make_int4(-a.x, -a.y, -a.z, -a.w);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 operator+(const int4& a, const int4& b)
+{
+  return ::make_int4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator+(const int4& a, const int b)
+{
+  return ::make_int4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator+(const int a, const int4& b)
+{
+  return b + a;
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator+=(int4& a, const int4& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator+=(int4& a, const int b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 operator-(const int4& a, const int4& b)
+{
+  return ::make_int4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator-(const int a, const int4& b)
+{
+  return ::make_int4(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator-(const int4& a, const int b)
+{
+  return ::make_int4(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator-=(int4& a, const int4& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator-=(int4& a, const int b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 operator*(const int4& a, const int4& b)
+{
+  return ::make_int4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator*(const int4& a, const int s)
+{
+  return ::make_int4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator*(const int s, const int4& a)
+{
+  return ::make_int4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator*=(int4& a, const int4& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator*=(int4& a, const int s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 operator/(const int4& a, const int4& b)
+{
+  return ::make_int4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator/(const int4& a, const int s)
+{
+  return ::make_int4(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 operator/(const int s, const int4& a)
+{
+  return ::make_int4(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator/=(int4& a, const int4& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE int4& operator/=(int4& a, const int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const int4& a, const int4& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const int4& a, const int4& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+namespace otk {
+
+/* int4 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int s)
+{
+  return ::make_int4(s, s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const float4& a)
+{
+  return ::make_int4((int)a.x, (int)a.y, (int)a.z, (int)a.w);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE int4 min(const int4& a, const int4& b)
+{
+  return ::make_int4(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z), min(a.w,b.w));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE int4 max(const int4& a, const int4& b)
+{
+  return ::make_int4(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z), max(a.w,b.w));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int4 clamp(const int4& v, const int a, const int b)
+{
+  return ::make_int4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE int4 clamp(const int4& v, const int4& a, const int4& b)
+{
+  return ::make_int4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE int getByIndex(const int4& v, int i)
+{
+  return ((int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(int4& v, int i, int x)
+{
+  ((int*)(&v))[i] = x;
+}
+
+
+/* uint functions */
+/******************************************************************************/
+
+/** clamp */
+OTK_INLINE OTK_HOSTDEVICE unsigned int clamp(const unsigned int f, const unsigned int a, const unsigned int b)
+{
+  return max(a, min(f, b));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE unsigned int getByIndex(const uint1& v, unsigned int i)
+{
+  return ((unsigned int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(uint1& v, int i, unsigned int x)
+{
+  ((unsigned int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* uint2 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 operator+(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator+(const uint2& a, const unsigned int b)
+{
+  return ::make_uint2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator+(const unsigned int a, const uint2& b)
+{
+  return ::make_uint2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator+=(uint2& a, const uint2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator+=(uint2& a, const unsigned int b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 operator-(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator-(const uint2& a, const unsigned int b)
+{
+  return ::make_uint2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator-(const unsigned int a, const uint2& b)
+{
+  return ::make_uint2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator-=(uint2& a, const uint2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator-=(uint2& a, const unsigned int b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 operator*(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator*(const uint2& a, const unsigned int s)
+{
+  return ::make_uint2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator*(const unsigned int s, const uint2& a)
+{
+  return ::make_uint2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator*=( uint2& a, const uint2& s )
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator*=( uint2& a, const unsigned int s )
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 operator/(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator/(const uint2& a, const unsigned int s)
+{
+  return ::make_uint2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 operator/(const unsigned int s, const uint2& a)
+{
+  return ::make_uint2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator/=(uint2& a, const uint2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint2& operator/=(uint2& a, const unsigned int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const uint2& a, const uint2& b)
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const uint2& a, const uint2& b)
+{
+  return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+namespace otk {
+
+/* uint2 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 make_uint2(const unsigned int s)
+{
+  return ::make_uint2(s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint2 make_uint2(const float2& a)
+{
+  return ::make_uint2((unsigned int)a.x, (unsigned int)a.y);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE uint2 min(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(min(a.x,b.x), min(a.y,b.y));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE uint2 max(const uint2& a, const uint2& b)
+{
+  return ::make_uint2(max(a.x,b.x), max(a.y,b.y));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint2 clamp(const uint2& v, const unsigned int a, const unsigned int b)
+{
+  return ::make_uint2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE uint2 clamp(const uint2& v, const uint2& a, const uint2& b)
+{
+  return ::make_uint2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE unsigned int getByIndex(const uint2& v, unsigned int i)
+{
+  return ((unsigned int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(uint2& v, int i, unsigned int x)
+{
+  ((unsigned int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* uint3 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 operator+( const uint3& a, const uint3& b )
+{
+  return ::make_uint3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator+( const uint3& a, const unsigned int b )
+{
+  return ::make_uint3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator+( const unsigned int a, const uint3& b )
+{
+  return ::make_uint3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator+=( uint3& a, const uint3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator+=( uint3& a, const unsigned int b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 operator-( const uint3& a, const uint3& b )
+{
+  return ::make_uint3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator-( const uint3& a, const unsigned int b )
+{
+  return ::make_uint3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator-( const unsigned int a, const uint3& b )
+{
+  return ::make_uint3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator-=( uint3& a, const uint3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator-=( uint3& a, const unsigned int b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 operator*(const uint3& a, const uint3& b)
+{
+  return ::make_uint3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator*(const uint3& a, const unsigned int s)
+{
+  return ::make_uint3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator*(const unsigned int s, const uint3& a)
+{
+  return ::make_uint3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator*=(uint3& a, const uint3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator*=(uint3& a, const unsigned int s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 operator/(const uint3& a, const uint3& b)
+{
+  return ::make_uint3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator/(const uint3& a, const unsigned int s)
+{
+  return ::make_uint3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 operator/(const unsigned int s, const uint3& a)
+{
+  return ::make_uint3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator/=(uint3& a, const uint3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint3& operator/=(uint3& a, const unsigned int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const uint3& a, const uint3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const uint3& a, const uint3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* uint3 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 make_uint3(const unsigned int s)
+{
+  return ::make_uint3(s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint3 make_uint3(const float3& a)
+{
+  return ::make_uint3((unsigned int)a.x, (unsigned int)a.y, (unsigned int)a.z);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE uint3 min(const uint3& a, const uint3& b)
+{
+  return ::make_uint3(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE uint3 max(const uint3& a, const uint3& b)
+{
+  return ::make_uint3(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint3 clamp(const uint3& v, const unsigned int a, const unsigned int b)
+{
+  return ::make_uint3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE uint3 clamp(const uint3& v, const uint3& a, const uint3& b)
+{
+  return ::make_uint3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE unsigned int getByIndex(const uint3& v, unsigned int i)
+{
+  return ((unsigned int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(uint3& v, int i, unsigned int x)
+{
+  ((unsigned int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* uint4 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 operator+(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator+(const uint4& a, const unsigned int b)
+{
+  return ::make_uint4(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator+(const unsigned int a, const uint4& b)
+{
+  return b + a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator+=(uint4& a, const uint4& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator+=(uint4& a, const unsigned int b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 operator-(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator-(const uint4& a, const unsigned int b)
+{
+  return ::make_uint4(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator-(const unsigned int a, const uint4& b)
+{
+  return ::make_uint4(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator-=(uint4& a, const uint4& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator-=(uint4& a, const unsigned int b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 operator*(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator*(const uint4& a, const unsigned int s)
+{
+  return ::make_uint4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator*(const unsigned int s, const uint4& a)
+{
+  return ::make_uint4(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator*=(uint4& a, const uint4& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator*=(uint4& a, const unsigned int s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 operator/(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator/(const uint4& a, const unsigned int s)
+{
+  return ::make_uint4(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 operator/(const unsigned int s, const uint4& a)
+{
+  return ::make_uint4(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator/=(uint4& a, const uint4& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE uint4& operator/=(uint4& a, const unsigned int s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const uint4& a, const uint4& b)
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const uint4& a, const uint4& b)
+{
+  return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+namespace otk {
+
+/* uint4 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const unsigned int s)
+{
+  return ::make_uint4(s, s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const float4& a)
+{
+  return ::make_uint4((unsigned int)a.x, (unsigned int)a.y, (unsigned int)a.z, (unsigned int)a.w);
+}
+/** @} */
+
+/** min
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 min(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(min(a.x,b.x), min(a.y,b.y), min(a.z,b.z), min(a.w,b.w));
+}
+/** @} */
+
+/** max
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 max(const uint4& a, const uint4& b)
+{
+  return ::make_uint4(max(a.x,b.x), max(a.y,b.y), max(a.z,b.z), max(a.w,b.w));
+}
+/** @} */
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE uint4 clamp(const uint4& v, const unsigned int a, const unsigned int b)
+{
+  return ::make_uint4(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE uint4 clamp(const uint4& v, const uint4& a, const uint4& b)
+{
+  return ::make_uint4(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE unsigned int getByIndex(const uint4& v, unsigned int i)
+{
+  return ((unsigned int*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(uint4& v, int i, unsigned int x)
+{
+  ((unsigned int*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* long2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE long2 operator-(const long2& a)
+{
+    return ::make_long2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long2 operator+(const long2& a, const long2& b)
+{
+  return ::make_long2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator+(const long2& a, const long b)
+{
+  return ::make_long2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator+(const long a, const long2& b)
+{
+  return ::make_long2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator+=(long2& a, const long2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator+=(long2& a, const long b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long2 operator-(const long2& a, const long2& b)
+{
+  return ::make_long2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator-(const long2& a, const long b)
+{
+  return ::make_long2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator-(const long a, const long2& b)
+{
+  return ::make_long2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator-=(long2& a, const long2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator-=(long2& a, const long b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long2 operator*(const long2& a, const long2& b)
+{
+  return ::make_long2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator*(const long2& a, const long s)
+{
+  return ::make_long2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator*(const long s, const long2& a)
+{
+  return ::make_long2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator*=(long2& a, const long2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator*=(long2& a, const long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long2 operator/(const long2& a, const long2& b)
+{
+  return ::make_long2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator/(const long2& a, const long s)
+{
+  return ::make_long2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE long2 operator/(const long s, const long2& a)
+{
+  return ::make_long2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator/=(long2& a, const long2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long2& operator/=(long2& a, const long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const long2& a, const long2& b )
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const long2& a, const long2& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* long2 functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* long3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE long3 operator-( const long3& a )
+{
+  return ::make_long3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long3 operator+( const long3& a, const long3& b )
+{
+  return ::make_long3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator+( const long3& a, const long b )
+{
+  return ::make_long3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator+( const long a, const long3& b )
+{
+  return ::make_long3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator+=( long3& a, const long3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator+=( long3& a, const long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long3 operator-( const long3& a, const long3& b )
+{
+  return ::make_long3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator-( const long3& a, const long b )
+{
+  return ::make_long3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator-( const long a, const long3& b )
+{
+  return ::make_long3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator-=( long3& a, const long3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator-=( long3& a, const long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long3 operator*(const long3& a, const long3& b)
+{
+  return ::make_long3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator*(const long3& a, const long s)
+{
+  return ::make_long3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator*(const long s, const long3& a)
+{
+  return ::make_long3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator*=(long3& a, const long3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator*=(long3& a, const long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long3 operator/(const long3& a, const long3& b)
+{
+  return ::make_long3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator/(const long3& a, const long s)
+{
+  return ::make_long3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE long3 operator/(const long s, const long3& a)
+{
+  return ::make_long3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator/=(long3& a, const long3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long3& operator/=(long3& a, const long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const long3& a, const long3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const long3& a, const long3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* long3 functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* long4_16a operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator-( const long4_16a& a )
+{
+  return make_long4_16a( -a.x, -a.y, -a.z, -a.w );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator+( const long4_16a& a, const long4_16a& b )
+{
+  return make_long4_16a( a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator+( const long4_16a& a, const long b )
+{
+  return make_long4_16a( a.x + b, a.y + b, a.z + b, a.w + b );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator+( const long a, const long4_16a& b )
+{
+  return make_long4_16a( a + b.x, a + b.y, a + b.z, a + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator+=( long4_16a& a, const long4_16a& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator+=( long4_16a& a, const long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator-( const long4_16a& a, const long4_16a& b )
+{
+  return make_long4_16a( a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator-( const long4_16a& a, const long b )
+{
+  return make_long4_16a( a.x - b, a.y - b, a.z - b, a.w - b );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator-( const long a, const long4_16a& b )
+{
+  return make_long4_16a( a - b.x, a - b.y, a - b.z, a - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator-=( long4_16a& a, const long4_16a& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator-=( long4_16a& a, const long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator*(const long4_16a& a, const long4_16a& b)
+{
+  return make_long4_16a(a.x * b.x, a.y * b.y, a.z * b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator*(const long4_16a& a, const long s)
+{
+  return make_long4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator*(const long s, const long4_16a& a)
+{
+  return make_long4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator*=(long4_16a& a, const long4_16a& s)
+{
+  a = a *s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator*=(long4_16a& a, const long s)
+{
+  a = a *s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator/(const long4_16a& a, const long4_16a& b)
+{
+  return make_long4_16a(a.x / b.x, a.y / b.y, a.z / b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator/(const long4_16a& a, const long s)
+{
+  return make_long4_16a(a.x / s, a.y / s, a.z / s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a operator/(const long s, const long4_16a& a)
+{
+  return make_long4_16a(s /a.x, s / a.y, s / a.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator/=(long4_16a& a, const long4_16a& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE long4_16a& operator/=(long4_16a& a, const long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const long4_16a& a, const long4_16a& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const long4_16a& a, const long4_16a& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* long4_16a functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* ulong4_16a operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator+( const ulong4_16a& a, const ulong4_16a& b )
+{
+  return make_ulong4_16a( a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator+( const ulong4_16a& a, const long b )
+{
+  return make_ulong4_16a( a.x + b, a.y + b, a.z + b, a.w + b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator+( const long a, const ulong4_16a& b )
+{
+  return make_ulong4_16a( a + b.x, a + b.y, a + b.z, a + b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator+=( ulong4_16a& a, const ulong4_16a& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator+=( ulong4_16a& a, const long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator-( const ulong4_16a& a, const ulong4_16a& b )
+{
+  return make_ulong4_16a( a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator-( const ulong4_16a& a, const long b )
+{
+  return make_ulong4_16a( a.x - b, a.y - b, a.z - b, a.w - b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator-( const long a, const ulong4_16a& b )
+{
+  return make_ulong4_16a( a - b.x, a - b.y, a - b.z, a - b.w );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator-=( ulong4_16a& a, const ulong4_16a& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator-=( ulong4_16a& a, const long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator*(const ulong4_16a& a, const ulong4_16a& b)
+{
+  return make_ulong4_16a(a.x * b.x, a.y * b.y, a.z * b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator*(const ulong4_16a& a, const long s)
+{
+  return make_ulong4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator*(const long s, const ulong4_16a& a)
+{
+  return make_ulong4_16a(a.x * s, a.y * s, a.z * s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator*=(ulong4_16a& a, const ulong4_16a& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator*=(ulong4_16a& a, const long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator/(const ulong4_16a& a, const ulong4_16a& b)
+{
+  return make_ulong4_16a(a.x / b.x, a.y / b.y, a.z / b.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator/(const ulong4_16a& a, const long s)
+{
+  return make_ulong4_16a(a.x / s, a.y / s, a.z / s, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a operator/(const long s, const ulong4_16a& a)
+{
+  return make_ulong4_16a(s /a.x, s / a.y, s / a.z, 0);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator/=(ulong4_16a& a, const ulong4_16a& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong4_16a& operator/=(ulong4_16a& a, const long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const ulong4_16a& a, const ulong4_16a& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const ulong4_16a& a, const ulong4_16a& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* ulong4_16a functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* ulong2 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator+(const ulong2& a, const ulong2& b)
+{
+  return ::make_ulong2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator+(const ulong2& a, const unsigned long b)
+{
+  return ::make_ulong2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator+(const unsigned long a, const ulong2& b)
+{
+  return ::make_ulong2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator+=(ulong2& a, const ulong2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator+=(ulong2& a, const unsigned long b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator-(const ulong2& a, const ulong2& b)
+{
+  return ::make_ulong2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator-(const ulong2& a, const unsigned long b)
+{
+  return ::make_ulong2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator-(const unsigned long a, const ulong2& b)
+{
+  return ::make_ulong2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator-=(ulong2& a, const ulong2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator-=(ulong2& a, const unsigned long b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator*(const ulong2& a, const ulong2& b)
+{
+  return ::make_ulong2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator*(const ulong2& a, const unsigned long s)
+{
+  return ::make_ulong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator*(const unsigned long s, const ulong2& a)
+{
+  return ::make_ulong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator*=(ulong2& a, const ulong2& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator*=(ulong2& a, const unsigned long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator/(const ulong2& a, const ulong2& b)
+{
+  return ::make_ulong2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator/(const ulong2& a, const unsigned long s)
+{
+  return ::make_ulong2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2 operator/(const unsigned long s, const ulong2& a)
+{
+  return ::make_ulong2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator/=(ulong2& a, const ulong2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong2& operator/=(ulong2& a, const unsigned long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const ulong2& a, const ulong2& b )
+{
+  return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const ulong2& a, const ulong2& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* ulong2 functions */
+/******************************************************************************/
+
+/* long long functions */
+/******************************************************************************/
+
+/** clamp */
+OTK_INLINE OTK_HOSTDEVICE long long clamp(const long long f, const long long a, const long long b)
+{
+    return max(a, min(f, b));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE long long getByIndex(const longlong1& v, int i)
+{
+    return ((long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong1& v, int i, long long x)
+{
+    ((long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* ulong3 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator+( const ulong3& a, const ulong3& b )
+{
+  return ::make_ulong3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator+( const ulong3& a, const unsigned long b )
+{
+  return ::make_ulong3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator+( const unsigned long a, const ulong3& b )
+{
+  return ::make_ulong3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator+=( ulong3& a, const ulong3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator+=( ulong3& a, const unsigned long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator-( const ulong3& a, const ulong3& b )
+{
+  return ::make_ulong3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator-( const ulong3& a, const unsigned long b )
+{
+  return ::make_ulong3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator-( const unsigned long a, const ulong3& b )
+{
+  return ::make_ulong3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator-=( ulong3& a, const ulong3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator-=( ulong3& a, const unsigned long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator*(const ulong3& a, const ulong3& b)
+{
+  return ::make_ulong3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator*(const ulong3& a, const unsigned long s)
+{
+  return ::make_ulong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator*(const unsigned long s, const ulong3& a)
+{
+  return ::make_ulong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator*=(ulong3& a, const ulong3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator*=(ulong3& a, const unsigned long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator/(const ulong3& a, const ulong3& b)
+{
+  return ::make_ulong3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator/(const ulong3& a, const unsigned long s)
+{
+  return ::make_ulong3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3 operator/(const unsigned long s, const ulong3& a)
+{
+  return ::make_ulong3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator/=(ulong3& a, const ulong3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulong3& operator/=(ulong3& a, const unsigned long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const ulong3& a, const ulong3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const ulong3& a, const ulong3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* ulong3 functions */
+/******************************************************************************/
+
+} // namespace otk
+
+/* longlong2 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator-(const longlong2& a)
+{
+    return ::make_longlong2(-a.x, -a.y);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator+(const longlong2& a, const longlong2& b)
+{
+  return ::make_longlong2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator+(const longlong2& a, const long long b)
+{
+  return ::make_longlong2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator+(const long long a, const longlong2& b)
+{
+  return ::make_longlong2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator+=(longlong2& a, const longlong2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator+=(longlong2& a, const long long b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator-(const longlong2& a, const longlong2& b)
+{
+  return ::make_longlong2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator-(const longlong2& a, const long long b)
+{
+  return ::make_longlong2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator-(const long long a, const longlong2& b)
+{
+  return ::make_longlong2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator-=(longlong2& a, const longlong2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator-=(longlong2& a, const long long b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator*(const longlong2& a, const longlong2& b)
+{
+    return ::make_longlong2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator*(const longlong2& a, const long long s)
+{
+    return ::make_longlong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator*(const long long s, const longlong2& a)
+{
+    return ::make_longlong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator*=(longlong2& a, const longlong2& s)
+{
+    a = a * s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator*=(longlong2& a, const long long s)
+{
+    a = a * s;
+    return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator/(const longlong2& a, const longlong2& b)
+{
+  return ::make_longlong2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator/(const longlong2& a, const long long s)
+{
+  return ::make_longlong2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 operator/(const long long s, const longlong2& a)
+{
+  return ::make_longlong2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator/=(longlong2& a, const longlong2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2& operator/=(longlong2& a, const long long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const longlong2& a, const longlong2& b)
+{
+    return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const longlong2& a, const longlong2& b)
+{
+    return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+namespace otk {
+
+/* longlong2 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 make_longlong2(const long long s)
+{
+    return ::make_longlong2(s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong2 make_longlong2(const float2& a)
+{
+    return ::make_longlong2(int(a.x), int(a.y));
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE longlong2 min(const longlong2& a, const longlong2& b)
+{
+    return ::make_longlong2(min(a.x, b.x), min(a.y, b.y));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE longlong2 max(const longlong2& a, const longlong2& b)
+{
+    return ::make_longlong2(max(a.x, b.x), max(a.y, b.y));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong2 clamp(const longlong2& v, const long long a, const long long b)
+{
+    return ::make_longlong2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE longlong2 clamp(const longlong2& v, const longlong2& a, const longlong2& b)
+{
+    return ::make_longlong2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE long long getByIndex(const longlong2& v, int i)
+{
+    return ((long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong2& v, int i, long long x)
+{
+    ((long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* longlong3 operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator-( const longlong3& a )
+{
+  return ::make_longlong3( -a.x, -a.y, -a.z );
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator+( const longlong3& a, const longlong3& b )
+{
+  return ::make_longlong3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator+( const longlong3& a, const long long b )
+{
+  return ::make_longlong3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator+( const long long a, const longlong3& b )
+{
+  return ::make_longlong3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator+=( longlong3& a, const longlong3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator+=( longlong3& a, const long long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator-( const longlong3& a, const longlong3& b )
+{
+  return ::make_longlong3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator-( const longlong3& a, const long long b )
+{
+  return ::make_longlong3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator-( const long long a, const longlong3& b )
+{
+  return ::make_longlong3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator-=( longlong3& a, const longlong3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator-=( longlong3& a, const long long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator*(const longlong3& a, const longlong3& b)
+{
+  return ::make_longlong3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator*(const longlong3& a, const long long s)
+{
+  return ::make_longlong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator*(const long long s, const longlong3& a)
+{
+  return ::make_longlong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator*=(longlong3& a, const longlong3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator*=(longlong3& a, const long long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator/(const longlong3& a, const longlong3& b)
+{
+  return ::make_longlong3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator/(const longlong3& a, const long long s)
+{
+  return ::make_longlong3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 operator/(const long long s, const longlong3& a)
+{
+  return ::make_longlong3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator/=(longlong3& a, const longlong3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3& operator/=(longlong3& a, const long long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const longlong3& a, const longlong3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const longlong3& a, const longlong3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+namespace otk {
+
+/* longlong3 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 make_longlong3(const long long s)
+{
+    return ::make_longlong3(s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong3 make_longlong3(const float3& a)
+{
+    return ::make_longlong3( (long long)a.x, (long long)a.y, (long long)a.z);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE longlong3 min(const longlong3& a, const longlong3& b)
+{
+    return ::make_longlong3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE longlong3 max(const longlong3& a, const longlong3& b)
+{
+    return ::make_longlong3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong3 clamp(const longlong3& v, const long long a, const long long b)
+{
+    return ::make_longlong3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE longlong3 clamp(const longlong3& v, const longlong3& a, const longlong3& b)
+{
+    return ::make_longlong3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE long long getByIndex(const longlong3& v, int i)
+{
+    return ((long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong3& v, int i, int x)
+{
+    ((long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* longlong4_16a operators */
+/******************************************************************************/
+
+/** negate */
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator-(const longlong4_16a& a)
+{
+    return make_longlong4_16a(-a.x, -a.y, -a.z, -a.w);
+}
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator+(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator+(const long long a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a + b.x, a + b.y, a + b.z, a + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator+(const longlong4_16a& a, const long long b)
+{
+    return make_longlong4_16a(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator+=(longlong4_16a& a, const longlong4_16a& b)
+{
+    a = a + b;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator+=(longlong4_16a& a, const long long b)
+{
+    a = a + b;
+    return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator-(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator-(const long long a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator-(const longlong4_16a& a, const long long b)
+{
+    return make_longlong4_16a(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator-=(longlong4_16a& a, const longlong4_16a& b)
+{
+    a = a - b;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator-=(longlong4_16a& a, const long long b)
+{
+    a = a - b;
+    return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator*(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator*(const longlong4_16a& a, const long long s)
+{
+    return make_longlong4_16a(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator*(const long long s, const longlong4_16a& a)
+{
+    return make_longlong4_16a(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator*=(longlong4_16a& a, const longlong4_16a& s)
+{
+    a = a * s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator*=(longlong4_16a& a, const long long s)
+{
+    a = a * s;
+    return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator/(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator/(const longlong4_16a& a, const long long s)
+{
+    return make_longlong4_16a(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a operator/(const long long s, const longlong4_16a& a)
+{
+    return make_longlong4_16a(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator/=(longlong4_16a& a, const longlong4_16a& s)
+{
+    a = a / s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a& operator/=(longlong4_16a& a, const long long s)
+{
+    a = a / s;
+    return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+namespace otk {
+
+/* longlong4_16a functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const long long x, const long long y, const long long z, const long long w)
+{
+    return ::make_longlong4_16a(x, y, z, w);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const long long s)
+{
+    return make_longlong4_16a(s, s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const float4& a)
+{
+    return make_longlong4_16a((long long)a.x, (long long)a.y, (long long)a.z, (long long)a.w);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a min(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a max(const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a clamp(const longlong4_16a& v, const long long a, const long long b)
+{
+    return make_longlong4_16a(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a clamp(const longlong4_16a& v, const longlong4_16a& a, const longlong4_16a& b)
+{
+    return make_longlong4_16a(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE long long getByIndex(const longlong4_16a& v, int i)
+{
+    return ((long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(longlong4_16a& v, int i, long long x)
+{
+    ((long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* ulonglong operators */
+/******************************************************************************/
+
+namespace otk {
+
+/* ulonglong functions */
+/******************************************************************************/
+
+/** clamp */
+OTK_INLINE OTK_HOSTDEVICE unsigned long long clamp(const unsigned long long f, const unsigned long long a, const unsigned long long b)
+{
+    return max(a, min(f, b));
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE unsigned long long getByIndex(const ulonglong1& v, unsigned int i)
+{
+    return ((unsigned long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(ulonglong1& v, int i, unsigned long long x)
+{
+    ((unsigned long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* ulonglong2 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator+(const ulonglong2& a, const ulonglong2& b)
+{
+  return ::make_ulonglong2(a.x + b.x, a.y + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator+(const ulonglong2& a, const unsigned long long b)
+{
+  return ::make_ulonglong2(a.x + b, a.y + b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator+(const unsigned long long a, const ulonglong2& b)
+{
+  return ::make_ulonglong2(a + b.x, a + b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator+=(ulonglong2& a, const ulonglong2& b)
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator+=(ulonglong2& a, const unsigned long long b)
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator-(const ulonglong2& a, const ulonglong2& b)
+{
+  return ::make_ulonglong2(a.x - b.x, a.y - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator-(const ulonglong2& a, const unsigned long long b)
+{
+  return ::make_ulonglong2(a.x - b, a.y - b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator-(const unsigned long long a, const ulonglong2& b)
+{
+  return ::make_ulonglong2(a - b.x, a - b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator-=(ulonglong2& a, const ulonglong2& b)
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator-=(ulonglong2& a, const unsigned long long b)
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator*(const ulonglong2& a, const ulonglong2& b)
+{
+    return ::make_ulonglong2(a.x * b.x, a.y * b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator*(const ulonglong2& a, const unsigned long long s)
+{
+    return ::make_ulonglong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator*(const unsigned long long s, const ulonglong2& a)
+{
+    return ::make_ulonglong2(a.x * s, a.y * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator*=(ulonglong2& a, const ulonglong2& s)
+{
+    a = a * s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator*=(ulonglong2& a, const unsigned long long s)
+{
+    a = a * s;
+    return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator/(const ulonglong2& a, const ulonglong2& b)
+{
+  return ::make_ulonglong2(a.x / b.x, a.y / b.y);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator/(const ulonglong2& a, const unsigned long long s)
+{
+  return ::make_ulonglong2(a.x / s, a.y / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 operator/(const unsigned long long s, const ulonglong2& a)
+{
+  return ::make_ulonglong2( s/a.x, s/a.y );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator/=(ulonglong2& a, const ulonglong2& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2& operator/=(ulonglong2& a, const unsigned long long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const ulonglong2& a, const ulonglong2& b)
+{
+    return a.x == b.x && a.y == b.y;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const ulonglong2& a, const ulonglong2& b)
+{
+    return a.x != b.x || a.y != b.y;
+}
+/** @} */
+
+namespace otk {
+
+/* ulonglong2 functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 make_ulonglong2(const unsigned long long s)
+{
+    return ::make_ulonglong2(s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 make_ulonglong2(const float2& a)
+{
+    return ::make_ulonglong2((unsigned long long)a.x, (unsigned long long)a.y);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 min(const ulonglong2& a, const ulonglong2& b)
+{
+    return ::make_ulonglong2(min(a.x, b.x), min(a.y, b.y));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 max(const ulonglong2& a, const ulonglong2& b)
+{
+    return ::make_ulonglong2(max(a.x, b.x), max(a.y, b.y));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 clamp(const ulonglong2& v, const unsigned long long a, const unsigned long long b)
+{
+    return ::make_ulonglong2(clamp(v.x, a, b), clamp(v.y, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 clamp(const ulonglong2& v, const ulonglong2& a, const ulonglong2& b)
+{
+    return ::make_ulonglong2(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE unsigned long long getByIndex(const ulonglong2& v, unsigned int i)
+{
+    return ((unsigned long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory */
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(ulonglong2& v, int i, unsigned long long x)
+{
+    ((unsigned long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* ulonglong3 operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator+( const ulonglong3& a, const ulonglong3& b )
+{
+  return ::make_ulonglong3( a.x + b.x, a.y + b.y, a.z + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator+( const ulonglong3& a, const unsigned long long b )
+{
+  return ::make_ulonglong3( a.x + b, a.y + b, a.z + b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator+( const unsigned long long a, const ulonglong3& b )
+{
+  return ::make_ulonglong3( a + b.x, a + b.y, a + b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator+=( ulonglong3& a, const ulonglong3& b )
+{
+  a = a + b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator+=( ulonglong3& a, const unsigned long long b )
+{
+  a = a + b;
+  return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator-( const ulonglong3& a, const ulonglong3& b )
+{
+  return ::make_ulonglong3( a.x - b.x, a.y - b.y, a.z - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator-( const ulonglong3& a, const unsigned long long b )
+{
+  return ::make_ulonglong3( a.x - b, a.y - b, a.z - b );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator-( const unsigned long long a, const ulonglong3& b )
+{
+  return ::make_ulonglong3( a - b.x, a - b.y, a - b.z );
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator-=( ulonglong3& a, const ulonglong3& b )
+{
+  a = a - b;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator-=( ulonglong3& a, const unsigned long long b )
+{
+  a = a - b;
+  return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator*(const ulonglong3& a, const ulonglong3& b)
+{
+  return ::make_ulonglong3(a.x * b.x, a.y * b.y, a.z * b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator*(const ulonglong3& a, const unsigned long long s)
+{
+  return ::make_ulonglong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator*(const unsigned long long s, const ulonglong3& a)
+{
+  return ::make_ulonglong3(a.x * s, a.y * s, a.z * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator*=(ulonglong3& a, const ulonglong3& s)
+{
+  a = a * s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator*=(ulonglong3& a, const unsigned long long s)
+{
+  a = a * s;
+  return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator/(const ulonglong3& a, const ulonglong3& b)
+{
+  return ::make_ulonglong3(a.x / b.x, a.y / b.y, a.z / b.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator/(const ulonglong3& a, const unsigned long long s)
+{
+  return ::make_ulonglong3(a.x / s, a.y / s, a.z / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 operator/(const unsigned long long s, const ulonglong3& a)
+{
+  return ::make_ulonglong3(s /a.x, s / a.y, s / a.z);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator/=(ulonglong3& a, const ulonglong3& s)
+{
+  a = a / s;
+  return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3& operator/=(ulonglong3& a, const unsigned long long s)
+{
+  a = a / s;
+  return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==( const ulonglong3& a, const ulonglong3& b )
+{
+  return a.x == b.x && a.y == b.y && a.z == b.z;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=( const ulonglong3& a, const ulonglong3& b )
+{
+  return !( a == b );
+}
+/** @} */
+
+/* ulonglong3 functions */
+/******************************************************************************/
+
+namespace otk {
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 make_ulonglong3(const unsigned long long s)
+{
+    return ::make_ulonglong3(s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 make_ulonglong3(const float3& a)
+{
+    return ::make_ulonglong3((unsigned long long)a.x, (unsigned long long)a.y, (unsigned long long)a.z);
+}
+/** @} */
+
+/** min */
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 min(const ulonglong3& a, const ulonglong3& b)
+{
+    return ::make_ulonglong3(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z));
+}
+
+/** max */
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 max(const ulonglong3& a, const ulonglong3& b)
+{
+    return ::make_ulonglong3(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z));
+}
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 clamp(const ulonglong3& v, const unsigned long long a, const unsigned long long b)
+{
+    return ::make_ulonglong3(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 clamp(const ulonglong3& v, const ulonglong3& a, const ulonglong3& b)
+{
+    return ::make_ulonglong3(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z));
+}
+/** @} */
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE unsigned long long getByIndex(const ulonglong3& v, unsigned int i)
+{
+    return ((unsigned long long*)(&v))[i];
+}
+
+/** If used on the device, this could place the the 'v' in local memory
+*/
+OTK_INLINE OTK_HOSTDEVICE void setByIndex(ulonglong3& v, int i, unsigned long long x)
+{
+    ((unsigned long long*)(&v))[i] = x;
+}
+
+} // namespace otk
+
+/* ulonglong4_16a operators */
+/******************************************************************************/
+
+/** add
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator+(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a.x + b.x, a.y + b.y, a.z + b.z, a.w + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator+(const unsigned long long a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a + b.x, a + b.y, a + b.z, a + b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator+(const ulonglong4_16a& a, const unsigned long long b)
+{
+    return make_ulonglong4_16a(a.x + b, a.y + b, a.z + b, a.w + b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator+=(ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    a = a + b;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator+=(ulonglong4_16a& a, const unsigned long long b)
+{
+    a = a + b;
+    return a;
+}
+/** @} */
+
+/** subtract
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator-(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a.x - b.x, a.y - b.y, a.z - b.z, a.w - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator-(const unsigned long long a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a - b.x, a - b.y, a - b.z, a - b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator-(const ulonglong4_16a& a, const unsigned long long b)
+{
+    return make_ulonglong4_16a(a.x - b, a.y - b, a.z - b, a.w - b);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator-=(ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    a = a - b;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator-=(ulonglong4_16a& a, const unsigned long long b)
+{
+    a = a - b;
+    return a;
+}
+/** @} */
+
+/** multiply
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator*(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a.x * b.x, a.y * b.y, a.z * b.z, a.w * b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator*(const ulonglong4_16a& a, const unsigned long long s)
+{
+    return make_ulonglong4_16a(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator*(const unsigned long long s, const ulonglong4_16a& a)
+{
+    return make_ulonglong4_16a(a.x * s, a.y * s, a.z * s, a.w * s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator*=(ulonglong4_16a& a, const ulonglong4_16a& s)
+{
+    a = a * s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator*=(ulonglong4_16a& a, const unsigned long long s)
+{
+    a = a * s;
+    return a;
+}
+/** @} */
+
+/** divide
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator/(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(a.x / b.x, a.y / b.y, a.z / b.z, a.w / b.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator/(const ulonglong4_16a& a, const unsigned long long s)
+{
+    return make_ulonglong4_16a(a.x / s, a.y / s, a.z / s, a.w / s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a operator/(const unsigned long long s, const ulonglong4_16a& a)
+{
+    return make_ulonglong4_16a(s / a.x, s / a.y, s / a.z, s / a.w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator/=(ulonglong4_16a& a, const ulonglong4_16a& s)
+{
+    a = a / s;
+    return a;
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a& operator/=(ulonglong4_16a& a, const unsigned long long s)
+{
+    a = a / s;
+    return a;
+}
+/** @} */
+
+/** equality
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE bool operator==(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return a.x == b.x && a.y == b.y && a.z == b.z && a.w == b.w;
+}
+
+OTK_INLINE OTK_HOSTDEVICE bool operator!=(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return a.x != b.x || a.y != b.y || a.z != b.z || a.w != b.w;
+}
+/** @} */
+
+namespace otk {
+
+/* ulonglong4_16a functions */
+/******************************************************************************/
+
+/** additional constructors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long x, const unsigned long long y, const unsigned long long z, const unsigned long long w)
+{
+    return ::make_ulonglong4_16a(x, y, z, w);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long s)
+{
+    return make_ulonglong4_16a(s, s, s, s);
+}
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const float4& a)
+{
+    return make_ulonglong4_16a((unsigned long long)a.x, (unsigned long long)a.y, (unsigned long long)a.z, (unsigned long long)a.w);
+}
+/** @} */
+
+/** min
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a min(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(min(a.x, b.x), min(a.y, b.y), min(a.z, b.z), min(a.w, b.w));
+}
+/** @} */
+
+/** max
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a max(const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(max(a.x, b.x), max(a.y, b.y), max(a.z, b.z), max(a.w, b.w));
+}
+/** @} */
+
+/** clamp
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a clamp(const ulonglong4_16a& v, const unsigned long long a, const unsigned long long b)
+{
+    return make_ulonglong4_16a(clamp(v.x, a, b), clamp(v.y, a, b), clamp(v.z, a, b), clamp(v.w, a, b));
+}
+
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a clamp(const ulonglong4_16a& v, const ulonglong4_16a& a, const ulonglong4_16a& b)
+{
+    return make_ulonglong4_16a(clamp(v.x, a.x, b.x), clamp(v.y, a.y, b.y), clamp(v.z, a.z, b.z), clamp(v.w, a.w, b.w));
+}
+/** @} */
+
+
+
+/******************************************************************************/
+
+/** Narrowing functions
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int2 make_int2(const int3& v0) { return ::make_int2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE int2 make_int2(const int4& v0) { return ::make_int2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE int3 make_int3(const int4& v0) { return ::make_int3( v0.x, v0.y, v0.z ); }
+OTK_INLINE OTK_HOSTDEVICE uint2 make_uint2(const uint3& v0) { return ::make_uint2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE uint2 make_uint2(const uint4& v0) { return ::make_uint2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE uint3 make_uint3(const uint4& v0) { return ::make_uint3( v0.x, v0.y, v0.z ); }
+OTK_INLINE OTK_HOSTDEVICE longlong2 make_longlong2(const longlong3& v0) { return ::make_longlong2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE longlong2 make_longlong2(const longlong4_16a& v0) { return ::make_longlong2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE longlong3 make_longlong3(const longlong4_16a& v0) { return ::make_longlong3( v0.x, v0.y, v0.z ); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 make_ulonglong2(const ulonglong3& v0) { return ::make_ulonglong2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong2 make_ulonglong2(const ulonglong4_16a& v0) { return ::make_ulonglong2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 make_ulonglong3(const ulonglong4_16a& v0) { return ::make_ulonglong3( v0.x, v0.y, v0.z ); }
+OTK_INLINE OTK_HOSTDEVICE float2 make_float2(const float3& v0) { return ::make_float2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE float2 make_float2(const float4& v0) { return ::make_float2( v0.x, v0.y ); }
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float4& v0) { return ::make_float3( v0.x, v0.y, v0.z ); }
+/** @} */
+
+/** Assemble functions from smaller vectors
+* @{
+*/
+OTK_INLINE OTK_HOSTDEVICE int3 make_int3(const int v0, const int2& v1) { return ::make_int3( v0, v1.x, v1.y ); }
+OTK_INLINE OTK_HOSTDEVICE int3 make_int3(const int2& v0, const int v1) { return ::make_int3( v0.x, v0.y, v1 ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int v0, const int v1, const int2& v2) { return ::make_int4( v0, v1, v2.x, v2.y ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int v0, const int2& v1, const int v2) { return ::make_int4( v0, v1.x, v1.y, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int2& v0, const int v1, const int v2) { return ::make_int4( v0.x, v0.y, v1, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int v0, const int3& v1) { return ::make_int4( v0, v1.x, v1.y, v1.z ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int3& v0, const int v1) { return ::make_int4( v0.x, v0.y, v0.z, v1 ); }
+OTK_INLINE OTK_HOSTDEVICE int4 make_int4(const int2& v0, const int2& v1) { return ::make_int4( v0.x, v0.y, v1.x, v1.y ); }
+OTK_INLINE OTK_HOSTDEVICE uint3 make_uint3(const unsigned int v0, const uint2& v1) { return ::make_uint3( v0, v1.x, v1.y ); }
+OTK_INLINE OTK_HOSTDEVICE uint3 make_uint3(const uint2& v0, const unsigned int v1) { return ::make_uint3( v0.x, v0.y, v1 ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const unsigned int v1, const uint2& v2) { return ::make_uint4( v0, v1, v2.x, v2.y ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const uint2& v1, const unsigned int v2) { return ::make_uint4( v0, v1.x, v1.y, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const uint2& v0, const unsigned int v1, const unsigned int v2) { return ::make_uint4( v0.x, v0.y, v1, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const unsigned int v0, const uint3& v1) { return ::make_uint4( v0, v1.x, v1.y, v1.z ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const uint3& v0, const unsigned int v1) { return ::make_uint4( v0.x, v0.y, v0.z, v1 ); }
+OTK_INLINE OTK_HOSTDEVICE uint4 make_uint4(const uint2& v0, const uint2& v1) { return ::make_uint4( v0.x, v0.y, v1.x, v1.y ); }
+OTK_INLINE OTK_HOSTDEVICE longlong3 make_longlong3(const long long v0, const longlong2& v1) { return ::make_longlong3(v0, v1.x, v1.y); }
+OTK_INLINE OTK_HOSTDEVICE longlong3 make_longlong3(const longlong2& v0, const long long v1) { return ::make_longlong3(v0.x, v0.y, v1); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const long long v0, const long long v1, const longlong2& v2) { return make_longlong4_16a(v0, v1, v2.x, v2.y); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const long long v0, const longlong2& v1, const long long v2) { return make_longlong4_16a(v0, v1.x, v1.y, v2); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const longlong2& v0, const long long v1, const long long v2) { return make_longlong4_16a(v0.x, v0.y, v1, v2); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const long long v0, const longlong3& v1) { return make_longlong4_16a(v0, v1.x, v1.y, v1.z); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const longlong3& v0, const long long v1) { return make_longlong4_16a(v0.x, v0.y, v0.z, v1); }
+OTK_INLINE OTK_HOSTDEVICE longlong4_16a make_longlong4_16a(const longlong2& v0, const longlong2& v1) { return make_longlong4_16a(v0.x, v0.y, v1.x, v1.y); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 make_ulonglong3(const unsigned long long v0, const ulonglong2& v1) { return ::make_ulonglong3(v0, v1.x, v1.y); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong3 make_ulonglong3(const ulonglong2& v0, const unsigned long long v1) { return ::make_ulonglong3(v0.x, v0.y, v1); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long v0, const unsigned long long v1, const ulonglong2& v2) { return make_ulonglong4_16a(v0, v1, v2.x, v2.y); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long v0, const ulonglong2& v1, const unsigned long long v2) { return make_ulonglong4_16a(v0, v1.x, v1.y, v2); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong2& v0, const unsigned long long v1, const unsigned long long v2) { return make_ulonglong4_16a(v0.x, v0.y, v1, v2); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const unsigned long long v0, const ulonglong3& v1) { return make_ulonglong4_16a(v0, v1.x, v1.y, v1.z); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong3& v0, const unsigned long long v1) { return make_ulonglong4_16a(v0.x, v0.y, v0.z, v1); }
+OTK_INLINE OTK_HOSTDEVICE ulonglong4_16a make_ulonglong4_16a(const ulonglong2& v0, const ulonglong2& v1) { return make_ulonglong4_16a(v0.x, v0.y, v1.x, v1.y); }
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float2& v0, const float v1) { return ::make_float3(v0.x, v0.y, v1); }
+OTK_INLINE OTK_HOSTDEVICE float3 make_float3(const float v0, const float2& v1) { return ::make_float3( v0, v1.x, v1.y ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float v0, const float v1, const float2& v2) { return ::make_float4( v0, v1, v2.x, v2.y ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float v0, const float2& v1, const float v2) { return ::make_float4( v0, v1.x, v1.y, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float2& v0, const float v1, const float v2) { return ::make_float4( v0.x, v0.y, v1, v2 ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float v0, const float3& v1) { return ::make_float4( v0, v1.x, v1.y, v1.z ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float3& v0, const float v1) { return ::make_float4( v0.x, v0.y, v0.z, v1 ); }
+OTK_INLINE OTK_HOSTDEVICE float4 make_float4(const float2& v0, const float2& v1) { return ::make_float4( v0.x, v0.y, v1.x, v1.y ); }
+/** @} */
+
+} // namespace otk

--- a/third_party/optix-toolkit/README.md
+++ b/third_party/optix-toolkit/README.md
@@ -8,6 +8,19 @@ Pinned upstream release:
 Pinned upstream tag:
 `v1.3.0`
 
+Compatibility backport:
+
+`OptiXToolkit/ShaderUtil/vec_math.h` includes a local backport of upstream
+commit `7acd88bc272a23067a36dc396ca835db145882fd`, which guards CUDA 13-only
+`_16a` vector helpers behind `CUDART_VERSION >= 13000`. Without this guard,
+CUDA 12 builds fail because types such as `double4_16a` are not defined.
+
+Backport reference:
+<https://github.com/NVIDIA/optix-toolkit/commit/7acd88bc272a23067a36dc396ca835db145882fd>
+
+Backport commit:
+`7acd88bc272a23067a36dc396ca835db145882fd`
+
 Vendored files:
 
 | Local file | Upstream file |
@@ -16,7 +29,9 @@ Vendored files:
 | `OptiXToolkit/ShaderUtil/Preprocessor.h` | `ShaderUtil/include/OptiXToolkit/ShaderUtil/Preprocessor.h` |
 | `LICENSE.txt` | `LICENSE.txt` |
 
-The headers were compared against the pinned upstream release after download.
+`Preprocessor.h` and `LICENSE.txt` match the pinned upstream release
+byte-for-byte. `vec_math.h` is otherwise from the pinned upstream release plus
+the CUDA 12 compatibility guard described above.
 
 License:
 
@@ -29,4 +44,8 @@ Simphony compatibility:
 
 Project-local compatibility code is kept in `sysrap/scuda.h`. That header
 includes `OptiXToolkit/ShaderUtil/vec_math.h` and retains only the local API
-surface that is not provided by the upstream OptiX Toolkit header.
+surface that is not provided by the upstream OptiX Toolkit header. For CUDA 12,
+it also restores the legacy narrowing overloads `make_float2(float3)`,
+`make_float2(float4)`, and `make_float3(float4)` because the compatibility
+backport guards those overloads together with adjacent CUDA 13-only `_16a`
+helpers.

--- a/third_party/optix-toolkit/README.md
+++ b/third_party/optix-toolkit/README.md
@@ -1,0 +1,32 @@
+Vendored NVIDIA OptiX Toolkit headers.
+
+Source repository: <https://github.com/NVIDIA/optix-toolkit>
+
+Pinned upstream release:
+<https://github.com/NVIDIA/optix-toolkit/releases/tag/v1.3.0>
+
+Pinned upstream tag:
+`v1.3.0`
+
+Vendored files:
+
+| Local file | Upstream file |
+| --- | --- |
+| `OptiXToolkit/ShaderUtil/vec_math.h` | `ShaderUtil/include/OptiXToolkit/ShaderUtil/vec_math.h` |
+| `OptiXToolkit/ShaderUtil/Preprocessor.h` | `ShaderUtil/include/OptiXToolkit/ShaderUtil/Preprocessor.h` |
+| `LICENSE.txt` | `LICENSE.txt` |
+
+The headers were compared against the pinned upstream release after download.
+
+License:
+
+The upstream repository is published under `BSD-3-Clause`. The vendored
+headers include SPDX license identifiers, and the upstream `LICENSE.txt` is
+included here to preserve the BSD-3 license conditions and disclaimer required
+for redistribution.
+
+Simphony compatibility:
+
+Project-local compatibility code is kept in `sysrap/scuda.h`. That header
+includes `OptiXToolkit/ShaderUtil/vec_math.h` and retains only the local API
+surface that is not provided by the upstream OptiX Toolkit header.


### PR DESCRIPTION
- Vendor NVIDIA OptiX Toolkit `v1.3.0` ShaderUtil headers under `third_party/optix-toolkit`
- Replace the duplicated vector math body in `sysrap/scuda.h` with a small compatibility facade over upstream `vec_math.h`
- Preserve Simphony-local helpers and legacy compatibility APIs that are not provided by upstream
- Add the OptiX Toolkit include root to SysRap and the CSGOptiX PTX target
- Install the vendored headers, README, and BSD-3 license alongside SysRap headers

The vendored files are pinned to NVIDIA/optix-toolkit `v1.3.0`
(`3b9d3c6d08c884372ffc85270c987d1f5273a985`) and keep the upstream BSD-3-Clause license text.

- Byte-compared `vec_math.h`, `Preprocessor.h`, and `LICENSE.txt` against the `v1.3.0` tag
