### PR TITLE
fix(g4app): record initial optical photon steps with null pre-step process

### DIFF
--- a/optiphy/ana/compare_ab.py
+++ b/optiphy/ana/compare_ab.py
@@ -73,14 +73,9 @@ def compare_records(a, b):
     if a.shape != b.shape:
         raise AssertionError(f"Shape mismatch: {a.shape} != {b.shape}")
 
-    # Geant4 and Opticks record one-step-shifted sequences for this geometry,
-    # so compare aligned slices directly, including time.
-    a_cmp = a[:, 1:]
-    b_cmp = b[:, :-1]
-
     return [
         index
-        for index, (a_row, b_row) in enumerate(zip(a_cmp, b_cmp))
+        for index, (a_row, b_row) in enumerate(zip(a, b))
         if not np.allclose(a_row, b_row, rtol=0.0, atol=1e-5)
     ]
 

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -319,7 +319,6 @@ struct SteppingAction : G4UserSteppingAction
             return;
 
         const G4Track *track = step->GetTrack();
-        G4VPhysicalVolume *pv = track->GetVolume();
         const G4VTouchable *touch = track->GetTouchable();
 
         spho ulabel = {};

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -318,11 +318,6 @@ struct SteppingAction : G4UserSteppingAction
         if (step->GetTrack()->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
             return;
 
-        const G4VProcess *process = step->GetPreStepPoint()->GetProcessDefinedStep();
-
-        if (process == nullptr)
-            return;
-
         const G4Track *track = step->GetTrack();
         G4VPhysicalVolume *pv = track->GetVolume();
         const G4VTouchable *touch = track->GetTouchable();


### PR DESCRIPTION
Geant4 can report a null `GetProcessDefinedStep()` on the pre-step
point, notably for the first optical-photon step. `SteppingAction`
previously treated that as a reason to return early, which skipped
recording the initial Geant4 photon point even though the process value
was not used afterward.

Remove that early return so the Geant4-side `record.npy` output
preserves the initial optical-photon step and stays aligned with the
Opticks-side record.

Update `optiphy/ana/compare_ab.py` to compare the A/B event records
directly instead of compensating for the previous one-step offset.
