### PR TITLE
build(devcontainer): centralize build versions in dotenv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,8 @@
 {
   "name": "simphony",
-  "build": {
-    "dockerfile": "../Dockerfile",
-    "context": "..",
-    "target": "devenv",
-    "args": {
-      "OS": "${localEnv:OS_VERSION:ubuntu24.04}",
-      "CUDA_VERSION": "${localEnv:CUDA_VERSION:13.0.3}",
-      "OPTIX_VERSION": "${localEnv:OPTIX_VERSION:9.0.0}",
-      "GEANT4_VERSION": "${localEnv:GEANT4_VERSION:11.4.2}",
-      "CMAKE_VERSION": "${localEnv:CMAKE_VERSION:4.2.1}"
-    },
-    "cacheFrom": [
-      "type=registry,ref=ghcr.io/bnlnpps/simphony-buildcache:cuda${localEnv:CUDA_VERSION:13.0.3}-base-${localEnv:OS_VERSION:ubuntu24.04}-optix${localEnv:OPTIX_VERSION:9.0.0}-geant4${localEnv:GEANT4_VERSION:11.4.2}-cmake${localEnv:CMAKE_VERSION:4.2.1}"
-    ]
-  },
+  "dockerComposeFile": "../compose.devcontainer.yaml",
+  "service": "simphony",
+  "workspaceFolder": "/workspaces/simphony",
   "containerUser": "dev",
   "remoteUser": "dev",
   "updateRemoteUserUID": true,

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git*
 .github/
 .devcontainer/
+.env
 .venv
 __pycache__/

--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+# Dev container build versions.
+OS=ubuntu24.04
+CUDA_VERSION=13.0.3
+OPTIX_VERSION=9.0.0
+GEANT4_VERSION=11.4.2
+CMAKE_VERSION=4.2.1

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Dev container build versions.
-OS=ubuntu24.04
+OS_VERSION=ubuntu24.04
 CUDA_VERSION=13.0.3
 OPTIX_VERSION=9.0.0
 GEANT4_VERSION=11.4.2

--- a/compose.devcontainer.yaml
+++ b/compose.devcontainer.yaml
@@ -1,0 +1,17 @@
+services:
+  simphony:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: devenv
+      args:
+        OS: ${OS:?Set OS in the selected environment file}
+        CUDA_VERSION: ${CUDA_VERSION:?Set CUDA_VERSION in the selected environment file}
+        OPTIX_VERSION: ${OPTIX_VERSION:?Set OPTIX_VERSION in the selected environment file}
+        GEANT4_VERSION: ${GEANT4_VERSION:?Set GEANT4_VERSION in the selected environment file}
+        CMAKE_VERSION: ${CMAKE_VERSION:?Set CMAKE_VERSION in the selected environment file}
+      cache_from:
+        - type=registry,ref=ghcr.io/bnlnpps/simphony-buildcache:cuda${CUDA_VERSION}-base-${OS}-optix${OPTIX_VERSION}-geant4${GEANT4_VERSION}-cmake${CMAKE_VERSION}
+    volumes:
+      - .:/workspaces/simphony:cached
+    command: sleep infinity

--- a/compose.devcontainer.yaml
+++ b/compose.devcontainer.yaml
@@ -5,13 +5,13 @@ services:
       dockerfile: Dockerfile
       target: devenv
       args:
-        OS: ${OS:?Set OS in the selected environment file}
+        OS: ${OS_VERSION:?Set OS_VERSION in the selected environment file}
         CUDA_VERSION: ${CUDA_VERSION:?Set CUDA_VERSION in the selected environment file}
         OPTIX_VERSION: ${OPTIX_VERSION:?Set OPTIX_VERSION in the selected environment file}
         GEANT4_VERSION: ${GEANT4_VERSION:?Set GEANT4_VERSION in the selected environment file}
         CMAKE_VERSION: ${CMAKE_VERSION:?Set CMAKE_VERSION in the selected environment file}
       cache_from:
-        - type=registry,ref=ghcr.io/bnlnpps/simphony-buildcache:cuda${CUDA_VERSION}-base-${OS}-optix${OPTIX_VERSION}-geant4${GEANT4_VERSION}-cmake${CMAKE_VERSION}
+        - type=registry,ref=ghcr.io/bnlnpps/simphony-buildcache:cuda${CUDA_VERSION}-base-${OS_VERSION}-optix${OPTIX_VERSION}-geant4${GEANT4_VERSION}-cmake${CMAKE_VERSION}
     volumes:
       - .:/workspaces/simphony:cached
     command: sleep infinity


### PR DESCRIPTION
Switch the development container to Docker Compose so the repository
.env file is loaded automatically before the image build. Use those
version values for both Docker build arguments and the matching registry
cache reference, with explicit errors when a required value is missing.
Preserve the existing development target and workspace mount, and
exclude .env from the Docker build context.

```
COMPOSE_ENV_FILES=.env devcontainer up --remove-existing-container
```
