### PR TITLE
Revert "ci(spack): pin buildcache geant4 to supported version (#413)"

### DIFF
--- a/.github/workflows/build-push-spack-buildcache.yaml
+++ b/.github/workflows/build-push-spack-buildcache.yaml
@@ -41,10 +41,6 @@ jobs:
           load: true
           target: spack-base
           tags: ${{ env.SPACK_BASE_IMAGE }}
-          # Keep this on the newest Geant4 version currently declared by
-          # spack/spack-packages. The Dockerfile default can move ahead of Spack.
-          build-args: |
-            GEANT4_VERSION=11.4.1
           cache-from: type=gha,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
           cache-to: type=gha,mode=max,scope=${{ env.SPACK_BASE_CACHE_SCOPE }}
 


### PR DESCRIPTION
This reverts commit 462cbd972294f6e33552402a1b82b90b315a1c03.
