### PR TITLE
fix(simg4ox): save run-wide Geant4 and GPU hit arrays

### DIFF
--- a/src/g4app.h
+++ b/src/g4app.h
@@ -1,4 +1,4 @@
-#include <algorithm>
+#include <cstring>
 #include <filesystem>
 #include <utility>
 #include <vector>
@@ -68,6 +68,9 @@ struct PhotonHit : public G4VHit
 };
 
 using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
+
+// NumPy hit arrays use the sphoton (4, 4) float layout.
+static_assert(sizeof(sphoton) == 16 * sizeof(float));
 
 struct PhotonSD : public G4VSensitiveDetector
 {
@@ -232,8 +235,9 @@ struct EventAction : G4UserEventAction
 
         for (size_t idx = 0; idx < num_gpu_hits; idx++)
         {
-            sphoton* photon = reinterpret_cast<sphoton*>(hits->values<float>() + idx * 16);
-            sev_gpu->getHit(*photon, idx);
+            sphoton photon;
+            sev_gpu->getHit(photon, idx);
+            std::memcpy(hits->bytes() + idx * sizeof(sphoton), &photon, sizeof(photon));
         }
 
         hits->save(cfg.output_dir.string().c_str(), "s_hits.npy");
@@ -270,8 +274,7 @@ struct EventAction : G4UserEventAction
 
                 for (PhotonHit* hit : *hc->GetVector())
                 {
-                    const float* photon_data = reinterpret_cast<const float*>(&hit->photon);
-                    std::copy(photon_data, photon_data + 16, hits->values<float>() + hit_index * 16);
+                    std::memcpy(hits->bytes() + hit_index * sizeof(sphoton), &hit->photon, sizeof(hit->photon));
                     hit_index++;
                 }
             }

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <filesystem>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -71,6 +72,7 @@ using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
 
 // NumPy hit arrays use the sphoton (4, 4) float layout.
 static_assert(sizeof(sphoton) == 16 * sizeof(float));
+static_assert(std::is_trivially_copyable_v<sphoton>);
 
 struct PhotonSD : public G4VSensitiveDetector
 {
@@ -212,10 +214,10 @@ struct PrimaryGenerator : G4VUserPrimaryGeneratorAction
 
 struct EventAction : G4UserEventAction
 {
-    simphony::Config cfg;
-    SEvt*            sev;
-    size_t           total_g4_hits{0};
-    size_t           total_gpu_hits{0};
+    simphony::Config     cfg;
+    SEvt*                sev;
+    std::vector<sphoton> g4_hits;
+    std::vector<sphoton> gpu_hits;
 
     EventAction(const simphony::Config& cfg, SEvt* sev) :
         cfg(cfg),
@@ -228,26 +230,25 @@ struct EventAction : G4UserEventAction
         sev->beginOfEvent(event->GetEventID());
     }
 
-    size_t SaveGPUHits(SEvt* sev_gpu)
+    void ClearHits()
+    {
+        g4_hits.clear();
+        gpu_hits.clear();
+    }
+
+    size_t CollectGPUHits(SEvt* sev_gpu)
     {
         const size_t num_gpu_hits = sev_gpu->getNumHit();
-        NP*          hits = NP::Make<float>(num_gpu_hits, 4, 4);
+        const size_t offset = gpu_hits.size();
+        gpu_hits.resize(offset + num_gpu_hits);
 
         for (size_t idx = 0; idx < num_gpu_hits; idx++)
-        {
-            sphoton photon;
-            sev_gpu->getHit(photon, idx);
-            std::memcpy(hits->bytes() + idx * sizeof(sphoton), &photon, sizeof(photon));
-        }
-
-        const char* outdir = sev && sev->getSaveDir() ? sev->getSaveDir() : cfg.output_dir.c_str();
-        hits->save(outdir, "s_hits.npy");
-        delete hits;
+            sev_gpu->getHit(gpu_hits[offset + idx], idx);
 
         return num_gpu_hits;
     }
 
-    size_t SaveG4Hits(const G4Event* event)
+    size_t CollectG4Hits(const G4Event* event)
     {
         G4HCofThisEvent* hce = event->GetHCofThisEvent();
         size_t           num_g4_hits = 0;
@@ -262,8 +263,7 @@ struct EventAction : G4UserEventAction
             }
         }
 
-        NP*    hits = NP::Make<float>(num_g4_hits, 4, 4);
-        size_t hit_index = 0;
+        g4_hits.reserve(g4_hits.size() + num_g4_hits);
 
         if (hce)
         {
@@ -274,18 +274,27 @@ struct EventAction : G4UserEventAction
                     continue;
 
                 for (PhotonHit* hit : *hc->GetVector())
-                {
-                    std::memcpy(hits->bytes() + hit_index * sizeof(sphoton), &hit->photon, sizeof(hit->photon));
-                    hit_index++;
-                }
+                    g4_hits.push_back(hit->photon);
             }
         }
 
