### PR TITLE
feat(simg4ox): add run-level GPU and Geant4 hit accounting

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -184,7 +184,7 @@ jobs:
 
 
   cleanup-pr-images:
-    if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-image
     runs-on: ubuntu-latest
     permissions:

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <utility>
 #include <vector>
 
 #include "G4BooleanSolid.hh"
@@ -17,6 +18,7 @@
 #include "G4Track.hh"
 #include "G4TrackStatus.hh"
 #include "G4UserEventAction.hh"
+#include "G4UserRunAction.hh"
 #include "G4UserSteppingAction.hh"
 #include "G4UserTrackingAction.hh"
 #include "G4VPhysicalVolume.hh"
@@ -38,44 +40,13 @@
 #include "config.h"
 #include "torch.h"
 
-bool IsSubtractionSolid(G4VSolid *solid)
-{
-    if (!solid)
-        return false;
-
-    // Check if the solid is directly a G4SubtractionSolid
-    if (dynamic_cast<G4SubtractionSolid *>(solid))
-        return true;
-
-    // If the solid is a Boolean solid, check its constituent solids
-    G4BooleanSolid *booleanSolid = dynamic_cast<G4BooleanSolid *>(solid);
-    if (booleanSolid)
-    {
-        G4VSolid *solidA = booleanSolid->GetConstituentSolid(0);
-        G4VSolid *solidB = booleanSolid->GetConstituentSolid(1);
-
-        // Recursively check the constituent solids
-        if (IsSubtractionSolid(solidA) || IsSubtractionSolid(solidB))
-            return true;
-    }
-
-    // For other solid types, return false
-    return false;
-}
-
-std::string str_tolower(std::string s)
-{
-    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
-    return s;
-}
-
 struct PhotonHit : public G4VHit
 {
     PhotonHit() = default;
 
     PhotonHit(G4double energy, G4double time, G4ThreeVector position, G4ThreeVector direction,
-              G4ThreeVector polarization)
-        : photon()
+              G4ThreeVector polarization) :
+        photon()
     {
         photon.pos = {static_cast<float>(position.x()), static_cast<float>(position.y()),
                       static_cast<float>(position.z())};
@@ -87,13 +58,11 @@ struct PhotonHit : public G4VHit
         photon.wavelength = h_Planck * c_light / (energy * CLHEP::eV);
     }
 
-    // Print method
     void Print() override
     {
         G4cout << photon << G4endl;
     }
 
-    // Member variables
     sphoton photon;
 };
 
