### PR TITLE
refactor(genstep): retire legacy suffixed type codes

### DIFF
--- a/dd4hepplugins/OpticsSteppingAction.cc
+++ b/dd4hepplugins/OpticsSteppingAction.cc
@@ -128,8 +128,7 @@ void OpticsSteppingAction::operator()(const G4Step *step, G4SteppingManager *mgr
 
             {
                 G4AutoLock lock(&genstep_mutex);
-                U4::CollectGenstep_DsG4Scintillation_r4695(track, step, numPhotons,
-                                                           /*scnt=*/1, scintTime);
+                U4::CollectGenstep_Scintillation(track, step, numPhotons, /*scnt=*/1, scintTime);
             }
 
             if (verbose_ > 0)

--- a/examples/MC_Truth/GPUMCTruth.h
+++ b/examples/MC_Truth/GPUMCTruth.h
@@ -605,8 +605,7 @@ struct SteppingAction : G4UserSteppingAction
                         G4double SCINTILLATIONTIMECONSTANT1 = MPT->GetConstProperty(kSCINTILLATIONTIMECONSTANT1);
 
                         G4AutoLock lock(&genstep_mutex);
-                        U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, fNumPhotons, 1,
-                                                                   SCINTILLATIONTIMECONSTANT1);
+                        U4::CollectGenstep_Scintillation(aTrack, aStep, fNumPhotons, 1, SCINTILLATIONTIMECONSTANT1);
                     }
                 }
             }

--- a/examples/async_gpu_launch/async_gpu_launch.h
+++ b/examples/async_gpu_launch/async_gpu_launch.h
@@ -449,7 +449,7 @@ static quad6 MakeGenstep_Scintillation(const G4Track* aTrack, const G4Step* aSte
     gs.zero();
     sscint* sc = (sscint*)(&gs);
 
-    sc->gentype = OpticksGenstep_DsG4Scintillation_r4695;
+    sc->gentype = OpticksGenstep_SCINTILLATION;
     sc->trackid = aTrack->GetTrackID();
     sc->matline = aMaterial->GetIndex() + SEvt::G4_INDEX_OFFSET;
     sc->numphoton = numPhotons;
@@ -953,7 +953,7 @@ struct SteppingAction : G4UserSteppingAction
                             nRemaining -= nPhotComp;
 
                             if (nPhotComp > 0)
-                                U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, nPhotComp, c + 1, tc[c]);
+                                U4::CollectGenstep_Scintillation(aTrack, aStep, nPhotComp, c + 1, tc[c]);
                         }
                     }
                 }

--- a/examples/async_gpu_std/async_gpu_std.h
+++ b/examples/async_gpu_std/async_gpu_std.h
@@ -522,7 +522,7 @@ static quad6 MakeGenstep_Scintillation(const G4Track* aTrack,
     gs.zero();
     sscint* sc = (sscint*)(&gs);
 
-    sc->gentype = OpticksGenstep_DsG4Scintillation_r4695;
+    sc->gentype = OpticksGenstep_SCINTILLATION;
     sc->trackid = aTrack->GetTrackID();
     sc->matline = mat->GetIndex() + SEvt::G4_INDEX_OFFSET;
     sc->numphoton = numPhotons;
@@ -1006,8 +1006,7 @@ struct SteppingAction : G4UserSteppingAction
                                 : static_cast<G4int>(numPhotons * yield[c] / yieldSum);
                         remaining -= n;
                         if (n > 0)
-                            U4::CollectGenstep_DsG4Scintillation_r4695(track, aStep, n, c + 1,
-                                                                       tc[c]);
+                            U4::CollectGenstep_Scintillation(track, aStep, n, c + 1, tc[c]);
                     }
                 }
             }

