### PR TITLE
fix(dd4hep): make the dRICH validation example runnable from main branch

### DIFF
--- a/dd4hepplugins/examples/validate_drich.py
+++ b/dd4hepplugins/examples/validate_drich.py
@@ -2,7 +2,7 @@
 """Run GPU and CPU with simplified dRICH geometry (no non-optical PDU components)."""
 import math, os, sys, numpy as np
 
-_SCRIPT_DIR = "/tmp/simphony/dd4hepplugins/examples"
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _GEOM_DIR = os.path.join(_SCRIPT_DIR, "geometry")
 sys.path.insert(0, _SCRIPT_DIR)
 
@@ -17,9 +17,9 @@ def setup_kernel(mode):
     cppyy.include("G4OpticalParameters.hh")
     from cppyy.gbl import G4OpticalParameters
 
-    compact = os.path.join(_GEOM_DIR, "epic_drich_simple.xml")
-    if "DRICH_SIMPLE_XML" not in os.environ:
-        os.environ["DRICH_SIMPLE_XML"] = os.path.join(_GEOM_DIR, "drich_1sector_simple.xml")
+    compact = os.path.join(_GEOM_DIR, "epic_drich_1sector.xml")
+    if "DRICH_1SECTOR_XML" not in os.environ:
+        os.environ["DRICH_1SECTOR_XML"] = os.path.join(_GEOM_DIR, "drich_1sector.xml")
 
     if mode == "gpu":
         os.environ["OPTICKS_EVENT_MODE"] = "Minimal"


### PR DESCRIPTION
`dd4hepplugins/examples/validate_drich.py` currently cannot run from a fresh checkout: the script directory is hardcoded to `/tmp/simphony/...`, and it points at geometry files (`epic_drich_simple.xml` / `drich_1sector_simple.xml`) that are not in the repository.

This makes the example runnable with a single command:

```
python3 dd4hepplugins/examples/validate_drich.py cpu
python3 dd4hepplugins/examples/validate_drich.py gpu
```

Changes:

- resolve the script directory from `__file__` instead of the hardcoded path
- point the example at the geometry files that ship with the repository (`epic_drich_1sector.xml` / `drich_1sector.xml`, overridable via `DRICH_1SECTOR_XML`)

Requires an epic install that includes eic/epic#1110 (current epic `main`).