-        const char* outdir = sev && sev->getSaveDir() ? sev->getSaveDir() : cfg.output_dir.c_str();
-        hits->save(outdir, "g_hits.npy");
-        delete hits;
-
         return num_g4_hits;
+    }
+
+    void SaveHits(const std::vector<sphoton>& source, const char* name) const
+    {
+        NP* hits = NP::Make<float>(source.size(), 4, 4);
+        if (!source.empty())
+            std::memcpy(hits->bytes(), source.data(), source.size() * sizeof(sphoton));
+
+        hits->save(cfg.output_dir.string().c_str(), name);
+        delete hits;
+    }
+
+    void SaveRunHits() const
+    {
+        SaveHits(gpu_hits, "s_hits.npy");
+        SaveHits(g4_hits, "g_hits.npy");
     }
 
     void EndOfEventAction(const G4Event* event) override
@@ -308,10 +317,12 @@ struct EventAction : G4UserEventAction
         G4cout << "EventAction::EndOfEventAction: GPU hits:  " << num_hits_gpu << G4endl;
         G4cout << "EventAction::EndOfEventAction: CPU hits:  " << num_hits_cpu << G4endl;
 
-        // The EGPU event owns one event-wide GPU hit buffer, so this is the
-        // GPU counterpart to flattening all Geant4 hit collections below.
-        total_gpu_hits += SaveGPUHits(sev_gpu);
-        total_g4_hits += SaveG4Hits(event);
+        // Append the event-wide GPU buffer and all Geant4 hit collections to
+        // run-scoped buffers before the event data is reset by either backend.
+        size_t collected_gpu_hits = CollectGPUHits(sev_gpu);
+        size_t collected_g4_hits = CollectG4Hits(event);
+        G4cout << "EventAction::EndOfEventAction: Collected GPU hits: " << collected_gpu_hits << G4endl;
+        G4cout << "EventAction::EndOfEventAction: Collected G4  hits: " << collected_g4_hits << G4endl;
 
         gx->reset(eventID);
     }
@@ -458,14 +469,14 @@ struct RunAction : G4UserRunAction
 
     void BeginOfRunAction(const G4Run*) override
     {
-        event_action->total_g4_hits = 0;
-        event_action->total_gpu_hits = 0;
+        event_action->ClearHits();
     }
 
     void EndOfRunAction(const G4Run*) override
     {
-        G4cout << "RunAction::EndOfRunAction: Total GPU hits: " << event_action->total_gpu_hits << G4endl;
-        G4cout << "RunAction::EndOfRunAction: Total G4  hits: " << event_action->total_g4_hits << G4endl;
+        event_action->SaveRunHits();
+        G4cout << "RunAction::EndOfRunAction: Total GPU hits: " << event_action->gpu_hits.size() << G4endl;
+        G4cout << "RunAction::EndOfRunAction: Total G4  hits: " << event_action->g4_hits.size() << G4endl;
     }
 };
 

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -240,7 +240,8 @@ struct EventAction : G4UserEventAction
             std::memcpy(hits->bytes() + idx * sizeof(sphoton), &photon, sizeof(photon));
         }
 
-        hits->save(cfg.output_dir.string().c_str(), "s_hits.npy");
+        const char* outdir = sev && sev->getSaveDir() ? sev->getSaveDir() : cfg.output_dir.c_str();
+        hits->save(outdir, "s_hits.npy");
         delete hits;
 
         return num_gpu_hits;
@@ -280,7 +281,8 @@ struct EventAction : G4UserEventAction
             }
         }
 
-        hits->save(cfg.output_dir.string().c_str(), "g_hits.npy");
+        const char* outdir = sev && sev->getSaveDir() ? sev->getSaveDir() : cfg.output_dir.c_str();
+        hits->save(outdir, "g_hits.npy");
         delete hits;
 
         return num_g4_hits;

--- a/src/g4app.h
+++ b/src/g4app.h
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <filesystem>
 #include <utility>
 #include <vector>
