### PR TITLE
ci(spack): pin buildcache geant4 to supported version

### DIFF
--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -41,6 +41,10 @@ jobs:
           load: true
           target: spack-base
           tags: ${{ env.SPACK_BASE_IMAGE }}
+          # Keep this on the newest Geant4 version currently declared by
+          # spack/spack-packages. The Dockerfile default can move ahead of Spack.
+          build-args: |
+            GEANT4_VERSION=11.4.1
           cache-from: type=gha,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
           cache-to: type=gha,mode=max,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
 


### PR DESCRIPTION
The buildcache refresh failed while concretizing simphony with ^geant4@11.4.2 because the official spack/spack-packages Geant4 package metadata does not declare 11.4.2 yet.

Keep the Dockerfile default at 11.4.2 for the normal image builds, but pass GEANT4_VERSION=11.4.1 when this workflow builds the spack-base image. The container exports that value, so the subsequent spack spec/install commands use a version currently available to Spack.

References: https://github.com/BNLNPPS/simphony/actions/runs/29130246634/job/86484075917
