### PR TITLE
chore(dd4hep): sync drich_1sector.xml with epic drich.xml as of eic/epic#1131

### DIFF
--- a/dd4hepplugins/examples/geometry/drich_1sector.xml
+++ b/dd4hepplugins/examples/geometry/drich_1sector.xml
@@ -59,6 +59,10 @@
 <constant name="DRICH_debug_sensors"   value="0"/>
 </define>
 
+<regions>
+  <region name="DRICHRegion"/>
+</regions>
+
 
 <detectors>
 
@@ -71,6 +75,7 @@
   id="ForwardRICH_ID"
   name="DRICH"
   type="epic_DRICH"
+  region="DRICHRegion"
   readout="DRICHHits"
   gas="C2F6_DRICH"
   material="Aluminum"


### PR DESCRIPTION
The bundled `drich_1sector.xml` is a local copy of epic `compact/pid/drich.xml` with `DRICH_num_sectors=1`.

This syncs it with the epic version as of eic/epic#1131: add the `DRICHRegion` definition and its assignment on the detector element.
