### PR TITLE
build(devcontainer): use host user and Codex configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,9 +7,9 @@
       "version": "23"
     }
   },
-  "remoteEnv": {
-    "CODEX_HOME": "${containerWorkspaceFolder}/.codex"
-  },
+  "mounts": [
+    "source=${localEnv:HOME}/.codex,target=/root/.codex,type=bind"
+  ],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,15 +4,12 @@
     "dockerfile": "../Dockerfile",
     "context": "..",
     "target": "devenv",
-    "args": {
-      "DEV_USER": "${localEnv:USER}"
-    },
     "cacheFrom": [
       "ghcr.io/bnlnpps/simphony:base"
     ]
   },
-  "containerUser": "${localEnv:USER}",
-  "remoteUser": "${localEnv:USER}",
+  "containerUser": "dev",
+  "remoteUser": "dev",
   "updateRemoteUserUID": true,
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
@@ -22,7 +19,7 @@
   },
   "initializeCommand": "mkdir -p \"${localEnv:HOME}/.codex\"",
   "mounts": [
-    "source=${localEnv:HOME}/.codex,target=/home/${localEnv:USER}/.codex,type=bind"
+    "source=${localEnv:HOME}/.codex,target=/home/dev/.codex,type=bind"
   ],
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,7 @@
       "version": "23"
     }
   },
+  "initializeCommand": "mkdir -p \"${localEnv:HOME}/.codex\"",
   "mounts": [
     "source=${localEnv:HOME}/.codex,target=/home/${localEnv:USER}/.codex,type=bind"
   ],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,19 @@
 {
   "name": "simphony",
-  "image": "ghcr.io/bnlnpps/simphony:base",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": "..",
+    "target": "devenv",
+    "args": {
+      "DEV_USER": "${localEnv:USER}"
+    },
+    "cacheFrom": [
+      "ghcr.io/bnlnpps/simphony:base"
+    ]
+  },
+  "containerUser": "${localEnv:USER}",
+  "remoteUser": "${localEnv:USER}",
+  "updateRemoteUserUID": true,
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "./features/llvm": {
@@ -8,7 +21,7 @@
     }
   },
   "mounts": [
-    "source=${localEnv:HOME}/.codex,target=/root/.codex,type=bind"
+    "source=${localEnv:HOME}/.codex,target=/home/${localEnv:USER}/.codex,type=bind"
   ],
   "customizations": {
     "vscode": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,18 @@ COPY optiphy $SIMPHONY_HOME/optiphy
 RUN uv sync --python "${PYTHON_VERSION}" --managed-python
 
 
+FROM base AS devenv
+
+ARG DEV_USER=dev
+
+RUN if ! id -u "${DEV_USER}" >/dev/null 2>&1; then \
+      useradd --create-home --user-group --shell /bin/bash "${DEV_USER}"; \
+    fi
+
+ENV HOME=/home/${DEV_USER}
+
+USER ${DEV_USER}
+
 FROM base AS release
 
 ARG CMAKE_BUILD_JOBS


### PR DESCRIPTION
## Summary

- Build the dev container from the new `devenv` Dockerfile target, reusing the published base-image cache.
- Run the container as the host user with matching UID ownership.
- Mount the host’s `~/.codex` directory into the container user’s home directory.
- Remove the repository-local `CODEX_HOME` override.

## Motivation

This lets the dev container reuse the host’s existing Codex configuration and state while avoiding root-owned workspace files and related permission issues.