--- a/qudarap/qsim.h
+++ b/qudarap/qsim.h
@@ -2424,7 +2424,6 @@ inline QSIM_METHOD void qsim::generate_photon(sphoton& p, RNG& rng, const quad6&
         case OpticksGenstep_CERENKOV:
                                               cerenkov->generate(    p, rng, gs, photon_id, genstep_id ) ; break ;
 
-        case OpticksGenstep_DsG4Scintillation_r4695:
         case OpticksGenstep_SCINTILLATION:
             if (scint != nullptr)
                 scint->generate(p, rng, gs, photon_id, genstep_id);

--- a/src/GPUCerenkov.h
+++ b/src/GPUCerenkov.h
@@ -501,8 +501,7 @@ struct SteppingAction : G4UserSteppingAction
                         G4double SCINTILLATIONTIMECONSTANT1 = MPT->GetConstProperty(kSCINTILLATIONTIMECONSTANT1);
 
                         G4AutoLock lock(&genstep_mutex);
-                        U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, fNumPhotons, 1,
-                                                                   SCINTILLATIONTIMECONSTANT1);
+                        U4::CollectGenstep_Scintillation(aTrack, aStep, fNumPhotons, 1, SCINTILLATIONTIMECONSTANT1);
                     }
                 }
             }

--- a/src/GPURaytrace.h
+++ b/src/GPURaytrace.h
@@ -601,7 +601,7 @@ struct SteppingAction : G4UserSteppingAction
                             nRemaining -= nPhotComp;
 
                             if (nPhotComp > 0)
-                                U4::CollectGenstep_DsG4Scintillation_r4695(aTrack, aStep, nPhotComp, c + 1, tc[c]);
+                                U4::CollectGenstep_Scintillation(aTrack, aStep, nPhotComp, c + 1, tc[c]);
                         }
                     }
                 }