@@ -70,13 +71,11 @@ using PhotonHitsCollection = G4THitsCollection<PhotonHit>;
 
 struct PhotonSD : public G4VSensitiveDetector
 {
-    simphony::Config      cfg;
     PhotonHitsCollection* photon_hit_collection{nullptr};
     G4int                 fHCID;
 
-    PhotonSD(const simphony::Config& cfg, G4String name) :
+    PhotonSD(G4String name) :
         G4VSensitiveDetector(name),
-        cfg(cfg),
         fHCID(-1)
     {
         G4String HCname = name + "_HC";
@@ -118,29 +117,15 @@ struct PhotonSD : public G4VSensitiveDetector
     {
         G4int num_g4_hits = photon_hit_collection->entries();
         G4cout << "PhotonSD::EndOfEvent: number of Geant4 hits: " << num_g4_hits << G4endl;
-
-        NP* hits = NP::Make<float>(num_g4_hits, 4, 4);
-        int i = 0;
-
-        for (PhotonHit* hit : *photon_hit_collection->GetVector())
-        {
-            float* photon_data = reinterpret_cast<float*>(&hit->photon);
-            std::copy(photon_data, photon_data + 16, hits->values<float>() + (i++) * 16);
-        }
-
-        hits->save(cfg.output_dir.string().c_str(), "g_hits.npy");
-        delete hits;
     }
 };
 
 struct DetectorConstruction : G4VUserDetectorConstruction
 {
-    simphony::Config      cfg;
     std::filesystem::path gdml_file_;
     G4GDMLParser          parser_;
 
-    DetectorConstruction(const simphony::Config& cfg, std::filesystem::path gdml_file) :
-        cfg(cfg),
+    DetectorConstruction(std::filesystem::path gdml_file) :
         gdml_file_(std::move(gdml_file))
     {
     }
@@ -168,7 +153,7 @@ struct DetectorConstruction : G4VUserDetectorConstruction
                 {
                     G4cout << "DetectorConstruction::ConstructSDandField: Attach sensitive detector to logical volume: " << logVol->GetName() << G4endl;
                     G4String  name = logVol->GetName() + "_PhotonDetector";
-                    PhotonSD* aPhotonSD = new PhotonSD(cfg, name);
+                    PhotonSD* aPhotonSD = new PhotonSD(name);
                     SDman->AddNewDetector(aPhotonSD);
                     logVol->SetSensitiveDetector(aPhotonSD);
                 }
@@ -226,7 +211,7 @@ struct EventAction : G4UserEventAction
 {
     simphony::Config cfg;
     SEvt*            sev;
-    G4int            total_g4_hits{0};
+    size_t           total_g4_hits{0};
     size_t           total_gpu_hits{0};
 
     EventAction(const simphony::Config& cfg, SEvt* sev) :
@@ -238,6 +223,64 @@ struct EventAction : G4UserEventAction
     void BeginOfEventAction(const G4Event* event) override
     {
         sev->beginOfEvent(event->GetEventID());
+    }
+
+    size_t SaveGPUHits(SEvt* sev_gpu)
+    {
+        const size_t num_gpu_hits = sev_gpu->getNumHit();
+        NP*          hits = NP::Make<float>(num_gpu_hits, 4, 4);
+
+        for (size_t idx = 0; idx < num_gpu_hits; idx++)
+        {
+            sphoton* photon = reinterpret_cast<sphoton*>(hits->values<float>() + idx * 16);
+            sev_gpu->getHit(*photon, idx);
+        }
+
+        hits->save(cfg.output_dir.string().c_str(), "s_hits.npy");
+        delete hits;
+
+        return num_gpu_hits;
+    }
+
+    size_t SaveG4Hits(const G4Event* event)
+    {
+        G4HCofThisEvent* hce = event->GetHCofThisEvent();
+        size_t           num_g4_hits = 0;
+
+        if (hce)
+        {
+            for (G4int i = 0; i < hce->GetNumberOfCollections(); i++)
+            {
+                PhotonHitsCollection* hc = dynamic_cast<PhotonHitsCollection*>(hce->GetHC(i));
+                if (hc)
+                    num_g4_hits += static_cast<size_t>(hc->entries());
+            }
+        }
+
+        NP*    hits = NP::Make<float>(num_g4_hits, 4, 4);
+        size_t hit_index = 0;
+
+        if (hce)
+        {
+            for (G4int i = 0; i < hce->GetNumberOfCollections(); i++)
+            {
+                PhotonHitsCollection* hc = dynamic_cast<PhotonHitsCollection*>(hce->GetHC(i));
+                if (!hc)
+                    continue;
+
+                for (PhotonHit* hit : *hc->GetVector())
+                {
+                    const float* photon_data = reinterpret_cast<const float*>(&hit->photon);
+                    std::copy(photon_data, photon_data + 16, hits->values<float>() + hit_index * 16);
+                    hit_index++;
+                }
+            }
+        }
+
+        hits->save(cfg.output_dir.string().c_str(), "g_hits.npy");
+        delete hits;
+
+        return num_g4_hits;
     }
 
     void EndOfEventAction(const G4Event* event) override
@@ -260,31 +303,12 @@ struct EventAction : G4UserEventAction
         G4cout << "EventAction::EndOfEventAction: GPU hits:  " << num_hits_gpu << G4endl;
         G4cout << "EventAction::EndOfEventAction: CPU hits:  " << num_hits_cpu << G4endl;
 
-        total_gpu_hits += num_hits_gpu;
-
-        NP* hits = NP::Make<float>(num_hits_gpu, 4, 4);
-
-        for (size_t idx = 0; idx < num_hits_gpu; idx++)
-        {
-            sphoton* photon = reinterpret_cast<sphoton*>(hits->values<float>() + idx * 16);
-            sev_gpu->getHit(*photon, idx);
-        }
-
-        hits->save(cfg.output_dir.string().c_str(), "s_hits.npy");
-        delete hits;
+        // The EGPU event owns one event-wide GPU hit buffer, so this is the
+        // GPU counterpart to flattening all Geant4 hit collections below.
+        total_gpu_hits += SaveGPUHits(sev_gpu);
+        total_g4_hits += SaveG4Hits(event);
 
         gx->reset(eventID);
-
-        G4HCofThisEvent* hce = event->GetHCofThisEvent();
-        if (hce)
-        {
-            for (G4int i = 0; i < hce->GetNumberOfCollections(); i++)
-            {
-                PhotonHitsCollection* hc = dynamic_cast<PhotonHitsCollection*>(hce->GetHC(i));
-                if (hc)
-                    total_g4_hits += hc->entries();
-            }
-        }
     }
 };
 
@@ -444,7 +468,7 @@ struct G4App
 {
     G4App(const simphony::Config& cfg, std::filesystem::path gdml_file) :
         sev(SEvt::CreateOrReuse_ECPU()),
-        det_cons_(new DetectorConstruction(cfg, gdml_file)),
+        det_cons_(new DetectorConstruction(gdml_file)),
         prim_gen_(new PrimaryGenerator(cfg, sev)),
         event_act_(new EventAction(cfg, sev)),
         run_act_(new RunAction(event_act_)),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,3 +18,21 @@ set_tests_properties(Integration.simg4ox PROPERTIES
     LABELS "integration"
     TIMEOUT 120
 )
+
+set(SIMPHONY_SIMG4OX_MULTIEVENT_TEST_WORKDIR "${CMAKE_CURRENT_BINARY_DIR}/simg4ox_multievent")
+file(MAKE_DIRECTORY "${SIMPHONY_SIMG4OX_MULTIEVENT_TEST_WORKDIR}")
+
+add_test(
+    NAME Integration.simg4ox_multievent
+    COMMAND ${CMAKE_COMMAND} -E env
+            REPO_DIR=${PROJECT_SOURCE_DIR}
+            PYTHON=${Python3_EXECUTABLE}
+            SIMG4OX_BIN=$<TARGET_FILE:simg4ox>
+            ${BASH_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_simg4ox_multievent.sh
+)
+
+set_tests_properties(Integration.simg4ox_multievent PROPERTIES
+    WORKING_DIRECTORY "${SIMPHONY_SIMG4OX_MULTIEVENT_TEST_WORKDIR}"
+    LABELS "integration"
+    TIMEOUT 120
+)

--- a/tests/check_simg4ox_multievent.py
+++ b/tests/check_simg4ox_multievent.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Validate that simg4ox saves run-wide hit arrays for a multi-event run."""
+
+import argparse
+import re
+from pathlib import Path
+
+import numpy as np
+
+
+EVENT_PATTERNS = {
+    "GPU": re.compile(r"Collected GPU hits:\s*(\d+)"),
+    "G4": re.compile(r"Collected G4\s+hits:\s*(\d+)"),
+}
+TOTAL_PATTERNS = {
+    "GPU": re.compile(r"Total GPU hits:\s*(\d+)"),
+    "G4": re.compile(r"Total G4\s+hits:\s*(\d+)"),
+}
+
+
+def parse_counts(log_text, label, events):
+    event_counts = [int(value) for value in EVENT_PATTERNS[label].findall(log_text)]
+    total_matches = TOTAL_PATTERNS[label].findall(log_text)
+
+    if len(event_counts) != events:
+        raise AssertionError(f"Expected {events} {label} event counts, found {len(event_counts)}")
+    if len(total_matches) != 1:
+        raise AssertionError(f"Expected one {label} run total, found {len(total_matches)}")
+
+    total = int(total_matches[0])
+    if total != sum(event_counts):
+        raise AssertionError(f"{label} run total {total} != per-event sum {sum(event_counts)}")
+    if total == 0:
+        raise AssertionError(f"Expected non-empty {label} hits")
+
+    return event_counts, total
+
+
+def check_array(path, expected_rows):
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing run hit array: {path}")
+
+    hits = np.load(path)
+    expected_shape = (expected_rows, 4, 4)
+    if hits.shape != expected_shape:
+        raise AssertionError(f"{path.name} shape {hits.shape} != {expected_shape}")
+    if hits.dtype != np.float32:
+        raise AssertionError(f"{path.name} dtype {hits.dtype} != float32")
+
+    return hits
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--events", type=int, default=5)
+    args = parser.parse_args()
+
+    log_text = args.log.read_text()
+    gpu_event_counts, gpu_total = parse_counts(log_text, "GPU", args.events)
+    g4_event_counts, g4_total = parse_counts(log_text, "G4", args.events)
+
+    gpu_hits = check_array(args.output_dir / "s_hits.npy", gpu_total)
+    g4_hits = check_array(args.output_dir / "g_hits.npy", g4_total)
+
+    print(f"GPU_EVENT_COUNTS={gpu_event_counts}")
+    print(f"G4_EVENT_COUNTS={g4_event_counts}")
+    print(f"S_HITS_SHAPE={gpu_hits.shape}")
+    print(f"G_HITS_SHAPE={g4_hits.shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run_5evt.mac
+++ b/tests/run_5evt.mac
@@ -1,0 +1,5 @@
+# Five-event batch run used by the simg4ox hit-aggregation regression test.
+/run/verbose 1
+/process/optical/boundary/setInvokeSD true
+/run/initialize
+/run/beamOn 5

--- a/tests/test_simg4ox_multievent.sh
+++ b/tests/test_simg4ox_multievent.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=${REPO_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}
+
+SIMG4OX_BIN=${SIMG4OX_BIN:-simg4ox}
+PYTHON=${PYTHON:-python3}
+RUN_LOG="${PWD}/simg4ox-multievent.log"
+
+export OPTICKS_HOME="${REPO_DIR}"
+export SIMPHONY_CONFIG_DIR="${SIMPHONY_CONFIG_DIR:-${REPO_DIR}/config}"
+export PYTHONPATH="${REPO_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+
+rm -f "${PWD}/g_hits.npy" "${PWD}/s_hits.npy" "${RUN_LOG}"
+
+"${SIMG4OX_BIN}" \
+    -g "${REPO_DIR}/tests/geom/opticks_raindrop.gdml" \
+    -m "${REPO_DIR}/tests/run_5evt.mac" \
+    -c dev 2>&1 | tee "${RUN_LOG}"
+
+"${PYTHON}" "${REPO_DIR}/tests/check_simg4ox_multievent.py" \
+    --log "${RUN_LOG}" \
+    --output-dir "${PWD}" \
+    --events 5


### PR DESCRIPTION
Update `simg4ox` to aggregate Geant4 and GPU hits across every event in a run and save the resulting arrays once during `EndOfRunAction`.

- Flatten all Geant4 `PhotonHitsCollection` instances from each event into a run-scoped hit buffer.
- Append each event-wide EGPU hit buffer to a corresponding run-scoped GPU buffer.
- Clear both buffers at the beginning of each run.
- Save the complete buffers as:
  - `g_hits.npy` for Geant4 hits
  - `s_hits.npy` for GPU hits
- Preserve the existing `(N, 4, 4)` `float32` `sphoton` layout.
- Remove configuration plumbing that is no longer needed by `PhotonSD` and `DetectorConstruction`.

## Motivation

Previously, hit arrays were written using fixed filenames during event processing. Multi-event runs could therefore overwrite earlier output, while the run-level counters retained only hit counts rather than the hit data itself.

This change ensures that `g_hits.npy` and `s_hits.npy` contain hits from the complete run and that their first dimension matches the corresponding run-level total.

## Regression coverage

Add a five-event `simg4ox` integration test using a geometry with a sensitive detector and detecting optical surface.

The regression test verifies that:

- exactly five events are collected;
- run totals equal the sums of the per-event counts;
- both Geant4 and GPU outputs are non-empty;
- both files use the `float32` `(N, 4, 4)` layout;
- each array's row count equals its reported run total.

## Operational note

The current implementation retains all hits in memory until the end of the run. Memory therefore grows linearly with the total hit count at 64 bytes per hit per backend, plus a temporary serialization copy. This is appropriate for the current use case and regression coverage; very large production runs may benefit from incremental `.npy` streaming in a follow-up.