### PR TITLE
fix(dd4hepplugins): sync bundled dRICH radiator XML with epic >= 26.06

### DIFF
--- a/dd4hepplugins/examples/geometry/drich_1sector.xml
+++ b/dd4hepplugins/examples/geometry/drich_1sector.xml
@@ -13,6 +13,7 @@
 <constant name="DRICH_bore_slope"         value="(DRICH_rmin1 - DRICH_rmin0) / DRICH_length"/> <!-- slope of bore radius -->
 <constant name="DRICH_wall_thickness"     value="1.0*cm"/>  <!-- thickness of radial walls -->
 <constant name="DRICH_window_thickness"   value="0.3*cm"/>  <!-- thickness of entrance and exit walls -->
+<constant name="DRICH_corona_thickness"   value="1*mm"/>  <!-- thickness of aerogel-tile support frames (coronas) -->
 <constant name="DRICH_num_sectors"        value="1"/>  <!-- number of azimuthal sectors -->
 <!-- snout geometry: cone with front radius rmax0 and back radius of rmax1 -->
 <constant name="DRICH_rmax0"              value="90.0*cm"/>
@@ -133,6 +134,18 @@
     vis="DRICH_aerogel_vis"
     thickness="DRICH_aerogel_thickness"
     />
+  <coronas
+    segmentation="trapezoidal"
+    thickness="DRICH_corona_thickness"
+    material="CarbonFiber_15percent"
+    vis="DRICH_Corona_vis"
+    >
+    <crown radius="12.9596*cm" num_segments="10"/>
+    <crown radius="31.8*cm"    num_segments="18"/>
+    <crown radius="51.0*cm"    num_segments="24"/>
+    <crown radius="70.5*cm"    num_segments="30"/>
+    <crown radius="88.7962*cm"/>
+  </coronas>
   <airgap
     material="AirOptical"
     vis="DRICH_gas_vis"


### PR DESCRIPTION
epic 26.06 segmented the dRICH aerogel into trapezoidal tiles held by carbon fiber support frames, and its DRICH plugin now requires a <coronas> element inside <radiator>. The bundled single-sector compact predates this, so geometry construction fails against current epic with

  Handle_t::child: Element [radiator] has no child of type 'coronas'

breaking benchmark_drich.py (and validate_drich.py once it points at this geometry). Port the <coronas> block and the DRICH_corona_thickness constant from epic's compact/pid/drich.xml. Older DRICH plugins (epic <= 26.05) never query the element and DD4hep ignores unknown children, so the file remains usable with older stacks.

Verified with benchmark_drich.py --mode cpu against an epic main build: construction succeeds and a full event completes.