### PR TITLE
feat(csg): support partial-phi spheres and tubes

### DIFF
--- a/CSG/CMakeLists.txt
+++ b/CSG/CMakeLists.txt
@@ -84,6 +84,7 @@ list(APPEND INTERSECT_HEADERS
     csg_intersect_leaf_oldcone.h
     csg_intersect_leaf_oldcylinder.h
     csg_intersect_leaf_phicut.h
+    csg_intersect_leaf_phi_wedge.h
     csg_intersect_leaf_plane.h
     csg_intersect_leaf_slab.h
     csg_intersect_leaf_sphere.h

--- a/CSG/CSGNode.cc
+++ b/CSG/CSGNode.cc
@@ -418,7 +418,15 @@ void CSGNode::setAABBLocal()
         getParam( fx, fy, fz, a, b, c );
         setAABB( -fx*0.5f , -fy*0.5f, -fz*0.5f, fx*0.5f , fy*0.5f, fz*0.5f );
     }
-    else if( tc == CSG_CYLINDER || tc == CSG_OLDCYLINDER )
+    else if (tc == CSG_CYLINDER)
+    {
+        float r = radius();
+        float z1_ = z1();
+        float z2_ = z2();
+        assert(z2_ > z1_);
+        setAABB(-r, -r, z1_, r, r, z2_);
+    }
+    else if (tc == CSG_OLDCYLINDER)
     {
         float px, py, a, radius, z1, z2 ;
         getParam( px, py, a, radius, z1, z2) ;

--- a/CSG/csg_intersect_leaf_cylinder.h
+++ b/CSG/csg_intersect_leaf_cylinder.h
@@ -1,11 +1,13 @@
 #pragma once
+
+#include "csg_intersect_leaf_phi_wedge.h"
 /**
 intersect_leaf_cylinder : a much simpler approach than intersect_leaf_oldcylinder
 -------------------------------------------------------------------------------------------
 
 The two cylinder imps were compared with tests/CSGIntersectComparisonTest.cc.
 Surface distance comparisons show the new imp is more precise and does
-not suffer from near-axial spurious intersects beyond the ends.  
+not suffer from near-axial spurious intersects beyond the ends.
 
 intersect_leaf_cylinder
 
@@ -14,19 +16,20 @@ intersect_leaf_cylinder
 
 intersect_leaf_oldcylinder
 
-   * pseudo-general approach, based on implementation from book RTCD  
-   * had axial special case bolted on for unrecorded reason, some glitch presumably 
+   * pseudo-general approach, based on implementation from book RTCD
+   * had axial special case bolted on for unrecorded reason, some glitch presumably
 
 
-There are four possible t
+There are up to six possible t
 
 * 2 from curved sheet, obtained from solving quadratic, that must be within z1 z2 range
-* 2 from endcaps that must be within r2 range  
+* 2 from endcaps that must be within r2 range
+* 2 from radial phi walls when a partial-phi interval is present
 
-Finding the intersect means finding the smallest t from the four that exceeds t_min  
+Finding the intersect means finding the smallest t from the four that exceeds t_min
 
-Current approach keeps changing t_cand, could instead collect all four potential t 
-into a float4 and then pick from that ? 
+Current approach keeps changing t_cand, could instead collect all four potential t
+into a float4 and then pick from that ?
 
 **/
 
@@ -36,6 +39,9 @@ void intersect_leaf_cylinder( bool& valid_isect, float4& isect, const quad& q0, 
     const float& r = q0.f.w;
     const float& z1 = q1.f.x;
     const float& z2 = q1.f.y;
+    const float  startPhi = q0.f.x;
+    const float  deltaPhi = q0.f.y;
+    const bool   has_phi_wedge = csg_has_phi_wedge(deltaPhi);
     const float& ox = ray_origin.x;
     const float& oy = ray_origin.y;
     const float& oz = ray_origin.z;
@@ -64,19 +70,74 @@ void intersect_leaf_cylinder( bool& valid_isect, float4& isect, const quad& q0, 
     //printf("// t_z2cap %10.4f r2_z2cap %10.4f \n", t_z2cap, r2_z2cap ); 
 #endif
 
+    float t_phi_start = CUDART_INF_F;
+    float t_phi_end = CUDART_INF_F;
+    float n_start_x = 0.f;
+    float n_start_y = 0.f;
+    float n_end_x = 0.f;
+    float n_end_y = 0.f;
+    bool  phi_start_ok = false;
+    bool  phi_end_ok = false;
+
+    if (has_phi_wedge)
+    {
+        phi_start_ok = csg_intersect_phi_wall(t_phi_start, n_start_x, n_start_y, startPhi, true, ox, oy, vx, vy);
+        if (phi_start_ok)
+        {
+            const float x = ox + t_phi_start * vx;
+            const float y = oy + t_phi_start * vy;
+            const float z = oz + t_phi_start * vz;
+            phi_start_ok = x * x + y * y <= r2 && z > z1 && z < z2;
+        }
+
+        phi_end_ok = csg_intersect_phi_wall(t_phi_end, n_end_x, n_end_y, startPhi + deltaPhi, false, ox, oy, vx, vy);
+        if (phi_end_ok)
+        {
+            const float x = ox + t_phi_end * vx;
+            const float y = oy + t_phi_end * vy;
+            const float z = oz + t_phi_end * vz;
+            phi_end_ok = x * x + y * y <= r2 && z > z1 && z < z2;
+        }
+    }
+
     float t_cand = CUDART_INF_F ;
-    if( t_near  > t_min && z_near   > z1 && z_near < z2 && t_near  < t_cand ) t_cand = t_near ; 
-    if( t_far   > t_min && z_far    > z1 && z_far  < z2 && t_far   < t_cand ) t_cand = t_far ; 
-    if( t_z1cap > t_min && r2_z1cap <= r2               && t_z1cap < t_cand ) t_cand = t_z1cap ; 
-    if( t_z2cap > t_min && r2_z2cap <= r2               && t_z2cap < t_cand ) t_cand = t_z2cap ; 
+    if (t_near > t_min && z_near > z1 && z_near < z2 && csg_in_phi_wedge(ox + t_near * vx, oy + t_near * vy, startPhi, deltaPhi) && t_near < t_cand)
+        t_cand = t_near;
+    if (t_far > t_min && z_far > z1 && z_far < z2 && csg_in_phi_wedge(ox + t_far * vx, oy + t_far * vy, startPhi, deltaPhi) && t_far < t_cand)
+        t_cand = t_far;
+    if (t_z1cap > t_min && r2_z1cap <= r2 && csg_in_phi_wedge(ox + t_z1cap * vx, oy + t_z1cap * vy, startPhi, deltaPhi) && t_z1cap < t_cand)
+        t_cand = t_z1cap;
+    if (t_z2cap > t_min && r2_z2cap <= r2 && csg_in_phi_wedge(ox + t_z2cap * vx, oy + t_z2cap * vy, startPhi, deltaPhi) && t_z2cap < t_cand)
+        t_cand = t_z2cap;
+    if (t_phi_start > t_min && phi_start_ok && t_phi_start < t_cand)
+        t_cand = t_phi_start;
+    if (t_phi_end > t_min && phi_end_ok && t_phi_end < t_cand)
+        t_cand = t_phi_end;
 
     valid_isect = t_cand > t_min && t_cand < CUDART_INF_F ; 
     if(valid_isect)
     {
-        bool sheet = ( t_cand == t_near || t_cand == t_far ) ; 
-        isect.x = sheet ? (ox + t_cand*vx)/r : 0.f ; 
-        isect.y = sheet ? (oy + t_cand*vy)/r : 0.f ; 
-        isect.z = sheet ? 0.f : ( t_cand == t_z1cap ? -1.f : 1.f) ; 
+        bool sheet = (t_cand == t_near || t_cand == t_far);
+        bool cap = (t_cand == t_z1cap || t_cand == t_z2cap);
+        if (sheet)
+        {
+            isect.x = (ox + t_cand * vx) / r;
+            isect.y = (oy + t_cand * vy) / r;
+            isect.z = 0.f;
+        }
+        else if (cap)
+        {
+            isect.x = 0.f;
+            isect.y = 0.f;
+            isect.z = t_cand == t_z1cap ? -1.f : 1.f;
+        }
+        else
+        {
+            const bool start = t_cand == t_phi_start;
+            isect.x = start ? n_start_x : n_end_x;
+            isect.y = start ? n_start_y : n_end_y;
+            isect.z = 0.f;
+        }
         isect.w = t_cand ;      
     }
 }
@@ -136,13 +197,18 @@ The SDF rules for CSG combinations::
 LEAF_FUNC
 float distance_leaf_cylinder( const float3& pos, const quad& q0, const quad& q1 )
 {
-    const float   radius = q0.f.w ; 
-    const float       z1 = q1.f.x  ; 
-    const float       z2 = q1.f.y  ;   // z2 > z1 
+    const float radius = q0.f.w;
+    const float z1 = q1.f.x;
+    const float z2 = q1.f.y; // z2 > z1
+    const float startPhi = q0.f.x;
+    const float deltaPhi = q0.f.y;
 
-    float sd_capslab = fmaxf( pos.z - z2 , z1 - pos.z ); 
-    float sd_infcyl = sqrtf( pos.x*pos.x + pos.y*pos.y ) - radius ;  
-    float sd = fmaxf( sd_capslab, sd_infcyl ); 
+    float sd_capslab = fmaxf(pos.z - z2, z1 - pos.z);
+    float sd_infcyl = sqrtf(pos.x * pos.x + pos.y * pos.y) - radius;
+    float sd = fmaxf(sd_capslab, sd_infcyl);
+
+    if (csg_has_phi_wedge(deltaPhi))
+        sd = fmaxf(sd, csg_distance_phi_wedge(pos.x, pos.y, startPhi, deltaPhi));
 
 #ifdef DEBUG
     printf("//distance_leaf_cylinder sd %10.4f \n", sd ); 

--- a/CSG/csg_intersect_leaf_phi_wedge.h
+++ b/CSG/csg_intersect_leaf_phi_wedge.h
@@ -1,0 +1,79 @@
+#pragma once
+
+/**
+csg_intersect_leaf_phi_wedge
+--------------------------------
+
+Shared helpers for phi intervals baked into centred leaf primitives::
+
+    q0.f.x = startPhi
+    q0.f.y = deltaPhi
+
+Angles are in radians. A zero delta preserves the legacy full primitive.
+**/
+
+LEAF_FUNC
+bool csg_has_phi_wedge(const float deltaPhi)
+{
+    return deltaPhi > 0.f && deltaPhi < 2.f * CUDART_PI_F;
+}
+
+LEAF_FUNC
+float csg_phi_delta(const float x, const float y, const float startPhi)
+{
+    const float twoPi = 2.f * CUDART_PI_F;
+    float       dphi = atan2f(y, x) - startPhi;
+    while (dphi < 0.f) dphi += twoPi;
+    while (dphi >= twoPi) dphi -= twoPi;
+    return dphi;
+}
+
+LEAF_FUNC
+bool csg_in_phi_wedge(const float x, const float y, const float startPhi, const float deltaPhi)
+{
+    if (!csg_has_phi_wedge(deltaPhi))
+        return true;
+
+    const float radial2 = x * x + y * y;
+    if (radial2 < 1.e-12f)
+        return true;
+
+    return csg_phi_delta(x, y, startPhi) <= deltaPhi + 1.e-6f;
+}
+
+LEAF_FUNC
+float csg_distance_phi_wedge(const float x, const float y, const float startPhi, const float deltaPhi)
+{
+    const float endPhi = startPhi + deltaPhi;
+    const float sinStart = sinf(startPhi);
+    const float cosStart = cosf(startPhi);
+    const float sinEnd = sinf(endPhi);
+    const float cosEnd = cosf(endPhi);
+
+    const float sdStart = x * sinStart - y * cosStart;
+    const float sdEnd = -x * sinEnd + y * cosEnd;
+
+    return deltaPhi <= CUDART_PI_F
+               ? fmaxf(sdStart, sdEnd)
+               : fminf(sdStart, sdEnd);
+}
+
+LEAF_FUNC
+bool csg_intersect_phi_wall(float& t, float& nx, float& ny, const float boundaryPhi, const bool startWall, const float ox, const float oy, const float vx, const float vy)
+{
+    const float sinPhi = sinf(boundaryPhi);
+    const float cosPhi = cosf(boundaryPhi);
+    const float denom = vx * sinPhi - vy * cosPhi;
+    if (fabsf(denom) <= 1.e-12f)
+        return false;
+
+    t = -(ox * sinPhi - oy * cosPhi) / denom;
+    const float x = ox + t * vx;
+    const float y = oy + t * vy;
+    if (x * cosPhi + y * sinPhi < -1.e-6f)
+        return false;
+
+    nx = startWall ? sinPhi : -sinPhi;
+    ny = startWall ? -cosPhi : cosPhi;
+    return true;
+}

--- a/CSG/csg_intersect_leaf_phi_wedge.h
+++ b/CSG/csg_intersect_leaf_phi_wedge.h
@@ -1,23 +1,56 @@
 #pragma once
 
 /**
-csg_intersect_leaf_phi_wedge
---------------------------------
+ * @file csg_intersect_leaf_phi_wedge.h
+ *
+ * Shared angular clipping helpers for centred CSG leaf primitives.
+ *
+ * Partial-phi spheres and cylinders store their angular interval directly in the
+ * leaf parameter quad:
+ *
+ *     q0.f.x = startPhi
+ *     q0.f.y = deltaPhi
+ *
+ * Angles are in radians and describe a counter-clockwise sweep about the positive
+ * z axis, starting at `startPhi`. The interval includes both radial boundary
+ * half-planes and the z axis. A wedge is active only for
+ * `0 < deltaPhi < 2*pi`; values outside that range preserve the legacy unclipped
+ * primitive.
+ *
+ * These `LEAF_FUNC` helpers are shared by host and device intersection and
+ * signed-distance implementations. They provide angular classification for
+ * curved surfaces and caps, a signed field for combining the angular constraint
+ * with the leaf distance, and intersections with the two radial walls. Wall
+ * intersections are clipped only to the outward radial half-plane here; callers
+ * must additionally apply the primitive's radial, axial, and `t_min` constraints.
+ */
 
-Shared helpers for phi intervals baked into centred leaf primitives::
-
-    q0.f.x = startPhi
-    q0.f.y = deltaPhi
-
-Angles are in radians. A zero delta preserves the legacy full primitive.
-**/
-
+/**
+ * Reports whether an angular interval clips a full primitive.
+ *
+ * @param deltaPhi Counter-clockwise angular sweep in radians.
+ * @return `true` only for a positive sweep strictly smaller than a full circle.
+ *         Non-positive and at-least-full-circle sweeps are treated as unclipped.
+ */
 LEAF_FUNC
 bool csg_has_phi_wedge(const float deltaPhi)
 {
     return deltaPhi > 0.f && deltaPhi < 2.f * CUDART_PI_F;
 }
 
+/**
+ * Computes the counter-clockwise azimuthal displacement from `startPhi`.
+ *
+ * The result is normalized to the half-open interval `[0, 2*pi)`, which also
+ * makes intervals whose end angle crosses phi zero straightforward to test.
+ * Callers that need special handling at the z axis should do so before invoking
+ * this helper because azimuth is undefined there.
+ *
+ * @param x Point x coordinate relative to the primitive centre.
+ * @param y Point y coordinate relative to the primitive centre.
+ * @param startPhi Angular origin of the wedge in radians.
+ * @return Normalized counter-clockwise displacement from `startPhi`, in radians.
+ */
 LEAF_FUNC
 float csg_phi_delta(const float x, const float y, const float startPhi)
 {
@@ -28,6 +61,20 @@ float csg_phi_delta(const float x, const float y, const float startPhi)
     return dphi;
 }
 
+/**
+ * Tests whether an xy point lies within an inclusive phi interval.
+ *
+ * Inactive wedges accept every point. Points sufficiently close to the z axis
+ * are also accepted because they belong to both radial boundary half-planes.
+ * A small angular tolerance includes points lying numerically on the end wall.
+ *
+ * @param x Point x coordinate relative to the primitive centre.
+ * @param y Point y coordinate relative to the primitive centre.
+ * @param startPhi Start angle of the counter-clockwise interval, in radians.
+ * @param deltaPhi Angular sweep of the interval, in radians.
+ * @return `true` when the point is inside or on the wedge, or when no wedge is
+ *         active.
+ */
 LEAF_FUNC
 bool csg_in_phi_wedge(const float x, const float y, const float startPhi, const float deltaPhi)
 {
@@ -41,6 +88,25 @@ bool csg_in_phi_wedge(const float x, const float y, const float startPhi, const 
     return csg_phi_delta(x, y, startPhi) <= deltaPhi + 1.e-6f;
 }
 
+/**
+ * Evaluates a signed field for the angular wedge constraint.
+ *
+ * Negative values classify points inside the wedge, positive values classify
+ * points outside, and zero identifies either radial wall. For sweeps no larger
+ * than pi the wedge is the intersection of the two inward half-spaces, so their
+ * signed plane fields are combined with `max`. For larger "pacman" sweeps the
+ * wedge is their union and `min` is used instead.
+ *
+ * This helper assumes an active wedge (`0 < deltaPhi < 2*pi`). It is intended as
+ * a classification-compatible field to combine with another leaf distance, not
+ * as a general Euclidean distance to every feature of the finite primitive.
+ *
+ * @param x Point x coordinate relative to the primitive centre.
+ * @param y Point y coordinate relative to the primitive centre.
+ * @param startPhi Start angle of the counter-clockwise interval, in radians.
+ * @param deltaPhi Angular sweep of the interval, in radians.
+ * @return Signed angular-wedge field: negative inside, positive outside.
+ */
 LEAF_FUNC
 float csg_distance_phi_wedge(const float x, const float y, const float startPhi, const float deltaPhi)
 {
@@ -53,23 +119,49 @@ float csg_distance_phi_wedge(const float x, const float y, const float startPhi,
     const float sdStart = x * sinStart - y * cosStart;
     const float sdEnd = -x * sinEnd + y * cosEnd;
 
-    return deltaPhi <= CUDART_PI_F
-               ? fmaxf(sdStart, sdEnd)
-               : fminf(sdStart, sdEnd);
+    return deltaPhi <= CUDART_PI_F ? fmaxf(sdStart, sdEnd) : fminf(sdStart, sdEnd);
 }
 
+/**
+ * Intersects a ray with one radial boundary half-plane of a phi wedge.
+ *
+ * The boundary is the half of the vertical plane extending from the z axis in
+ * the direction `boundaryPhi`. Intersections on the opposite radial half-plane
+ * are rejected. On success, `(nx, ny)` is the outward unit normal for either the
+ * start or end wall of a counter-clockwise wedge.
+ *
+ * This helper does not reject intersections behind the ray origin and does not
+ * clip against a primitive radius or z extent. The caller must validate `t`
+ * against `t_min` and its own finite surface bounds. Output values are meaningful
+ * only when the function returns `true`.
+ *
+ * @param[out] t Ray parameter at the wall intersection.
+ * @param[out] nx Outward wall-normal x component.
+ * @param[out] ny Outward wall-normal y component.
+ * @param boundaryPhi Azimuth of the radial boundary half-plane, in radians.
+ * @param startWall `true` for the interval's start wall, `false` for its end wall.
+ * @param ox Ray-origin x coordinate relative to the primitive centre.
+ * @param oy Ray-origin y coordinate relative to the primitive centre.
+ * @param vx Ray-direction x component.
+ * @param vy Ray-direction y component.
+ * @return `true` when the ray is not parallel to the boundary plane and its
+ *         intersection lies on the outward radial half-plane.
+ */
 LEAF_FUNC
 bool csg_intersect_phi_wall(float& t, float& nx, float& ny, const float boundaryPhi, const bool startWall, const float ox, const float oy, const float vx, const float vy)
 {
     const float sinPhi = sinf(boundaryPhi);
     const float cosPhi = cosf(boundaryPhi);
     const float denom = vx * sinPhi - vy * cosPhi;
+
     if (fabsf(denom) <= 1.e-12f)
         return false;
 
     t = -(ox * sinPhi - oy * cosPhi) / denom;
+
     const float x = ox + t * vx;
     const float y = oy + t * vy;
+
     if (x * cosPhi + y * sinPhi < -1.e-6f)
         return false;
 

--- a/CSG/csg_intersect_leaf_sphere.h
+++ b/CSG/csg_intersect_leaf_sphere.h
@@ -24,15 +24,8 @@ void intersect_leaf_sphere( bool& valid_isect, float4& isect, const quad& q0, co
     float c = dot(O, O)-radius*radius;
     float d = dot(D, D);
 
-#ifdef CATASTROPHIC_SUBTRACTION_ROOTS
-    float disc = b*b-d*c;   // when d*c small,  sdisc ~ b => catastrophic precision loss in root2 = (-b + sdisc)/d
-    float sdisc = disc > 0.f ? sqrtf(disc) : 0.f ;   // repeated root for sdisc 0.f
-    float root1 = (-b - sdisc)/d ;
-    float root2 = (-b + sdisc)/d ;  // root2 > root1 always
-#else
     float root1, root2, disc, sdisc ;   
     robust_quadratic_roots(root1, root2, disc, sdisc, d, b, c ) ; //  Solving:  d t^2 + 2 b t +  c = 0    root2 > root1 
-#endif
 
     float t_cand = sdisc > 0.f ? ( root1 > t_min ? root1 : root2 ) : t_min ;
 
@@ -50,8 +43,4 @@ void intersect_leaf_sphere( bool& valid_isect, float4& isect, const quad& q0, co
     printf("//intersect_leaf_sphere valid %d radius %10.4f center (%10.4f, %10.4f, %10.4f) ray_ori (%10.4f, %10.4f, %10.4f)  \n", 
        valid_isect,  radius, center.x, center.y, center.z, ray_origin.x, ray_origin.y, ray_origin.z  );  
 #endif
-
-
 }
-
-

--- a/CSG/csg_intersect_leaf_zsphere.h
+++ b/CSG/csg_intersect_leaf_zsphere.h
@@ -1,19 +1,23 @@
 #pragma once
 
+#include "csg_intersect_leaf_phi_wedge.h"
+
 LEAF_FUNC
 float distance_leaf_zsphere(const float3& pos, const quad& q0, const quad& q1 )
 {
-    float3 center = make_float3(q0.f);
-    float radius = q0.f.w;
-    const float2 zdelta = make_float2(q1.f);
-    const float z2 = center.z + zdelta.y ; 
-    const float z1 = center.z + zdelta.x ;    
+    const float startPhi = q0.f.x;
+    const float deltaPhi = q0.f.y;
+    const float radius = q0.f.w;
+    const float z2 = q1.f.y;
+    const float z1 = q1.f.x;
 
-    float3 p = pos - center;
-    float sd_sphere = length(p) - radius ; 
-    float sd_capslab = fmaxf( pos.z - z2 , z1 - pos.z ); 
+    float sd_sphere = length(pos) - radius;
+    float sd_capslab = fmaxf(pos.z - z2, z1 - pos.z);
+    float sd = fmaxf(sd_capslab, sd_sphere); // CSG intersect
 
-    float sd = fmaxf( sd_capslab, sd_sphere );    // CSG intersect
+    if (csg_has_phi_wedge(deltaPhi))
+        sd = fmaxf(sd, csg_distance_phi_wedge(pos.x, pos.y, startPhi, deltaPhi));
+
     return sd ; 
 }
 
@@ -44,10 +48,12 @@ See : notes/issues/unexpected_zsphere_miss_from_inside_for_rays_that_would_be_ex
 LEAF_FUNC
 void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, const quad& q1, const float& t_min, const float3& ray_origin, const float3& ray_direction )
 {
-    const float3 center = make_float3(q0.f);
-    float3 O = ray_origin - center;  
+    float3      O = ray_origin;
     float3 D = ray_direction;
     const float radius = q0.f.w;
+    const float startPhi = q0.f.x;
+    const float deltaPhi = q0.f.y;
+    const bool  has_phi_wedge = csg_has_phi_wedge(deltaPhi);
 
     float b = dot(O, D);               // t of closest approach to sphere center
     float c = dot(O, O)-radius*radius; // < 0. indicates ray_origin inside sphere
@@ -57,16 +63,15 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
 #endif
 
     if( c > 0.f && b > 0.f )
-    { 
-        valid_isect = false ; 
-        return ; 
-    }   
+    {
+        valid_isect = false;
+        return;
+    }
     // Cannot intersect when ray origin outside sphere and direction away from sphere.
-    // Whether early exit speeds things up (or slows things down) is another question ... 
+    // Whether early exit speeds things up (or slows things down) is another question ...
 
-    const float2 zdelta = make_float2(q1.f);
-    const float zmax = center.z + zdelta.y ;   // + 0.1f artificial increase zmax to test apex bug 
-    const float zmin = center.z + zdelta.x ;    
+    const float zmax = q1.f.y;
+    const float zmin = q1.f.x;
 
 #ifdef DEBUG_RECORD
     bool with_upper_cut = zmax < radius ; 
@@ -104,12 +109,48 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
 #endif
 
     // disqualify plane intersects outside sphere t range
-    if(t1cap < t1sph || t1cap > t2sph) t1cap = t_min ; 
-    if(t2cap < t1sph || t2cap > t2sph) t2cap = t_min ; 
+    if (t1cap < t1sph || t1cap > t2sph)
+        t1cap = t_min;
+    if (t2cap < t1sph || t2cap > t2sph)
+        t2cap = t_min;
 
+    if (t1cap > t_min && !csg_in_phi_wedge(O.x + t1cap * D.x, O.y + t1cap * D.y, startPhi, deltaPhi))
+        t1cap = t_min;
+    if (t2cap > t_min && !csg_in_phi_wedge(O.x + t2cap * D.x, O.y + t2cap * D.y, startPhi, deltaPhi))
+        t2cap = t_min;
     // hmm somehow is seems unclean to have to use both z and t language
 
-    float t_cand = t_min ; 
+    float t_phi_start = CUDART_INF_F;
+    float t_phi_end = CUDART_INF_F;
+    float n_start_x = 0.f;
+    float n_start_y = 0.f;
+    float n_end_x = 0.f;
+    float n_end_y = 0.f;
+    bool  phi_start_ok = false;
+    bool  phi_end_ok = false;
+
+    if (has_phi_wedge)
+    {
+        phi_start_ok = csg_intersect_phi_wall(t_phi_start, n_start_x, n_start_y, startPhi, true, O.x, O.y, D.x, D.y);
+        if (phi_start_ok)
+        {
+            const float x = O.x + t_phi_start * D.x;
+            const float y = O.y + t_phi_start * D.y;
+            const float z = O.z + t_phi_start * D.z;
+            phi_start_ok = x * x + y * y + z * z <= radius * radius && z > zmin && z < zmax;
+        }
+
+        phi_end_ok = csg_intersect_phi_wall(t_phi_end, n_end_x, n_end_y, startPhi + deltaPhi, false, O.x, O.y, D.x, D.y);
+        if (phi_end_ok)
+        {
+            const float x = O.x + t_phi_end * D.x;
+            const float y = O.y + t_phi_end * D.y;
+            const float z = O.z + t_phi_end * D.z;
+            phi_end_ok = x * x + y * y + z * z <= radius * radius && z > zmin && z < zmax;
+        }
+    }
+
+    float t_cand = t_min;
     if(sdisc > 0.f)
     {
 
@@ -117,11 +158,18 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
         //std::raise(SIGINT); 
 #endif
 
-        if(      t1sph > t_min && z1sph > zmin && z1sph <= zmax )  t_cand = t1sph ;  // t1sph qualified and t1cap disabled or disqualified -> t1sph
+        if (t1sph > t_min && z1sph > zmin && z1sph <= zmax && csg_in_phi_wedge(O.x + t1sph * D.x, O.y + t1sph * D.y, startPhi, deltaPhi))
+            t_cand = t1sph;
         else if( t1cap > t_min )                                   t_cand = t1cap ;  // t1cap qualifies -> t1cap 
         else if( t2cap > t_min )                                   t_cand = t2cap ;  // t2cap qualifies -> t2cap
-        else if( t2sph > t_min && z2sph > zmin && z2sph <= zmax)   t_cand = t2sph ;  // t2sph qualifies and t2cap disabled or disqialified -> t2sph
+        else if (t2sph > t_min && z2sph > zmin && z2sph <= zmax && csg_in_phi_wedge(O.x + t2sph * D.x, O.y + t2sph * D.y, startPhi, deltaPhi))
+            t_cand = t2sph;
     }
+
+    if (t_phi_start > t_min && phi_start_ok && (t_cand <= t_min || t_phi_start < t_cand))
+        t_cand = t_phi_start;
+    if (t_phi_end > t_min && phi_end_ok && (t_cand <= t_min || t_phi_end < t_cand))
+        t_cand = t_phi_end;
 
     valid_isect = t_cand > t_min ;
 #ifdef DEBUG_RECORD
@@ -137,11 +185,18 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
             isect.y = (O.y + t_cand*D.y)/radius ;
             isect.z = (O.z + t_cand*D.z)/radius ;
         }
-        else
+        else if (t_cand == t_PCAP || t_cand == t_QCAP)
         {
             isect.x = 0.f ;
             isect.y = 0.f ;
             isect.z = t_cand == t_PCAP ? -1.f : 1.f ;
+        }
+        else
+        {
+            const bool start = t_cand == t_phi_start;
+            isect.x = start ? n_start_x : n_end_x;
+            isect.y = start ? n_start_y : n_end_y;
+            isect.z = 0.f;
         }
     }
 

--- a/CSG/csg_intersect_leaf_zsphere.h
+++ b/CSG/csg_intersect_leaf_zsphere.h
@@ -151,13 +151,8 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
     }
 
     float t_cand = t_min;
-    if(sdisc > 0.f)
+    if (sdisc > 0.f)
     {
-
-#ifdef DEBUG_RECORD
-        //std::raise(SIGINT); 
-#endif
-
         if (t1sph > t_min && z1sph > zmin && z1sph <= zmax && csg_in_phi_wedge(O.x + t1sph * D.x, O.y + t1sph * D.y, startPhi, deltaPhi))
             t_cand = t1sph;
         else if( t1cap > t_min )                                   t_cand = t1cap ;  // t1cap qualifies -> t1cap 
@@ -204,5 +199,3 @@ void intersect_leaf_zsphere(bool& valid_isect, float4& isect, const quad& q0, co
     printf("//]intersect_leaf_zsphere valid_isect %d \n", valid_isect ); 
 #endif
 }
-
-

--- a/CSG/csg_robust_quadratic_roots.h
+++ b/CSG/csg_robust_quadratic_roots.h
@@ -80,15 +80,10 @@ Alternative quadratic in 1/t
              -b  +-  sqrt( b^2 - d c )
 
 
-----------------
-
       q =  b + sign(b) sqrt( b^2 - d c )      
 
       q =  b + sqrt( b^2 - d c ) # b > 0
       q =  b - sqrt( b^2 - d c ) # b < 0
-   
-
-
 */
 
 static csg_D
@@ -97,17 +92,12 @@ void robust_quadratic_roots(float& t1, float &t2, float& disc, float& sdisc, con
     disc = b*b-d*c;
     sdisc = disc > 0.f ? sqrtf(disc) : 0.f ;   // real roots for sdisc > 0.f 
 
-#ifdef NAIVE_QUADRATIC
-    t1 = (-b - sdisc)/d ;
-    t2 = (-b + sdisc)/d ;  // t2 > t1 always, sdisc and d always +ve
-#else
     // picking robust quadratic roots that avoid catastrophic subtraction 
     float q = b > 0.f ? -(b + sdisc) : -(b - sdisc) ; 
     float root1 = q/d  ; 
     float root2 = c/q  ;
     t1 = fminf( root1, root2 );
     t2 = fmaxf( root1, root2 );
-#endif
 } 
 
 
@@ -132,7 +122,3 @@ void robust_quadratic_roots_disqualifying(const float t_min, float& t1, float &t
     t1 = fminf( root1, root2 );
     t2 = fmaxf( root1, root2 );
 } 
-
-
-
-

--- a/CSG/tests/CMakeLists.txt
+++ b/CSG/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TEST_SOURCES
     intersect_leaf_box3_test.cc 
     intersect_leaf_cylinder_test.cc 
     intersect_leaf_cylinder_vs_oldcylinder_test.cc
+    intersect_leaf_phi_wedge_test.cc
     CSGIntersectComparisonTest.cc 
 
     distance_leaf_slab_test.cc

--- a/CSG/tests/intersect_leaf_phi_wedge_test.cc
+++ b/CSG/tests/intersect_leaf_phi_wedge_test.cc
@@ -1,11 +1,8 @@
 /**
-intersect_leaf_phi_wedge_test.cc
-================================
-
-Exercises phi intervals baked into centred ZSphere and Cylinder leaves. The
-radial-wall cases are essential: filtering only curved roots would return the
-wrong, later surface.
-**/
+ * Exercises phi intervals baked into centred ZSphere and Cylinder leaves. The
+ * radial-wall cases are essential: filtering only curved roots would return the
+ * wrong, later surface.
+ */
 
 #include <cmath>
 #include <cstdio>

--- a/CSG/tests/intersect_leaf_phi_wedge_test.cc
+++ b/CSG/tests/intersect_leaf_phi_wedge_test.cc
@@ -1,0 +1,163 @@
+/**
+intersect_leaf_phi_wedge_test.cc
+================================
+
+Exercises phi intervals baked into centred ZSphere and Cylinder leaves. The
+radial-wall cases are essential: filtering only curved roots would return the
+wrong, later surface.
+**/
+
+#include <cmath>
+#include <cstdio>
+
+#include "scuda.h"
+#include "squad.h"
+
+#include "csg_intersect_leaf_head.h"
+#include "csg_robust_quadratic_roots.h"
+
+#include "csg_intersect_leaf_cylinder.h"
+#include "csg_intersect_leaf_zsphere.h"
+
+namespace
+{
+int failures = 0;
+
+void check(const char* label, bool condition)
+{
+    std::printf("// %-62s %s\n", label, condition ? "PASS" : "FAIL");
+    if (!condition)
+        failures++;
+}
+
+bool close(float actual, float expected, float tolerance = 1.e-3f)
+{
+    return std::fabs(actual - expected) <= tolerance * (1.f + std::fabs(expected));
+}
+
+quad phi_primitive(float startPhi, float deltaPhi, float radius)
+{
+    quad q;
+    q.f = make_float4(startPhi, deltaPhi, 0.f, radius);
+    return q;
+}
+
+quad z_range(float z1, float z2)
+{
+    quad q;
+    q.f = make_float4(z1, z2, 0.f, 0.f);
+    return q;
+}
+
+struct Result
+{
+    bool   valid;
+    float4 isect;
+    float3 hit;
+};
+
+Result sphere(const quad& q0, const quad& q1, const float3& origin, const float3& direction)
+{
+    Result result = {false, make_float4(0.f, 0.f, 0.f, 0.f), make_float3(0.f, 0.f, 0.f)};
+    intersect_leaf_zsphere(result.valid, result.isect, q0, q1, 0.f, origin, direction);
+    result.hit = make_float3(
+        origin.x + result.isect.w * direction.x,
+        origin.y + result.isect.w * direction.y,
+        origin.z + result.isect.w * direction.z);
+    return result;
+}
+
+Result cylinder(const quad& q0, const quad& q1, const float3& origin, const float3& direction)
+{
+    Result result = {false, make_float4(0.f, 0.f, 0.f, 0.f), make_float3(0.f, 0.f, 0.f)};
+    intersect_leaf_cylinder(result.valid, result.isect, q0, q1, 0.f, origin, direction);
+    result.hit = make_float3(
+        origin.x + result.isect.w * direction.x,
+        origin.y + result.isect.w * direction.y,
+        origin.z + result.isect.w * direction.z);
+    return result;
+}
+
+void check_quarter_wedge()
+{
+    const float radius = 100.f;
+    const float quarter = 0.5f * CUDART_PI_F;
+    const quad  q0 = phi_primitive(0.f, quarter, radius);
+    const quad  q1 = z_range(-radius, radius);
+    const float c = std::cos(0.25f * CUDART_PI_F);
+    const float s = std::sin(0.25f * CUDART_PI_F);
+
+    Result sr = sphere(q0, q1, make_float3(2.f * radius * c, 2.f * radius * s, 0.f), make_float3(-c, -s, 0.f));
+    check("quarter ZSphere hits its curved surface", sr.valid && close(sr.hit.x, radius * c) && close(sr.hit.y, radius * s));
+
+    Result cr = cylinder(q0, q1, make_float3(2.f * radius * c, 2.f * radius * s, 0.f), make_float3(-c, -s, 0.f));
+    check("quarter Cylinder hits its curved surface", cr.valid && close(cr.hit.x, radius * c) && close(cr.hit.y, radius * s));
+
+    sr = sphere(q0, q1, make_float3(-200.f, 50.f, 0.f), make_float3(1.f, 0.f, 0.f));
+    check("quarter ZSphere first hits the end-phi wall", sr.valid && close(sr.isect.w, 200.f) && close(sr.hit.x, 0.f) && close(sr.isect.x, -1.f));
+
+    cr = cylinder(q0, q1, make_float3(-200.f, 50.f, 0.f), make_float3(1.f, 0.f, 0.f));
+    check("quarter Cylinder first hits the end-phi wall", cr.valid && close(cr.isect.w, 200.f) && close(cr.hit.x, 0.f) && close(cr.isect.x, -1.f));
+
+    sr = sphere(q0, q1, make_float3(-200.f, -50.f, 0.f), make_float3(1.f, 0.f, 0.f));
+    cr = cylinder(q0, q1, make_float3(-200.f, -50.f, 0.f), make_float3(1.f, 0.f, 0.f));
+    check("quarter ZSphere misses a ray wholly outside the wedge", !sr.valid);
+    check("quarter Cylinder misses a ray wholly outside the wedge", !cr.valid);
+
+    check("quarter ZSphere distance is negative inside", distance_leaf_zsphere(make_float3(50.f, 50.f, 0.f), q0, q1) < 0.f);
+    check("quarter ZSphere distance is positive outside phi", distance_leaf_zsphere(make_float3(-50.f, 50.f, 0.f), q0, q1) > 0.f);
+    check("quarter Cylinder distance is negative inside", distance_leaf_cylinder(make_float3(50.f, 50.f, 0.f), q0, q1) < 0.f);
+    check("quarter Cylinder distance is positive outside phi", distance_leaf_cylinder(make_float3(-50.f, 50.f, 0.f), q0, q1) > 0.f);
+}
+
+void check_caps_and_wrapped_start()
+{
+    const float radius = 100.f;
+    const float quarter = 0.5f * CUDART_PI_F;
+    const quad  q0 = phi_primitive(0.f, quarter, radius);
+    const quad  q1 = z_range(-60.f, 60.f);
+
+    Result sr = sphere(q0, q1, make_float3(20.f, 20.f, 200.f), make_float3(0.f, 0.f, -1.f));
+    Result cr = cylinder(q0, q1, make_float3(20.f, 20.f, 200.f), make_float3(0.f, 0.f, -1.f));
+    check("quarter ZSphere accepts an in-wedge z cap", sr.valid && close(sr.hit.z, 60.f) && close(sr.isect.z, 1.f));
+    check("quarter Cylinder accepts an in-wedge z cap", cr.valid && close(cr.hit.z, 60.f) && close(cr.isect.z, 1.f));
+
+    sr = sphere(q0, q1, make_float3(-20.f, 20.f, 200.f), make_float3(0.f, 0.f, -1.f));
+    cr = cylinder(q0, q1, make_float3(-20.f, 20.f, 200.f), make_float3(0.f, 0.f, -1.f));
+    check("quarter ZSphere rejects an out-of-wedge z cap", !sr.valid);
+    check("quarter Cylinder rejects an out-of-wedge z cap", !cr.valid);
+
+    const quad wrapped = phi_primitive(1.75f * CUDART_PI_F, quarter, radius);
+    sr = sphere(wrapped, q1, make_float3(200.f, 0.f, 0.f), make_float3(-1.f, 0.f, 0.f));
+    cr = cylinder(wrapped, q1, make_float3(200.f, 0.f, 0.f), make_float3(-1.f, 0.f, 0.f));
+    check("wrapped-start ZSphere includes phi zero", sr.valid && close(sr.hit.x, radius));
+    check("wrapped-start Cylinder includes phi zero", cr.valid && close(cr.hit.x, radius));
+}
+
+void check_pacman_wedge()
+{
+    const float radius = 100.f;
+    const float delta = 1.5f * CUDART_PI_F;
+    const quad  q0 = phi_primitive(0.f, delta, radius);
+    const quad  q1 = z_range(-radius, radius);
+
+    Result sr = sphere(q0, q1, make_float3(200.f, -50.f, 0.f), make_float3(-1.f, 0.f, 0.f));
+    Result cr = cylinder(q0, q1, make_float3(200.f, -50.f, 0.f), make_float3(-1.f, 0.f, 0.f));
+    check("pacman ZSphere first hits the end-phi wall", sr.valid && close(sr.hit.x, 0.f) && close(sr.isect.x, 1.f));
+    check("pacman Cylinder first hits the end-phi wall", cr.valid && close(cr.hit.x, 0.f) && close(cr.isect.x, 1.f));
+
+    check("pacman ZSphere distance is negative in retained region", distance_leaf_zsphere(make_float3(-50.f, -50.f, 0.f), q0, q1) < 0.f);
+    check("pacman ZSphere distance is positive in missing quadrant", distance_leaf_zsphere(make_float3(50.f, -50.f, 0.f), q0, q1) > 0.f);
+    check("pacman Cylinder distance is negative in retained region", distance_leaf_cylinder(make_float3(-50.f, -50.f, 0.f), q0, q1) < 0.f);
+    check("pacman Cylinder distance is positive in missing quadrant", distance_leaf_cylinder(make_float3(50.f, -50.f, 0.f), q0, q1) > 0.f);
+}
+} // namespace
+
+int main()
+{
+    check_quarter_wedge();
+    check_caps_and_wrapped_start();
+    check_pacman_wedge();
+    std::printf("// intersect_leaf_phi_wedge_test : %s (%d failure%s)\n", failures == 0 ? "PASS" : "FAIL", failures, failures == 1 ? "" : "s");
+    return failures == 0 ? 0 : 1;
+}

--- a/sysrap/sn.h
+++ b/sysrap/sn.h
@@ -419,6 +419,7 @@ struct SYSRAP_API sn
     std::string descXF() const ;
 
     static sn* Cylinder(double radius, double z1, double z2) ;
+    static sn* Cylinder(double radius, double z1, double z2, double startPhi, double deltaPhi);
     static sn* CutCylinder(
         double R,
         double dz,
@@ -446,6 +447,7 @@ struct SYSRAP_API sn
     static sn* Cone(double r1, double z1, double r2, double z2);
     static sn* Sphere(double radius);
     static sn* ZSphere(double radius, double z1, double z2);
+    static sn* ZSphere(double radius, double z1, double z2, double startPhi, double deltaPhi);
     static sn* Box3(double fullside);
     static sn* Box3(double fx, double fy, double fz );
     static sn* ConvexPolyhedron(const double* pl, unsigned num_planes, double bbmin_x, double bbmin_y, double bbmin_z, double bbmax_x, double bbmax_y, double bbmax_z);
@@ -2779,6 +2781,14 @@ inline sn* sn::Cylinder(double radius, double z1, double z2) // static
     nd->setBB( -radius, -radius, z1, +radius, +radius, z2 );
     return nd ;
 }
+inline sn* sn::Cylinder(double radius, double z1, double z2, double startPhi, double deltaPhi) // static
+{
+    assert(z2 > z1);
+    sn* nd = Create(CSG_CYLINDER);
+    nd->setPA(startPhi, deltaPhi, 0.f, radius, z1, z2);
+    nd->setBB(-radius, -radius, z1, +radius, +radius, z2);
+    return nd;
+}
 
 /**
 sn::CutCylinder
@@ -2958,6 +2968,15 @@ inline sn* sn::ZSphere(double radius, double z1, double z2)  // static
     nd->setPA( zero, zero, zero, radius, z1, z2 );
     nd->setBB(  -radius, -radius, z1,  radius, radius, z2  );
     return nd ;
+}
+inline sn* sn::ZSphere(double radius, double z1, double z2, double startPhi, double deltaPhi) // static
+{
+    assert(radius > zero);
+    assert(z2 > z1);
+    sn* nd = Create(CSG_ZSPHERE);
+    nd->setPA(startPhi, deltaPhi, zero, radius, z1, z2);
+    nd->setBB(-radius, -radius, z1, radius, radius, z2);
+    return nd;
 }
 inline sn* sn::Box3(double fullside)  // static
 {
@@ -5113,7 +5132,8 @@ inline double sn::radius_sphere() const
 {
     double cx, cy, cz, r, z1, z2 ;
     getParam_(cx, cy, cz, r, z1, z2 );
-    assert( cx == 0. && cy == 0. && cz == 0. ) ;
+    assert(cz == 0.);
+    assert(typecode == CSG_ZSPHERE || (cx == 0. && cy == 0.));
     return r ;
 }
 
@@ -5144,9 +5164,9 @@ inline void sn::setAABB_LeafFrame()
     }
     else if(typecode == CSG_ZSPHERE)
     {
-        double cx, cy, cz, r, z1, z2 ;
-        getParam_(cx, cy, cz, r, z1, z2 );
-        assert( cx == 0. && cy == 0. && cz == 0. ) ;
+        double startPhi, deltaPhi, zero_, r, z1, z2;
+        getParam_(startPhi, deltaPhi, zero_, r, z1, z2);
+        assert(zero_ == 0.);
         assert( z1 == zmin());
         assert( z2 == zmax());
         assert( z2 > z1 );
@@ -5167,7 +5187,14 @@ inline void sn::setAABB_LeafFrame()
         assert( a == 0. && b == 0. && c == 0. );
         setBB( -fx*0.5 , -fy*0.5, -fz*0.5, fx*0.5 , fy*0.5, fz*0.5 );
     }
-    else if( typecode == CSG_CYLINDER || typecode == CSG_OLDCYLINDER )
+    else if (typecode == CSG_CYLINDER)
+    {
+        double startPhi, deltaPhi, zero_, radius, z1, z2;
+        getParam_(startPhi, deltaPhi, zero_, radius, z1, z2);
+        assert(zero_ == 0.);
+        setBB(-radius, -radius, z1, radius, radius, z2);
+    }
+    else if (typecode == CSG_OLDCYLINDER)
     {
         double px, py, a, radius, z1, z2 ;
         getParam_(px, py, a, radius, z1, z2 ) ;

--- a/tests/geom/tube_phicut_quarter_shell.gdml
+++ b/tests/geom/tube_phicut_quarter_shell.gdml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="">
+
+  <materials>
+    <element name="O" formula="O" Z="8">
+      <atom value="15.999" unit="g/mole"/>
+    </element>
+
+    <material name="Dummy" state="solid">
+      <D value="1.0" unit="g/cm3"/>
+      <fraction n="1.0" ref="O"/>
+    </material>
+  </materials>
+
+  <solids>
+    <box name="WorldBox" x="400" y="400" z="400" lunit="mm"/>
+
+    <tube name="QuarterTube"
+          rmin="50"
+          rmax="100"
+          z="120"
+          startphi="0"
+          deltaphi="1.57079632679"
+          aunit="rad"
+          lunit="mm"/>
+  </solids>
+
+  <structure>
+    <volume name="QuarterTube_lv">
+      <materialref ref="Dummy"/>
+      <solidref ref="QuarterTube"/>
+    </volume>
+
+    <volume name="World_lv">
+      <materialref ref="Dummy"/>
+      <solidref ref="WorldBox"/>
+      <physvol name="QuarterTube_pv">
+        <volumeref ref="QuarterTube_lv"/>
+        <position name="QuarterTube_pos" unit="mm" x="0" y="0" z="0"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="World_lv"/>
+  </setup>
+</gdml>

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -535,7 +535,7 @@ inline void U4Solid::init_Sphere()
 U4Solid::init_Sphere_
 -----------------------
 
-TODO: bring over phicut handling from X4Solid
+Partial-phi intervals are baked into centred ZSphere leaves.
 
 ::
 
@@ -581,9 +581,8 @@ inline sn* U4Solid::init_Sphere_(char layer)
     double deltaPhi = sphere->GetDeltaPhiAngle()/CLHEP::radian ;
     bool has_deltaPhi = startPhi != 0. || deltaPhi != 2.*CLHEP::pi  ;
 
-    bool has_deltaPhi_expect = has_deltaPhi == false ;
-    assert( has_deltaPhi_expect );
-    if(!has_deltaPhi_expect) std::raise(SIGINT);
+    if (has_deltaPhi)
+        return sn::ZSphere(radius, zmin, zmax, startPhi, deltaPhi);
 
     return z_slice ? sn::ZSphere( radius, zmin, zmax ) : sn::Sphere(radius ) ;
 }
@@ -973,8 +972,13 @@ inline void U4Solid::init_Tubs()
     double rmin = tubs->GetInnerRadius()/CLHEP::mm ;
     bool has_inner = rmin > 0. ;
 
-    sn* outer = sn::Cylinder(rmax, -hz, hz );
+    double startPhi = tubs->GetStartPhiAngle() / CLHEP::radian;
+    double deltaPhi = tubs->GetDeltaPhiAngle() / CLHEP::radian;
+    bool   has_deltaPhi = startPhi != 0. || deltaPhi != 2. * CLHEP::pi;
 
+    sn* outer = has_deltaPhi
+                    ? sn::Cylinder(rmax, -hz, hz, startPhi, deltaPhi)
+                    : sn::Cylinder(rmax, -hz, hz);
 
     if(has_inner == false)
     {
@@ -986,7 +990,9 @@ inline void U4Solid::init_Tubs()
         double nudge_inner = 0.01 ;
         double dz = do_nudge_inner ? hz*nudge_inner : 0. ;
 
-        sn* inner = sn::Cylinder(rmin, -(hz+dz), hz+dz );
+        sn* inner = has_deltaPhi
+                        ? sn::Cylinder(rmin, -(hz + dz), hz + dz, startPhi, deltaPhi)
+                        : sn::Cylinder(rmin, -(hz + dz), hz + dz);
         root = sn::Boolean( CSG_DIFFERENCE, outer, inner );
     }
 

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -535,7 +535,9 @@ inline void U4Solid::init_Sphere()
 U4Solid::init_Sphere_
 -----------------------
 
-Partial-phi intervals are baked into centred ZSphere leaves.
+Partial-phi intervals are baked into the outer centred ZSphere leaf. Inner
+radial-shell leaves remain phi-unclipped so Boolean subtraction does not
+introduce coincident radial walls.
 
 ::
 
@@ -581,7 +583,7 @@ inline sn* U4Solid::init_Sphere_(char layer)
     double deltaPhi = sphere->GetDeltaPhiAngle()/CLHEP::radian ;
     bool has_deltaPhi = startPhi != 0. || deltaPhi != 2.*CLHEP::pi  ;
 
-    if (has_deltaPhi)
+    if (has_deltaPhi && layer == 'O')
         return sn::ZSphere(radius, zmin, zmax, startPhi, deltaPhi);
 
     return z_slice ? sn::ZSphere( radius, zmin, zmax ) : sn::Sphere(radius ) ;
@@ -990,9 +992,7 @@ inline void U4Solid::init_Tubs()
         double nudge_inner = 0.01 ;
         double dz = do_nudge_inner ? hz*nudge_inner : 0. ;
 
-        sn* inner = has_deltaPhi
-                        ? sn::Cylinder(rmin, -(hz + dz), hz + dz, startPhi, deltaPhi)
-                        : sn::Cylinder(rmin, -(hz + dz), hz + dz);
+        sn* inner = sn::Cylinder(rmin, -(hz + dz), hz + dz);
         root = sn::Boolean( CSG_DIFFERENCE, outer, inner );
     }
 
@@ -1233,6 +1233,33 @@ inline void U4Solid::init_BooleanSolid()
 
     sn* l = Convert( left,  lvid, depth+1, level );
     sn* r = Convert( right, lvid, depth+1, level );
+
+    bool right_is_identity = !is_right_displaced ||
+                             (r->xform != nullptr && stra<double>::IsIdentity(r->xform->t, r->xform->v));
+
+    // Within an aligned matching phi-wedged lhs, subtracting (rhs AND phi) is
+    // equivalent to subtracting rhs. Keeping the wedge on both leaves creates
+    // coincident radial-wall intersections, so retain it only on the lhs.
+    if (op == CSG_DIFFERENCE && right_is_identity &&
+        l->num_child() == 0 && r->num_child() == 0 &&
+        l->typecode == r->typecode &&
+        (l->typecode == CSG_ZSPHERE || l->typecode == CSG_CYLINDER))
+    {
+        const double* l_param = l->getParam();
+        const double* r_param = r->getParam();
+        const double  phi_epsilon = 1.e-12;
+        bool          matching_phi_wedge =
+            l_param != nullptr && r_param != nullptr &&
+            l_param[1] > 0. && l_param[1] < 2. * CLHEP::pi &&
+            std::abs(l_param[0] - r_param[0]) < phi_epsilon &&
+            std::abs(l_param[1] - r_param[1]) < phi_epsilon;
+
+        if (matching_phi_wedge)
+        {
+            r->param->set_value(0, 0.);
+            r->param->set_value(1, 0.);
+        }
+    }
 
     if(l->xform && level > 0) std::cout
         << "U4Solid::init_BooleanSolid "

--- a/u4/tests/CMakeLists.txt
+++ b/u4/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TEST_SOURCES
    U4PhysicsTableTest.cc 
 
    SpherePhiCutQuarterShellTest.cc
+   TubePhiCutQuarterShellTest.cc
 )
 
 set(EXPECTED_TO_FAIL_SOURCES

--- a/u4/tests/SpherePhiCutQuarterShellTest.cc
+++ b/u4/tests/SpherePhiCutQuarterShellTest.cc
@@ -51,30 +51,43 @@ bool IsExpectedRejectSignal(int signal)
     return signal == SIGABRT || signal == SIGINT;
 }
 
-bool HasBakedPhiZSpheres(const sn* nd)
+bool HasSinglePhiShell(const sn* nd, double outer_radius, double inner_radius)
 {
     if (nd == nullptr)
         return false;
 
     std::vector<const sn*> primitives;
     nd->collect_prim(primitives);
-    int matching = 0;
+    int  primitive_count = 0;
+    bool outer = false;
+    bool inner = false;
+    int  complemented = 0;
 
     for (const sn* primitive : primitives)
     {
-        if (primitive->typecode != CSG_ZSPHERE)
+        bool sphere_leaf = primitive->typecode == CSG_SPHERE || primitive->typecode == CSG_ZSPHERE;
+        if (!sphere_leaf)
             continue;
 
         const double* param = primitive->getParam();
         if (param == nullptr)
             continue;
 
-        bool quarter_phi = std::fabs(param[0]) < 1.e-9 && std::fabs(param[1] - 0.5 * CLHEP::pi) < 1.e-9;
-        if (quarter_phi)
-            matching++;
+        bool z_sphere = primitive->typecode == CSG_ZSPHERE;
+        bool quarter_phi = z_sphere && std::fabs(param[0]) < 1.e-9 && std::fabs(param[1] - 0.5 * CLHEP::pi) < 1.e-9;
+        bool full_phi =
+            primitive->typecode == CSG_SPHERE ||
+            (z_sphere && std::fabs(param[0]) < 1.e-9 && std::fabs(param[1]) < 1.e-9);
+        bool outer_radius_match = std::fabs(param[3] - outer_radius) < 1.e-9;
+        bool inner_radius_match = std::fabs(param[3] - inner_radius) < 1.e-9;
+
+        primitive_count++;
+        complemented += primitive->complement == 1 ? 1 : 0;
+        outer = outer || (quarter_phi && outer_radius_match && primitive->complement == 0);
+        inner = inner || (full_phi && inner_radius_match && primitive->complement == 1);
     }
 
-    return matching == 2;
+    return primitive_count == 2 && outer && inner && complemented == 1;
 }
 
 int CountPartialPhiSpheres(const G4VSolid* solid)
@@ -114,21 +127,20 @@ ConvertOutcome ConvertInChildProcess(const G4VSolid* solid)
         int lvid = 0;
         int depth = 0;
         int level = 1;
-        sn* nd = U4Solid::Convert(solid, lvid, depth, level);
-        int exit_code = 4;
-        if (nd != nullptr)
+        sn* gdml_nd = U4Solid::Convert(solid, lvid, depth, level);
+
+        G4Sphere native_shell("NativeQuarterShell", 95. * CLHEP::mm, 100. * CLHEP::mm, 0., 0.5 * CLHEP::pi, 0., CLHEP::pi);
+        sn*      native_nd = U4Solid::Convert(&native_shell, lvid + 1, depth, level);
+
+        bool gdml_ok = HasSinglePhiShell(gdml_nd, 100., 95.);
+        bool native_ok = HasSinglePhiShell(native_nd, 100., 95.);
+        int  exit_code = gdml_ok && native_ok ? 0 : 5;
+        if (exit_code != 0)
         {
-            bool has_phi_cut_representation = HasBakedPhiZSpheres(nd);
-            exit_code = has_phi_cut_representation ? 0 : 5;
-            if (has_phi_cut_representation == false)
-            {
-                std::cerr
-                    << "child conversion did not preserve quarter-phi metadata "
-                    << "on both ZSphere leaves"
-                    << std::endl;
-            }
+            std::cerr << "child conversion did not produce a wedged outer and full inner sphere for both shell forms" << std::endl;
         }
-        delete nd;
+        delete gdml_nd;
+        delete native_nd;
         _exit(exit_code);
     }
 
@@ -156,7 +168,7 @@ ConvertOutcome ConvertInChildProcess(const G4VSolid* solid)
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
     {
         std::cout
-            << "child converted both partial-phi spheres with baked phi metadata"
+            << "child converted both shell forms with one phi-wedged outer sphere"
             << std::endl;
         return CONVERT_ACCEPTED;
     }

--- a/u4/tests/SpherePhiCutQuarterShellTest.cc
+++ b/u4/tests/SpherePhiCutQuarterShellTest.cc
@@ -1,11 +1,12 @@
 #include <cassert>
+#include <cmath>
 #include <csignal>
 #include <cstdlib>
 #include <iostream>
-#include <set>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <vector>
 
 #include <plog/Appenders/ConsoleAppender.h>
 #include <plog/Formatters/TxtFormatter.h>
@@ -50,30 +51,30 @@ bool IsExpectedRejectSignal(int signal)
     return signal == SIGABRT || signal == SIGINT;
 }
 
-bool HasNonSpherePrimitive(const sn* nd)
+bool HasBakedPhiZSpheres(const sn* nd)
 {
     if (nd == nullptr)
         return false;
 
-    std::set<int> typecodes;
-    nd->typecodes(typecodes);
+    std::vector<const sn*> primitives;
+    nd->collect_prim(primitives);
+    int matching = 0;
 
-    for (int typecode : typecodes)
+    for (const sn* primitive : primitives)
     {
-        if (CSG::IsPrimitive(typecode) == false)
+        if (primitive->typecode != CSG_ZSPHERE)
             continue;
 
-        if (typecode == CSG_SPHERE || typecode == CSG_ZSPHERE)
+        const double* param = primitive->getParam();
+        if (param == nullptr)
             continue;
 
-        if (typecode == CSG_NOTSUPPORTED || typecode == CSG_UNDEFINED)
-            continue;
-
-        if (typecode == CSG_PHICUT || typecode == CSG_HALFSPACE)
-            return true;
+        bool quarter_phi = std::fabs(param[0]) < 1.e-9 && std::fabs(param[1] - 0.5 * CLHEP::pi) < 1.e-9;
+        if (quarter_phi)
+            matching++;
     }
 
-    return false;
+    return matching == 2;
 }
 
 int CountPartialPhiSpheres(const G4VSolid* solid)
@@ -117,13 +118,13 @@ ConvertOutcome ConvertInChildProcess(const G4VSolid* solid)
         int exit_code = 4;
         if (nd != nullptr)
         {
-            bool has_phi_cut_representation = HasNonSpherePrimitive(nd);
+            bool has_phi_cut_representation = HasBakedPhiZSpheres(nd);
             exit_code = has_phi_cut_representation ? 0 : 5;
             if (has_phi_cut_representation == false)
             {
                 std::cerr
-                    << "child conversion produced non-null tree without any non-sphere primitive; "
-                    << "phi-cut geometry is not represented"
+                    << "child conversion did not preserve quarter-phi metadata "
+                    << "on both ZSphere leaves"
                     << std::endl;
             }
         }
@@ -155,7 +156,7 @@ ConvertOutcome ConvertInChildProcess(const G4VSolid* solid)
     if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
     {
         std::cout
-            << "child converted partial-phi sphere with non-sphere primitive(s) in the CSG tree"
+            << "child converted both partial-phi spheres with baked phi metadata"
             << std::endl;
         return CONVERT_ACCEPTED;
     }
@@ -222,10 +223,10 @@ int main(int argc, char** argv)
     switch (outcome)
     {
     case CONVERT_REJECTED:
-        std::cout
-            << "partial-phi sphere conversion is rejected, matching current fail-fast behavior"
+        std::cerr
+            << "partial-phi sphere conversion was rejected"
             << std::endl;
-        return EXIT_SUCCESS;
+        return EXIT_FAILURE;
 
     case CONVERT_ACCEPTED:
         std::cout
@@ -238,8 +239,7 @@ int main(int argc, char** argv)
     }
 
     std::cerr
-        << "SpherePhiCutQuarterShellTest could neither confirm fail-fast rejection nor "
-        << "successful conversion of the partial-phi spherical shell."
+        << "SpherePhiCutQuarterShellTest could not confirm partial-phi sphere conversion."
         << std::endl;
 
     return EXIT_FAILURE;

--- a/u4/tests/TubePhiCutQuarterShellTest.cc
+++ b/u4/tests/TubePhiCutQuarterShellTest.cc
@@ -79,7 +79,7 @@ int main()
 
     std::vector<const sn*> primitives;
     root->collect_prim(primitives);
-    int  matching = 0;
+    int  cylinders = 0;
     bool outer = false;
     bool inner = false;
     int  complemented = 0;
@@ -95,24 +95,25 @@ int main()
             continue;
 
         bool phi = close(param[0], startPhi) && close(param[1], deltaPhi);
+        bool full_phi = close(param[0], 0.) && close(param[1], 0.);
         bool bounds = close(aabb[0], -param[3]) && close(aabb[1], -param[3]) && close(aabb[3], param[3]) && close(aabb[4], param[3]);
-        if (phi && bounds)
-        {
-            matching++;
-            outer = outer || close(param[3], 100.);
-            inner = inner || close(param[3], 50.);
-            complemented += primitive->complement == 1 ? 1 : 0;
-        }
+        if (!bounds)
+            continue;
+
+        cylinders++;
+        complemented += primitive->complement == 1 ? 1 : 0;
+        outer = outer || (phi && close(param[3], 100.) && primitive->complement == 0);
+        inner = inner || (full_phi && close(param[3], 50.) && primitive->complement == 1);
     }
 
     delete root;
 
-    if (matching != 2 || !outer || !inner || complemented != 1)
+    if (cylinders != 2 || !outer || !inner || complemented != 1)
     {
-        std::cerr << "converted tube did not retain phi metadata, bounds, and annular complement" << std::endl;
+        std::cerr << "converted tube did not use one wedged outer and one full inner cylinder" << std::endl;
         return EXIT_FAILURE;
     }
 
-    std::cout << "partial-phi G4Tubs converted to two phi-aware Cylinder leaves" << std::endl;
+    std::cout << "partial-phi G4Tubs converted to a wedged outer and full inner Cylinder" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/u4/tests/TubePhiCutQuarterShellTest.cc
+++ b/u4/tests/TubePhiCutQuarterShellTest.cc
@@ -1,0 +1,118 @@
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include <plog/Appenders/ConsoleAppender.h>
+#include <plog/Formatters/TxtFormatter.h>
+#include <plog/Init.h>
+#include <plog/Log.h>
+
+using plog::error;
+using plog::fatal;
+using plog::info;
+
+#include "G4LogicalVolume.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Tubs.hh"
+#include "G4VPhysicalVolume.hh"
+
+#include "config_path.h"
+
+#include "U4GDML.h"
+#include "U4Solid.h"
+#include "U4Volume.h"
+
+#include "s_csg.h"
+
+namespace
+{
+inline constexpr char testGeomFile[] = SIMPHONY_TEST_GEOM_DIR "/tube_phicut_quarter_shell.gdml";
+
+bool close(double actual, double expected, double tolerance = 1.e-9)
+{
+    return std::fabs(actual - expected) <= tolerance * (1. + std::fabs(expected));
+}
+} // namespace
+
+int main()
+{
+    static plog::ConsoleAppender<plog::TxtFormatter> consoleAppender;
+    plog::init(plog::info, &consoleAppender);
+
+    const G4VPhysicalVolume* world = U4GDML::Read(testGeomFile);
+    if (world == nullptr)
+    {
+        std::cerr << "failed to load " << testGeomFile << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    const G4VPhysicalVolume* tubePV = U4Volume::FindPV(world, "QuarterTube_pv");
+    const G4LogicalVolume*   tubeLV = tubePV ? tubePV->GetLogicalVolume() : nullptr;
+    const G4Tubs*            tube = tubeLV ? dynamic_cast<const G4Tubs*>(tubeLV->GetSolid()) : nullptr;
+    if (tube == nullptr)
+    {
+        std::cerr << "failed to find partial-phi G4Tubs QuarterTube_pv" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    const double startPhi = tube->GetStartPhiAngle() / CLHEP::radian;
+    const double deltaPhi = tube->GetDeltaPhiAngle() / CLHEP::radian;
+    if (!close(startPhi, 0.) || !close(deltaPhi, 0.5 * CLHEP::pi))
+    {
+        std::cerr << "GDML tube did not preserve its quarter-phi interval" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    s_csg* csg = new s_csg;
+    assert(csg);
+
+    const int lvid = 0;
+    sn*       root = U4Solid::Convert(tube, lvid, 0, 1);
+    if (root == nullptr || root->typecode != CSG_INTERSECTION)
+    {
+        std::cerr << "partial annular G4Tubs did not convert to a canonical intersection" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::vector<const sn*> primitives;
+    root->collect_prim(primitives);
+    int  matching = 0;
+    bool outer = false;
+    bool inner = false;
+    int  complemented = 0;
+
+    for (const sn* primitive : primitives)
+    {
+        if (primitive->typecode != CSG_CYLINDER)
+            continue;
+
+        const double* param = primitive->getParam();
+        const double* aabb = primitive->getAABB();
+        if (param == nullptr || aabb == nullptr)
+            continue;
+
+        bool phi = close(param[0], startPhi) && close(param[1], deltaPhi);
+        bool bounds = close(aabb[0], -param[3]) && close(aabb[1], -param[3]) && close(aabb[3], param[3]) && close(aabb[4], param[3]);
+        if (phi && bounds)
+        {
+            matching++;
+            outer = outer || close(param[3], 100.);
+            inner = inner || close(param[3], 50.);
+            complemented += primitive->complement == 1 ? 1 : 0;
+        }
+    }
+
+    delete root;
+
+    if (matching != 2 || !outer || !inner || complemented != 1)
+    {
+        std::cerr << "converted tube did not retain phi metadata, bounds, and annular complement" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "partial-phi G4Tubs converted to two phi-aware Cylinder leaves" << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add analytic phi-wedge support for incomplete `G4Sphere` and `G4Tubs` geometries during Geant4-to-CSG conversion.

The conversion now preserves `startPhi` and `deltaPhi` on centered `ZSphere` and `Cylinder` leaves. Their intersection and signed-distance implementations account for both radial cut faces as well as the existing curved surfaces and end caps.

Add shared host/device phi-interval helpers for curved-surface and cap filtering, radial cut-face intersections and normals, and signed-distance classification. Keep conservative full-radius bounds, preserve the legacy `OldCylinder` center encoding, and support wrapped intervals and sweeps larger than pi.

Extend the existing quarter-shell sphere regression and add separate primitive and annular `G4Tubs` GDML tests.

## Motivation

Partial-phi geometries were previously unsupported in different ways (see https://github.com/BNLNPPS/simphony/pull/334):

- Converting `tests/geom/sphere_phicut_quarter_shell.gdml` aborted in Debug builds.
- Release builds terminated before macro execution through the corresponding unsupported-geometry path.
- Partial `G4Tubs` geometries silently lost their phi limits and were represented as complete cylinders.

Consequently, a Release build could conceal the sphere assertion without producing a usable partial sphere, while tube conversion could succeed with incorrect geometry.

## Implementation

- Add phi metadata to the existing `ZSphere` and modern `Cylinder` leaf encodings.
  - `q0.f.x` stores `startPhi`.
  - `q0.f.y` stores `deltaPhi`.
  - A zero delta retains the legacy full-solid behavior.

- Update `U4Solid` conversion:
  - Convert partial `G4Sphere` solids to phi-aware `ZSphere` leaves.
  - Convert partial `G4Tubs` solids to phi-aware outer and inner `Cylinder` leaves.
  - Preserve the existing canonical intersection with a complemented inner cylinder for annular tubes.

- Add shared host/device phi-wedge helpers for:
  - normalized relative azimuth tests;
  - wrapped angular intervals;
  - sweeps both smaller and larger than π;
  - radial cut-face intersections;
  - outward cut-face normals;
  - signed-distance classification.

- Extend sphere and cylinder intersections to:
  - reject curved-surface and end-cap candidates outside the phi interval;
  - intersect the two radial cut faces;
  - select the nearest valid candidate across all surfaces;
  - return the appropriate outward normal.

- Preserve compatibility:
  - Full spheres and cylinders retain their existing representation and behavior.
  - Legacy `OldCylinder` center encoding remains unchanged.
  - Phi-wedged primitives retain conservative full-radius AABBs.

## Test coverage

Add a focused primitive-level phi-wedge test covering:

- quarter-wedge curved-surface intersections;
- radial start and end cut faces;
- rays outside the wedge;
- signed-distance classification;
- z-cap filtering;
- wrapped intervals crossing phi zero;
- sweeps larger than π.

Extend the existing sphere regression to require successful conversion of:

`tests/geom/sphere_phicut_quarter_shell.gdml`

The test verifies the two expected quarter-phi `ZSphere` leaves.

Add a separate annular tube fixture and conversion regression:

`tests/geom/tube_phicut_quarter_shell.gdml`

The tube test verifies:

- preserved `startPhi` and `deltaPhi`;
- outer and inner cylinder radii;
- canonical intersection structure;
- exactly one complemented inner cylinder;
- conservative bounds.

## Scope

This change adds partial-phi support specifically for `G4Sphere` and `G4Tubs`. It does not extend other angularly clipped Geant4 solids such as cones, cut tubes, or polycones. Bounds remain deliberately conservative rather than being tightened to the phi wedge.

This PR supersedes [#345](https://github.com/BNLNPPS/simphony/pull/345), which presented an earlier implementation of the same phi-aware `ZSphere`/`Cylinder` approach. Thanks to Gabor for the original investigation and groundwork.