--- a/sysrap/OpticksGenstep.h
+++ b/sysrap/OpticksGenstep.h
@@ -19,11 +19,7 @@ See also: npy/G4StepNPY.cpp  (TODO: consolidate these?)
 enum
 {
     OpticksGenstep_INVALID                  = 0,
-    OpticksGenstep_G4Cerenkov_1042          = 1,
-    OpticksGenstep_G4Scintillation_1042     = 2,
-    OpticksGenstep_DsG4Cerenkov_r3971       = 3,
-    OpticksGenstep_DsG4Scintillation_r3971  = 4,
-    OpticksGenstep_DsG4Scintillation_r4695  = 5,
+    // Values 1-5 are intentionally unused after retiring their legacy encodings.
     OpticksGenstep_TORCH                    = 6,
     OpticksGenstep_FABRICATED               = 7,
     OpticksGenstep_EMITSOURCE               = 8,
@@ -52,11 +48,6 @@ enum
 struct OpticksGenstep_
 {
     static constexpr const char* INVALID_                 = "INVALID" ;
-    static constexpr const char* G4Cerenkov_1042_         = "G4Cerenkov_1042" ;
-    static constexpr const char* G4Scintillation_1042_    = "G4Scintillation_1042" ;
-    static constexpr const char* DsG4Cerenkov_r3971_      = "DsG4Cerenkov_r3971" ;
-    static constexpr const char* DsG4Scintillation_r3971_ = "DsG4Scintillation_r3971" ;
-    static constexpr const char* DsG4Scintillation_r4695_ = "DsG4Scintillation_r4695" ;
     static constexpr const char* TORCH_                   = "TORCH" ;
     static constexpr const char* FABRICATED_              = "FABRICATED" ;
     static constexpr const char* EMITSOURCE_              = "EMITSOURCE" ;
@@ -97,12 +88,7 @@ struct OpticksGenstep_
 inline unsigned OpticksGenstep_::Type(const char* name)
 {
     unsigned type = OpticksGenstep_INVALID  ;
-    if(strcmp(name,G4Cerenkov_1042_ )==0)         type = OpticksGenstep_G4Cerenkov_1042 ;
-    if(strcmp(name,G4Scintillation_1042_ )==0)    type = OpticksGenstep_G4Scintillation_1042 ;
-    if(strcmp(name,DsG4Cerenkov_r3971_ )==0)      type = OpticksGenstep_DsG4Cerenkov_r3971 ;
     if(strcmp(name,G4Cerenkov_modified_ )==0)     type = OpticksGenstep_G4Cerenkov_modified ;
-    if(strcmp(name,DsG4Scintillation_r3971_ )==0) type = OpticksGenstep_DsG4Scintillation_r3971 ;
-    if(strcmp(name,DsG4Scintillation_r4695_ )==0) type = OpticksGenstep_DsG4Scintillation_r4695 ;
     if(strcmp(name,TORCH_)==0)                    type = OpticksGenstep_TORCH ;
     if(strcmp(name,FABRICATED_)==0)               type = OpticksGenstep_FABRICATED ;
     if(strcmp(name,EMITSOURCE_)==0)               type = OpticksGenstep_EMITSOURCE ;
@@ -131,12 +117,7 @@ inline const char* OpticksGenstep_::Name(unsigned type)
     switch(type)
     {
         case OpticksGenstep_INVALID:                 n = INVALID_                 ; break ;
-        case OpticksGenstep_G4Cerenkov_1042:         n = G4Cerenkov_1042_         ; break ;
-        case OpticksGenstep_G4Scintillation_1042:    n = G4Scintillation_1042_    ; break ;
-        case OpticksGenstep_DsG4Cerenkov_r3971:      n = DsG4Cerenkov_r3971_      ; break ;
         case OpticksGenstep_G4Cerenkov_modified:     n = G4Cerenkov_modified_     ; break ;
-        case OpticksGenstep_DsG4Scintillation_r3971: n = DsG4Scintillation_r3971_ ; break ;
-        case OpticksGenstep_DsG4Scintillation_r4695: n = DsG4Scintillation_r4695_ ; break ;
         case OpticksGenstep_TORCH:                   n = TORCH_                   ; break ;
         case OpticksGenstep_FABRICATED:              n = FABRICATED_              ; break ;
         case OpticksGenstep_EMITSOURCE:              n = EMITSOURCE_              ; break ;
@@ -167,19 +148,11 @@ inline bool OpticksGenstep_::IsValid(int gentype)   // static
 
 inline bool OpticksGenstep_::IsCerenkov(int gentype)  // static
 {
-   return gentype == OpticksGenstep_G4Cerenkov_1042  ||
-          gentype == OpticksGenstep_DsG4Cerenkov_r3971 ||
-          gentype == OpticksGenstep_CERENKOV ||
-          gentype == OpticksGenstep_G4Cerenkov_modified
-          ;
+    return gentype == OpticksGenstep_CERENKOV || gentype == OpticksGenstep_G4Cerenkov_modified;
 }
 inline bool OpticksGenstep_::IsScintillation(int gentype)  // static
 {
-   return gentype == OpticksGenstep_G4Scintillation_1042 ||
-          gentype == OpticksGenstep_DsG4Scintillation_r3971 ||
-          gentype == OpticksGenstep_DsG4Scintillation_r4695 ||
-          gentype == OpticksGenstep_SCINTILLATION
-         ;
+    return gentype == OpticksGenstep_SCINTILLATION;
 }
 inline bool OpticksGenstep_::IsTorchLike(int gentype)   // static
 {
@@ -263,5 +236,3 @@ inline unsigned OpticksGenstep_::GentypeToPhotonFlag(char gentype)  // static
 
 
 #endif
-
-

--- a/sysrap/sscint.h
+++ b/sysrap/sscint.h
@@ -5,11 +5,9 @@ sscint.h : scintillation genstep helpers
 ========================================
 
 * FOLLOWING PATTERN OF storch.h and scerenkov.h
-
-For now just implemnet for JUNO specific variant : collectGenstep_DsG4Scintillation_r4695
+* shared by collected and fabricated scintillation gensteps
 
 **/
-
 
 #if defined(__CUDACC__) || defined(__CUDABE__)
    #define SSCINT_METHOD __device__

--- a/sysrap/tests/CMakeLists.txt
+++ b/sysrap/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ set(TEST_SOURCES
    scanvasTest.cc 
 
    OpticksPhotonTest.cc
+   GenstepTest.cc
    SUTest.cc
    SEventConfigTest.cc
    SFrameConfigTest.cc

--- a/sysrap/tests/GenstepTest.cc
+++ b/sysrap/tests/GenstepTest.cc
@@ -1,0 +1,39 @@
+#include <cassert>
+#include <cstring>
+
+#include "OpticksGenstep.h"
+
+void test_retired_codes()
+{
+    for (unsigned type = 1; type <= 5; ++type)
+    {
+        assert(std::strcmp(OpticksGenstep_::Name(type), OpticksGenstep_::INVALID_) == 0);
+        assert(!OpticksGenstep_::IsValid(type));
+        assert(!OpticksGenstep_::IsCerenkov(type));
+        assert(!OpticksGenstep_::IsScintillation(type));
+        assert(!OpticksGenstep_::IsExpected(type));
+        assert(OpticksGenstep_::GenstepToPhotonFlag(type) == NAN_ABORT);
+    }
+}
+
+void test_current_optical_codes()
+{
+    static_assert(OpticksGenstep_TORCH == 6, "genstep protocol values must remain stable");
+    static_assert(OpticksGenstep_CERENKOV == 15, "genstep protocol values must remain stable");
+    static_assert(OpticksGenstep_SCINTILLATION == 16, "genstep protocol values must remain stable");
+
+    assert(OpticksGenstep_::Type("CERENKOV") == OpticksGenstep_CERENKOV);
+    assert(OpticksGenstep_::Type("SCINTILLATION") == OpticksGenstep_SCINTILLATION);
+    assert(OpticksGenstep_::IsCerenkov(OpticksGenstep_CERENKOV));
+    assert(OpticksGenstep_::IsCerenkov(OpticksGenstep_G4Cerenkov_modified));
+    assert(OpticksGenstep_::IsScintillation(OpticksGenstep_SCINTILLATION));
+    assert(OpticksGenstep_::GenstepToPhotonFlag(OpticksGenstep_CERENKOV) == CERENKOV);
+    assert(OpticksGenstep_::GenstepToPhotonFlag(OpticksGenstep_SCINTILLATION) == SCINTILLATION);
+}
+
+int main()
+{
+    test_retired_codes();
+    test_current_optical_codes();
+    return 0;
+}

--- a/sysrap/tests/sgs_test.cc
+++ b/sysrap/tests/sgs_test.cc
@@ -6,32 +6,31 @@
 
 void test_assign()
 {
-    sgs gs ; 
+    sgs gs;
 
-    gs = {} ; 
-    std::cout << gs.desc() << std::endl ; 
+    gs = {};
+    std::cout << gs.desc() << std::endl;
 
-    gs = { 101, 10000, 5000, OpticksGenstep_TORCH } ; 
-    std::cout << gs.desc() << std::endl ; 
+    gs = {101, 10000, 5000, OpticksGenstep_TORCH};
+    std::cout << gs.desc() << std::endl;
 
-    gs = { 202, 20000, 4000, OpticksGenstep_CERENKOV } ; 
-    std::cout << gs.desc() << std::endl ; 
+    gs = {202, 20000, 4000, OpticksGenstep_CERENKOV};
+    std::cout << gs.desc() << std::endl;
 
-    gs = { 303, 30000, 3000, OpticksGenstep_SCINTILLATION } ; 
-    std::cout << gs.desc() << std::endl ; 
+    gs = {303, 30000, 3000, OpticksGenstep_SCINTILLATION};
+    std::cout << gs.desc() << std::endl;
 
-    gs = { 303, 30000, 3000, OpticksGenstep_G4Cerenkov_1042 } ; 
+    gs = {303, 30000, 3000, OpticksGenstep_G4Cerenkov_modified};
     std::cout << gs.desc() << std::endl ; 
 }
 
 void test_array()
 {
-    sgs gs[] = { 
-        { 101, 10000, 5000, OpticksGenstep_TORCH },
-        { 202, 20000, 4000, OpticksGenstep_CERENKOV },
-        { 303, 30000, 3000, OpticksGenstep_SCINTILLATION },
-        { 303, 30000, 3000, OpticksGenstep_G4Cerenkov_1042 } 
-        }; 
+    sgs gs[] = {
+        {101, 10000, 5000, OpticksGenstep_TORCH},
+        {202, 20000, 4000, OpticksGenstep_CERENKOV},
+        {303, 30000, 3000, OpticksGenstep_SCINTILLATION},
+        {303, 30000, 3000, OpticksGenstep_G4Cerenkov_modified}};
 
     std::cout 
          << " sizeof(sgs) " << sizeof(sgs) 

--- a/u4/Local_DsG4Scintillation.cc
+++ b/u4/Local_DsG4Scintillation.cc
@@ -584,7 +584,7 @@ Local_DsG4Scintillation::PostStepDoIt(const G4Track& aTrack, const G4Step& aStep
         if(is_opticks_genstep && (m_opticksMode & 1))
         {
             NumPhoton = std::min( NumPhoton, 3 );  // for debugging purposes it helps to have less photons
-            U4::CollectGenstep_DsG4Scintillation_r4695( &aTrack, &aStep, NumPhoton, scnt, ScintillationTime); 
+            U4::CollectGenstep_Scintillation(&aTrack, &aStep, NumPhoton, scnt, ScintillationTime);
         }
 
          if( m_opticksMode == 0 || (m_opticksMode & 2) )

--- a/u4/U4.cc
+++ b/u4/U4.cc
@@ -49,8 +49,7 @@ HMM: perhapa this state belongs better within SEvt together with the full genste
 
 **/
 
-
-static sgs gs = {} ;            // updated by eg U4::CollectGenstep_DsG4Scintillation_r4695 prior to each photon generation loop
+static sgs  gs = {};            // updated by eg U4::CollectGenstep_Scintillation prior to each photon generation loop
 static spho ancestor = {} ;     // updated by U4::GenPhotonAncestor prior to the photon generation loop(s)
 static spho pho = {} ;          // updated by U4::GenPhotonBegin at start of photon generation loop
 static spho secondary = {} ;    // updated by U4::GenPhotonEnd   at end of photon generation loop
@@ -65,13 +64,12 @@ Using hidden static non-member functions allows keeping Opticks types like quad6
 
 **/
 
-static quad6 MakeGenstep_DsG4Scintillation_r4695(
-     const G4Track* aTrack,
-     const G4Step* aStep,
-     G4int    numPhotons,
-     G4int    scnt,
-     G4double ScintillationTime
-    )
+static quad6 MakeGenstep_Scintillation(
+    const G4Track* aTrack,
+    const G4Step*  aStep,
+    G4int          numPhotons,
+    G4int          scnt,
+    G4double       ScintillationTime)
 {
     G4StepPoint* pPreStepPoint  = aStep->GetPreStepPoint();
     G4StepPoint* pPostStepPoint = aStep->GetPostStepPoint();
@@ -89,7 +87,7 @@ static quad6 MakeGenstep_DsG4Scintillation_r4695(
 
     sscint* gs = (sscint*)(&_gs) ;   // warning: dereferencing type-punned pointer will break strict-aliasing rules
 
-    gs->gentype = OpticksGenstep_DsG4Scintillation_r4695 ;
+    gs->gentype = OpticksGenstep_SCINTILLATION;
     gs->trackid = aTrack->GetTrackID() ;
     gs->matline = aMaterial->GetIndex() + SEvt::G4_INDEX_OFFSET ;  // offset signals that a mapping must be done in SEvt::setGenstep
     gs->numphoton = numPhotons ;
@@ -125,15 +123,13 @@ static quad6 MakeGenstep_DsG4Scintillation_r4695(
     return _gs ;
 }
 
-
-const char* U4::CollectGenstep_DsG4Scintillation_r4695_DISABLE = "U4__CollectGenstep_DsG4Scintillation_r4695_DISABLE" ;
-const char* U4::CollectGenstep_DsG4Scintillation_r4695_ZEROPHO = "U4__CollectGenstep_DsG4Scintillation_r4695_ZEROPHO" ;
-
+const char* U4::CollectGenstep_Scintillation_DISABLE = "U4__CollectGenstep_Scintillation_DISABLE";
+const char* U4::CollectGenstep_Scintillation_ZEROPHO = "U4__CollectGenstep_Scintillation_ZEROPHO";
 
 /**
 
-U4::CollectGenstep_DsG4Scintillation_r4695
--------------------------------------------
+U4::CollectGenstep_Scintillation
+--------------------------------
 
 1. makes quad6 gs_ collecting parameters needed to generate photons on GPU
 2. adds gs_ to SEvt using SEvt::AddGenstep which collects into a vectors of quad6 for each SEvt
@@ -142,33 +138,30 @@ U4::CollectGenstep_DsG4Scintillation_r4695
 
 **/
 
-void U4::CollectGenstep_DsG4Scintillation_r4695(
-         const G4Track* aTrack,
-         const G4Step* aStep,
-         G4int    numPhotons,
-         G4int    scnt,
-         G4double ScintillationTime
-    )
+void U4::CollectGenstep_Scintillation(
+    const G4Track* aTrack,
+    const G4Step*  aStep,
+    G4int          numPhotons,
+    G4int          scnt,
+    G4double       ScintillationTime)
 {
-    if(getenv(CollectGenstep_DsG4Scintillation_r4695_DISABLE))
+    if (getenv(CollectGenstep_Scintillation_DISABLE))
     {
-        LOG(error) << CollectGenstep_DsG4Scintillation_r4695_DISABLE ;
+        LOG(error) << CollectGenstep_Scintillation_DISABLE;
         return ;
     }
-    if(getenv(CollectGenstep_DsG4Scintillation_r4695_ZEROPHO))
+    if (getenv(CollectGenstep_Scintillation_ZEROPHO))
     {
-        LOG(error) << CollectGenstep_DsG4Scintillation_r4695_ZEROPHO ;
+        LOG(error) << CollectGenstep_Scintillation_ZEROPHO;
         numPhotons = 0 ;
     }
 
-
-
-    quad6 gs_ = MakeGenstep_DsG4Scintillation_r4695( aTrack, aStep, numPhotons, scnt, ScintillationTime);
+    quad6 gs_ = MakeGenstep_Scintillation(aTrack, aStep, numPhotons, scnt, ScintillationTime);
 
     gs = SEvt::AddGenstep(gs_);    // returns sgs struct which is a simple 4 int label
     // gs is private static genstep label
 
-    //if(dump) std::cout << "U4::CollectGenstep_DsG4Scintillation_r4695 " << gs.desc() << std::endl ;
+    // if(dump) std::cout << "U4::CollectGenstep_Scintillation " << gs.desc() << std::endl ;
     LOG(LEVEL) << gs.desc();
 }
 

--- a/u4/U4.hh
+++ b/u4/U4.hh
@@ -100,15 +100,14 @@ struct U4_API U4
     static const plog::Severity LEVEL ;
 
     // genstep collection
-    static const char* CollectGenstep_DsG4Scintillation_r4695_DISABLE ; 
-    static const char* CollectGenstep_DsG4Scintillation_r4695_ZEROPHO ; 
-    static void CollectGenstep_DsG4Scintillation_r4695( 
-         const G4Track* aTrack,
-         const G4Step* aStep,
-         G4int    numPhotons,
-         G4int    scnt,        
-         G4double ScintillationTime
-    ); 
+    static const char* CollectGenstep_Scintillation_DISABLE;
+    static const char* CollectGenstep_Scintillation_ZEROPHO;
+    static void CollectGenstep_Scintillation(
+        const G4Track* aTrack,
+        const G4Step*  aStep,
+        G4int          numPhotons,
+        G4int          scnt,
+        G4double       ScintillationTime);
 
     static const char* CollectGenstep_G4Cerenkov_modified_DISABLE ; 
     static const char* CollectGenstep_G4Cerenkov_modified_ZEROPHO ; 
@@ -138,5 +137,3 @@ struct U4_API U4
 
 
 };
-
-


### PR DESCRIPTION
Motivation:

The five low-valued Geant4 and DsG4 genstep identifiers encode the upstream version or revision that originally introduced their layouts, rather than distinct behavior still supported by simphony. Investigation showed that codes 1-4 survived only in name parsing and classification helpers. The remaining r4695 scintillation code had live producers and GPU dispatch, but used the same sscint representation and generator as the generic SCINTILLATION type.

Keeping these aliases made current data describe historical implementations, obscured which protocol variants are genuinely supported, and required a revision-qualified U4 API for ordinary scintillation collection. Since compatibility with old saved genstep.npy arrays is not required, retire those encodings instead of preserving dead aliases.

Values 1–4 are still recognized by `Name`, `IsCerenkov`, `IsScintillation`, and `GenstepToPhotonFlag` (`sysrap/OpticksGenstep.h:128`). That gives them limited diagnostic/host-side classification behavior. However:

- There are no current producers for them.
- OpticksGenstep_::Type() has no callers.
- Input genstep files are accepted based only on shape (sysrap/SEvt.cc:402).
- On the GPU, none of values 1–4 has a dispatch case. They fall into generate_photon_dummy, which emits placeholder data (qudarap/qsim.h:155, qudarap/qsim.h:2434).

So their apparent legacy-file compatibility is incomplete and potentially misleading.

The suffixes are historical format/version tags:

- 1042 means the layout derived from Geant4 10.4.p02.
- r3971 and r4695 appear to identify revisions of detector-specific DsG4* implementations. Current code explicitly calls r4695 the JUNO-specific variant (sysrap/sscint.h:9). I found no authoritative in-tree statement identifying exactly which upstream revision-control repository those
  numbers came from.

- They were introduced in commit 2bae5bc8f (https://github.com/BNLNPPS/simphony/commit/2bae5bc8f8ea49ba1f5af738346409eb86002122) as “genstep versioning for clarity.” The old OptiX generators were removed in 2024 and the legacy producers in 2025.

Historical context:

- 2bae5bc8f (2020-06-21, "start adding genstep versioning for clarity") introduced codes 1-4 as version-qualified G4 10.4.2 and DsG4 r3971 layouts.
- 062bc6dfc (2020-06-21) separated genstep codes from photon flags and partially ported the G4 10.4.2 scintillation representation.
- c578cd427 (2021-06-21) added DsG4Scintillation_r4695 as code 5 and its G4Opticks collector, shifting TORCH and the later protocol values upward.
- 3b467a150 (2021-06-23) described the old-style r4695 generation path itself as a "quickfix" and a "stopgap prior to new qudarap approach being ready."
- 59028761d (2022-05-05) introduced the revision-independent CERENKOV and SCINTILLATION codes 15 and 16 for the modern generator layouts.
- 0d21dfdd3 (2022-05-13) introduced lower-level sscint/U4 collection: fabricated sscint gensteps already used generic SCINTILLATION, while the U4 collector retained the historical r4695 label.
- 62435a138 (2022-08-10) routed r4695 and generic SCINTILLATION through the same qsim scintillation generator, confirming that the old code had become a compatibility alias rather than a separate algorithm.

Thus codes 1-4 are remnants of retired layouts, and code 5 is an obsolete alias for the generic scintillation path. The current change completes the migration begun by the 2022 generic genstep work.

Implementation:

- remove the five suffixed enum names and their string, parsing, naming, and classification branches
- leave numeric values 1-5 intentionally unused so current genstep protocol values are not renumbered
- emit OpticksGenstep_SCINTILLATION from U4 and standalone producers and use the single generic qsim dispatch path
- rename U4::CollectGenstep_DsG4Scintillation_r4695 and its environment controls to revision-independent scintillation names
- update all source, example, and DD4hep call sites
- add OpticksGenstepTest coverage for rejected retired codes, stable current IDs, classification, and photon-flag mapping

This intentionally makes gensteps carrying codes 1-5 invalid and removes the old U4 API and environment-variable names.

DD4hep was not available in the local build, so its mechanically updated call site was not compiled.