@@ -101,76 +70,85 @@ using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
 
 struct PhotonSD : public G4VSensitiveDetector
 {
-    PhotonSD(G4String name) : G4VSensitiveDetector(name), fHCID(-1)
+    gphox::Config         cfg;
+    PhotonHitsCollection* photon_hit_collection{nullptr};
+    G4int                 fHCID;
+
+    PhotonSD(const gphox::Config& cfg, G4String name) :
+        G4VSensitiveDetector(name),
+        cfg(cfg),
+        fHCID(-1)
     {
         G4String HCname = name + "_HC";
         collectionName.insert(HCname);
-        G4cout << collectionName.size() << "   PhotonSD name:  " << name << " collection Name: " << HCname << G4endl;
+        G4cout << "PhotonSD::PhotonSD: name: " << name << ", collection: " << HCname << ", size: " << collectionName.size() << G4endl;
     }
 
-    void Initialize(G4HCofThisEvent *hce) override
+    void Initialize(G4HCofThisEvent* hce) override
     {
-        fPhotonHitsCollection = new PhotonHitsCollection(SensitiveDetectorName, collectionName[0]);
+        photon_hit_collection = new PhotonHitsCollection(SensitiveDetectorName, collectionName[0]);
         if (fHCID < 0)
         {
             G4cout << "PhotonSD::Initialize:  " << SensitiveDetectorName << "   " << collectionName[0] << G4endl;
             fHCID = G4SDManager::GetSDMpointer()->GetCollectionID(collectionName[0]);
         }
-        hce->AddHitsCollection(fHCID, fPhotonHitsCollection);
+        hce->AddHitsCollection(fHCID, photon_hit_collection);
     }
 
-    G4bool ProcessHits(G4Step *aStep, G4TouchableHistory *) override
+    G4bool ProcessHits(G4Step* aStep, G4TouchableHistory*) override
     {
-        G4Track *track = aStep->GetTrack();
+        G4Track* track = aStep->GetTrack();
 
         // Only process optical photons
         if (track->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
             return false;
 
-        // Create a new hit (CopyNr is set to 0 as DetectorID is omitted)
-        PhotonHit *hit = new PhotonHit(
+        // Create a new hit
+        PhotonHit* hit = new PhotonHit(
             track->GetTotalEnergy(), track->GetGlobalTime(), aStep->GetPostStepPoint()->GetPosition(),
             aStep->GetPostStepPoint()->GetMomentumDirection(), aStep->GetPostStepPoint()->GetPolarization());
 
-        fPhotonHitsCollection->insert(hit);
+        photon_hit_collection->insert(hit);
         track->SetTrackStatus(fStopAndKill);
 
         return true;
     }
 
-    void EndOfEvent(G4HCofThisEvent *) override
+    void EndOfEvent(G4HCofThisEvent*) override
     {
-        G4int num_hits = fPhotonHitsCollection->entries();
-        G4cout << "PhotonSD::EndOfEvent Number of PhotonHits: " << num_hits << G4endl;
+        G4int num_g4_hits = photon_hit_collection->entries();
+        G4cout << "PhotonSD::EndOfEvent: number of Geant4 hits: " << num_g4_hits << G4endl;
 
-        NP *hits = NP::Make<float>(num_hits, 4, 4);
+        NP* hits = NP::Make<float>(num_g4_hits, 4, 4);
         int i = 0;
 
-        for (PhotonHit *hit : *fPhotonHitsCollection->GetVector())
+        for (PhotonHit* hit : *photon_hit_collection->GetVector())
         {
-            float *photon_data = reinterpret_cast<float *>(&hit->photon);
+            float* photon_data = reinterpret_cast<float*>(&hit->photon);
             std::copy(photon_data, photon_data + 16, hits->values<float>() + (i++) * 16);
         }
 
-        hits->save("g_hits.npy");
+        hits->save(cfg.output_dir.string().c_str(), "g_hits.npy");
         delete hits;
     }
-
-  private:
-    PhotonHitsCollection *fPhotonHitsCollection{nullptr};
-    G4int fHCID;
 };
 
 struct DetectorConstruction : G4VUserDetectorConstruction
 {
-    DetectorConstruction(std::filesystem::path gdml_file) : gdml_file_(gdml_file)
+    gphox::Config         cfg;
+    std::filesystem::path gdml_file_;
+    G4GDMLParser          parser_;
+
+    DetectorConstruction(const gphox::Config& cfg, std::filesystem::path gdml_file) :
+        cfg(cfg),
+        gdml_file_(std::move(gdml_file))
     {
     }
 
-    G4VPhysicalVolume *Construct() override
+    G4VPhysicalVolume* Construct() override
     {
         parser_.Read(gdml_file_.string(), false);
-        G4VPhysicalVolume *world = parser_.GetWorldVolume();
+        G4VPhysicalVolume* world = parser_.GetWorldVolume();
 
         G4CXOpticks::SetGeometry(world);
 
@@ -179,63 +157,59 @@ struct DetectorConstruction : G4VUserDetectorConstruction
 
     void ConstructSDandField() override
     {
-        G4cout << "ConstructSDandField is called." << G4endl;
-        G4SDManager *SDman = G4SDManager::GetSDMpointer();
+        G4SDManager* SDman = G4SDManager::GetSDMpointer();
 
-        const G4GDMLAuxMapType *auxmap = parser_.GetAuxMap();
-        for (auto const &[logVol, listType] : *auxmap)
+        const G4GDMLAuxMapType* auxmap = parser_.GetAuxMap();
+        for (auto const& [logVol, listType] : *auxmap)
         {
-            for (auto const &auxtype : listType)
+            for (auto const& auxtype : listType)
             {
                 if (auxtype.type == "SensDet")
                 {
-                    G4cout << "Attaching sensitive detector to logical volume: " << logVol->GetName() << G4endl;
-                    G4String name = logVol->GetName() + "_PhotonDetector";
-                    PhotonSD *aPhotonSD = new PhotonSD(name);
+                    G4cout << "DetectorConstruction::ConstructSDandField: Attach sensitive detector to logical volume: " << logVol->GetName() << G4endl;
+                    G4String  name = logVol->GetName() + "_PhotonDetector";
+                    PhotonSD* aPhotonSD = new PhotonSD(cfg, name);
                     SDman->AddNewDetector(aPhotonSD);
                     logVol->SetSensitiveDetector(aPhotonSD);
                 }
             }
         }
     }
-
-  private:
-    std::filesystem::path gdml_file_;
-    G4GDMLParser parser_;
 };
 
 struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 {
     gphox::Config cfg;
-    SEvt *sev;
+    SEvt*         sev;
 
-    PrimaryGenerator(const gphox::Config& cfg, SEvt *sev) : cfg(cfg), sev(sev)
+    PrimaryGenerator(const gphox::Config& cfg, SEvt* sev) :
+        cfg(cfg),
+        sev(sev)
     {
     }
 
-    void GeneratePrimaries(G4Event *event) override
+    void GeneratePrimaries(G4Event* event) override
     {
         std::vector<sphoton> sphotons = generate_photons(cfg.torch);
 
-        size_t num_floats = sphotons.size()*4*4;
+        size_t num_floats = sphotons.size() * 4 * 4;
         float* data = reinterpret_cast<float*>(sphotons.data());
-        NP* photons = NP::MakeFromValues<float>(data, num_floats);
+        NP*    photons = NP::MakeFromValues<float>(data, num_floats);
 
-        photons->reshape({ static_cast<int64_t>(sphotons.size()), 4, 4});
+        photons->reshape({static_cast<int64_t>(sphotons.size()), 4, 4});
 
         for (const sphoton& p : sphotons)
         {
             G4ThreeVector position_mm(p.pos.x, p.pos.y, p.pos.z);
-            G4double time_ns = p.time;
+            G4double      time_ns = p.time;
             G4ThreeVector direction(p.mom.x, p.mom.y, p.mom.z);
-            // direction = direction.unit();
-            G4double wavelength_nm = p.wavelength;
+            G4double      wavelength_nm = p.wavelength;
             G4ThreeVector polarization(p.pol.x, p.pol.y, p.pol.z);
 
-            G4PrimaryVertex *vertex = new G4PrimaryVertex(position_mm, time_ns);
-            G4double kineticEnergy = h_Planck * c_light / (wavelength_nm * nm);
+            G4PrimaryVertex* vertex = new G4PrimaryVertex(position_mm, time_ns);
+            G4double         kineticEnergy = h_Planck * c_light / (wavelength_nm * nm);
 
-            G4PrimaryParticle *particle = new G4PrimaryParticle(G4OpticalPhoton::Definition());
+            G4PrimaryParticle* particle = new G4PrimaryParticle(G4OpticalPhoton::Definition());
             particle->SetKineticEnergy(kineticEnergy);
             particle->SetMomentumDirection(direction);
             particle->SetPolarization(polarization);
@@ -250,18 +224,23 @@ struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 
 struct EventAction : G4UserEventAction
 {
-    SEvt *sev;
+    gphox::Config cfg;
+    SEvt*         sev;
+    G4int         total_g4_hits{0};
+    size_t        total_gpu_hits{0};
 
-    EventAction(SEvt *sev) : sev(sev)
+    EventAction(const gphox::Config& cfg, SEvt* sev) :
+        cfg(cfg),
+        sev(sev)
     {
     }
 
-    void BeginOfEventAction(const G4Event *event) override
+    void BeginOfEventAction(const G4Event* event) override
     {
         sev->beginOfEvent(event->GetEventID());
     }
 
-    void EndOfEventAction(const G4Event *event) override
+    void EndOfEventAction(const G4Event* event) override
     {
         int eventID = event->GetEventID();
         sev->addEventConfigArray();
@@ -269,67 +248,73 @@ struct EventAction : G4UserEventAction
         sev->endOfEvent(eventID);
 
         // GPU-based simulation
-        G4CXOpticks *gx = G4CXOpticks::Get();
+        G4CXOpticks* gx = G4CXOpticks::Get();
 
         gx->simulate(eventID, false);
         cudaDeviceSynchronize();
 
-        unsigned int num_hits = SEvt::GetNumHit(SEvt::EGPU);
+        SEvt*  sev_gpu = SEvt::Get_EGPU();
+        size_t num_hits_gpu = sev_gpu->getNumHit();
+        size_t num_hits_cpu = sev->getNumHit();
 
-        std::cout << "Opticks: NumHits:  " << num_hits << std::endl;
+        G4cout << "EventAction::EndOfEventAction: GPU hits:  " << num_hits_gpu << G4endl;
+        G4cout << "EventAction::EndOfEventAction: CPU hits:  " << num_hits_cpu << G4endl;
 
-        SEvt *sev = SEvt::Get_EGPU();
-        NP *hits = NP::Make<float>(num_hits, 4, 4);
+        total_gpu_hits += num_hits_gpu;
 
-        for (unsigned idx = 0; idx < num_hits; idx++)
+        NP* hits = NP::Make<float>(num_hits_gpu, 4, 4);
+
+        for (size_t idx = 0; idx < num_hits_gpu; idx++)
         {
-            sphoton *photon = reinterpret_cast<sphoton *>(hits->values<float>() + idx * 16);
-            sev->getHit(*photon, idx);
+            sphoton* photon = reinterpret_cast<sphoton*>(hits->values<float>() + idx * 16);
+            sev_gpu->getHit(*photon, idx);
         }
 
-        hits->save("o_hits.npy");
+        hits->save(cfg.output_dir.string().c_str(), "s_hits.npy");
         delete hits;
 
         gx->reset(eventID);
+
+        G4HCofThisEvent* hce = event->GetHCofThisEvent();
+        if (hce)
+        {
+            for (G4int i = 0; i < hce->GetNumberOfCollections(); i++)
+            {
+                PhotonHitsCollection* hc = dynamic_cast<PhotonHitsCollection*>(hce->GetHC(i));
+                if (hc)
+                    total_g4_hits += hc->entries();
+            }
+        }
     }
 };
 
-void get_label(spho &ulabel, const G4Track *track)
-{
-    spho *label = STrackInfo::GetRef(track);
-    assert(label && label->isDefined() && "all photons are expected to be labelled");
-
-    std::array<int, spho::N> a_label;
-    label->serialize(a_label);
-
-    ulabel.load(a_label);
-}
-
 struct SteppingAction : G4UserSteppingAction
 {
-    SEvt *sev;
+    SEvt* sev;
 
-    SteppingAction(SEvt *sev) : sev(sev)
+    SteppingAction(SEvt* sev) :
+        sev(sev)
     {
     }
 
-    void UserSteppingAction(const G4Step *step)
+    void UserSteppingAction(const G4Step* step)
     {
         if (step->GetTrack()->GetDefinition() != G4OpticalPhoton::OpticalPhotonDefinition())
             return;
 
-        const G4Track *track = step->GetTrack();
-        const G4VTouchable *touch = track->GetTouchable();
+        const G4Track*      track = step->GetTrack();
+        const G4VTouchable* touch = track->GetTouchable();
 
-        spho ulabel = {};
-        get_label(ulabel, track);
+        const spho* label = STrackInfo::GetRef(track);
+        assert(label && label->isDefined() && "all photons are expected to be labelled");
+        spho ulabel = *label;
 
-        const G4StepPoint *pre = step->GetPreStepPoint();
-        const G4StepPoint *post = step->GetPostStepPoint();
+        const G4StepPoint* pre = step->GetPreStepPoint();
+        const G4StepPoint* post = step->GetPostStepPoint();
 
         sev->checkPhotonLineage(ulabel);
 
-        sphoton &current_photon = sev->current_ctx.p;
+        sphoton& current_photon = sev->current_ctx.p;
 
         if (current_photon.flagmask_count() == 1)
         {
@@ -337,9 +322,9 @@ struct SteppingAction : G4UserSteppingAction
             sev->pointPhoton(ulabel);                 // copying current into buffers
         }
 
-        bool tir;
+        bool     tir;
         unsigned flag = U4StepPoint::Flag<G4OpBoundaryProcess>(post, true, tir);
-        bool is_detect_flag = OpticksPhoton::IsSurfaceDetectFlag(flag);
+        bool     is_detect_flag = OpticksPhoton::IsSurfaceDetectFlag(flag);
 
         current_photon.hitcount_iindex =
             is_detect_flag ? U4Touchable::ImmediateReplicaNumber(touch) : U4Touchable::AncestorReplicaNumber(touch);
@@ -354,49 +339,41 @@ struct SteppingAction : G4UserSteppingAction
 
 struct TrackingAction : G4UserTrackingAction
 {
-    const G4Track *transient_fSuspend_track = nullptr;
-    SEvt *sev;
+    const G4Track* transient_suspend_track = nullptr;
+    SEvt*          sev;
 
-    TrackingAction(SEvt *sev) : sev(sev)
+    TrackingAction(SEvt* sev) :
+        sev(sev)
     {
     }
 
-    void PreUserTrackingAction_Optical_FabricateLabel(const G4Track *track)
+    void PreUserTrackingAction_Optical_FabricateLabel(const G4Track* track)
     {
         U4Track::SetFabricatedLabel(track);
-        spho *label = STrackInfo::GetRef(track);
+        spho* label = STrackInfo::GetRef(track);
         assert(label);
     }
 
-    void PreUserTrackingAction(const G4Track *track) override
+    void PreUserTrackingAction(const G4Track* track) override
     {
         if (track->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition())
         {
             // Geant4 boundary updates optical velocity via ProposeVelocity, but the
             // track must honor the given velocity for post-boundary timing to match.
-            G4Track *mutable_track = const_cast<G4Track *>(track);
+            G4Track* mutable_track = const_cast<G4Track*>(track);
             mutable_track->UseGivenVelocity(true);
         }
 
-        spho *label = STrackInfo::GetRef(track);
-
-        if (label == nullptr)
-        {
+        if (!STrackInfo::Exists(track))
             PreUserTrackingAction_Optical_FabricateLabel(track);
-            label = STrackInfo::GetRef(track);
-        }
 
-        assert(label && label->isDefined());
-
-        std::array<int, spho::N> a_label;
-        label->serialize(a_label);
-
-        spho ulabel = {};
-        ulabel.load(a_label);
+        const spho* label = STrackInfo::GetRef(track);
+        assert(label && label->isDefined() && "all photons are expected to be labelled");
+        spho ulabel = *label;
 
         U4Random::SetSequenceIndex(ulabel.id);
 
-        bool resume_fSuspend = track == transient_fSuspend_track;
+        bool resume_fSuspend = track == transient_suspend_track;
 
         if (ulabel.gen() == 0)
         {
@@ -414,49 +391,74 @@ struct TrackingAction : G4UserTrackingAction
         }
     }
 
-    void PostUserTrackingAction(const G4Track *track) override
+    void PostUserTrackingAction(const G4Track* track) override
     {
         G4TrackStatus tstat = track->GetTrackStatus();
 
-        bool is_fStopAndKill = tstat == fStopAndKill;
-        bool is_fSuspend = tstat == fSuspend;
-        bool is_fStopAndKill_or_fSuspend = is_fStopAndKill || is_fSuspend;
+        bool is_stop_and_kill = tstat == fStopAndKill;
+        bool is_suspend = tstat == fSuspend;
+        bool is_stop_and_kill_or_suspend = is_stop_and_kill || is_suspend;
 
-        assert(is_fStopAndKill_or_fSuspend);
+        assert(is_stop_and_kill_or_suspend);
 
-        spho ulabel = {};
-        get_label(ulabel, track);
+        const spho* label = STrackInfo::GetRef(track);
+        assert(label && label->isDefined() && "all photons are expected to be labelled");
+        spho ulabel = *label;
 
-        if (is_fStopAndKill)
+        if (is_stop_and_kill)
         {
             U4Random::SetSequenceIndex(-1);
             sev->finalPhoton(ulabel);
-            transient_fSuspend_track = nullptr;
+            transient_suspend_track = nullptr;
         }
-        else if (is_fSuspend)
+        else if (is_suspend)
         {
-            transient_fSuspend_track = track;
+            transient_suspend_track = track;
         }
+    }
+};
+
+struct RunAction : G4UserRunAction
+{
+    EventAction* event_action;
+
+    RunAction(EventAction* eventAction) :
+        event_action(eventAction)
+    {
+    }
+
+    void BeginOfRunAction(const G4Run*) override
+    {
+        event_action->total_g4_hits = 0;
+        event_action->total_gpu_hits = 0;
+    }
+
+    void EndOfRunAction(const G4Run*) override
+    {
+        G4cout << "RunAction::EndOfRunAction: Total GPU hits: " << event_action->total_gpu_hits << G4endl;
+        G4cout << "RunAction::EndOfRunAction: Total G4  hits: " << event_action->total_g4_hits << G4endl;
     }
 };
 
 struct G4App
 {
-    G4App(const gphox::Config& cfg, std::filesystem::path gdml_file)
-        : sev(SEvt::CreateOrReuse_ECPU()), det_cons_(new DetectorConstruction(gdml_file)),
-          prim_gen_(new PrimaryGenerator(cfg, sev)), event_act_(new EventAction(sev)), stepping_(new SteppingAction(sev)),
-          tracking_(new TrackingAction(sev))
+    G4App(const gphox::Config& cfg, std::filesystem::path gdml_file) :
+        sev(SEvt::CreateOrReuse_ECPU()),
+        det_cons_(new DetectorConstruction(cfg, gdml_file)),
+        prim_gen_(new PrimaryGenerator(cfg, sev)),
+        event_act_(new EventAction(cfg, sev)),
+        run_act_(new RunAction(event_act_)),
+        stepping_(new SteppingAction(sev)),
+        tracking_(new TrackingAction(sev))
     {
     }
 
-    //~G4App(){ G4CXOpticks::Finalize();}
+    SEvt* sev;
 
-    // Create "global" event
-    SEvt *sev;
-
-    G4VUserDetectorConstruction *det_cons_;
-    G4VUserPrimaryGeneratorAction *prim_gen_;
-    EventAction *event_act_;
-    SteppingAction *stepping_;
-    TrackingAction *tracking_;
+    G4VUserDetectorConstruction*   det_cons_;
+    G4VUserPrimaryGeneratorAction* prim_gen_;
+    EventAction*                   event_act_;
+    RunAction*                     run_act_;
+    SteppingAction*                stepping_;
+    TrackingAction*                tracking_;
 };

--- a/src/simg4ox.cpp
+++ b/src/simg4ox.cpp
@@ -18,14 +18,14 @@
 
 using namespace std;
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     OPTICKS_LOG(argc, argv);
 
     argparse::ArgumentParser program("simg4ox", "0.0.0");
 
     string gdml_file, config_name, macro_name;
-    bool interactive;
+    bool   interactive;
 
     program.add_argument("-g", "--gdml")
         .help("path to GDML file")
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
     {
         program.parse_args(argc, argv);
     }
-    catch (const exception &err)
+    catch (const exception& err)
     {
         cerr << err.what() << endl;
         cerr << program;
@@ -65,22 +65,23 @@ int main(int argc, char **argv)
 
     // Configure Geant4
     // The physics list must be instantiated before other user actions
-    G4VModularPhysicsList *physics = new FTFP_BERT;
+    G4VModularPhysicsList* physics = new FTFP_BERT;
     physics->RegisterPhysics(new G4OpticalPhysics);
 
     G4RunManager run_mgr;
     run_mgr.SetUserInitialization(physics);
 
-    G4App *g4app = new G4App(cfg, gdml_file);
+    G4App* g4app = new G4App(cfg, gdml_file);
     run_mgr.SetUserInitialization(g4app->det_cons_);
     run_mgr.SetUserAction(g4app->prim_gen_);
+    run_mgr.SetUserAction(g4app->run_act_);
     run_mgr.SetUserAction(g4app->event_act_);
     run_mgr.SetUserAction(g4app->tracking_);
     run_mgr.SetUserAction(g4app->stepping_);
     run_mgr.Initialize();
 
-    G4UIExecutive *uix = nullptr;
-    G4VisManager *vis = nullptr;
+    G4UIExecutive* uix = nullptr;
+    G4VisManager*  vis = nullptr;
 
     if (interactive)
     {
@@ -89,7 +90,7 @@ int main(int argc, char **argv)
         vis->Initialize();
     }
 
-    G4UImanager *ui = G4UImanager::GetUIpointer();
+    G4UImanager* ui = G4UImanager::GetUIpointer();
     ui->ApplyCommand("/control/execute " + macro_name);
 
     if (interactive)


### PR DESCRIPTION
Register a Geant4 run action that reports accumulated GPU and Geant4
hit counts at the end of each run.

Read GPU and CPU hit counts from their corresponding SEvt instances,
persist GPU hits from the EGPU event, and accumulate sensitive-detector
hit collections for the Geant4 total.

Improve sensitive-detector and event-action diagnostics and remove
unused helper functions from g4app.h.
