### PR TITLE
build(devcontainer): support versioned builds and caches

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,15 @@
     "dockerfile": "../Dockerfile",
     "context": "..",
     "target": "devenv",
+    "args": {
+      "OS": "${localEnv:OS_VERSION:ubuntu24.04}",
+      "CUDA_VERSION": "${localEnv:CUDA_VERSION:13.0.3}",
+      "OPTIX_VERSION": "${localEnv:OPTIX_VERSION:9.0.0}",
+      "GEANT4_VERSION": "${localEnv:GEANT4_VERSION:11.4.2}",
+      "CMAKE_VERSION": "${localEnv:CMAKE_VERSION:4.2.1}"
+    },
     "cacheFrom": [
-      "ghcr.io/bnlnpps/simphony:base"
+      "type=registry,ref=ghcr.io/bnlnpps/simphony-buildcache:cuda${localEnv:CUDA_VERSION:13.0.3}-base-${localEnv:OS_VERSION:ubuntu24.04}-optix${localEnv:OPTIX_VERSION:9.0.0}-geant4${localEnv:GEANT4_VERSION:11.4.2}-cmake${localEnv:CMAKE_VERSION:4.2.1}"
     ]
   },
   "containerUser": "dev",


### PR DESCRIPTION
Allow developers to choose the OS, CUDA, OptiX, Geant4, and CMake versions used for local Dev Container builds.

The selected versions also determine the corresponding BuildKit registry cache, avoiding unnecessary dependency rebuilds when a matching cache is available.

- Pass the following host environment variables to the Docker build:
  - `OS_VERSION`
  - `CUDA_VERSION`
  - `OPTIX_VERSION`
  - `GEANT4_VERSION`
  - `CMAKE_VERSION`
- Preserve the current Dockerfile versions as defaults when variables are unset.
- Derive the `simphony-buildcache` tag from the selected dependency versions.
- Use the version-specific GHCR cache through BuildKit's registry cache importer.
- Continue building the `devenv` target with the existing non-root developer setup and Dev Container features.

For example, start a development container using the supported CUDA 12.1 configuration:

```bash
OS_VERSION=ubuntu22.04 \
CUDA_VERSION=12.1.1 \
OPTIX_VERSION=8.0.0 \
GEANT4_VERSION=11.3.2 \
CMAKE_VERSION=3.22.1 \
devcontainer up --workspace-folder . --remove-existing-container
```

This selects the cache:

```
ghcr.io/bnlnpps/simphony-buildcache:cuda12.1.1-base-ubuntu22.04-optix8.0.0-geant411.3.2-cmake3.22.1
```

Existing containers must be removed or rebuilt for changed build arguments to take effect.
