### PR TITLE
build(cmake): stop defaulting to Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,6 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES 75)
 endif()
 
-# Default CMAKE_BUILD_TYPE=Debug for single-config generators (Ninja/Makefiles) when not specified
-if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type")
-endif()
-
 project(simphony VERSION 0.7.0 LANGUAGES CXX CUDA)
 
 # Use CMake's standard testing option, but avoid enabling this project's tests


### PR DESCRIPTION
Remove the top-level CMAKE_BUILD_TYPE fallback that forced single-config generators such as Ninja and Makefiles into Debug when users did not pass an explicit build type.

This lets CMake preserve its standard empty build-type behavior and requires callers to choose Debug, Release, RelWithDebInfo, or MinSizeRel intentionally.
